### PR TITLE
Add agent skills framework with schemas, Docker deps, and content lifecycle

### DIFF
--- a/.claude/skills/actors/admin.json
+++ b/.claude/skills/actors/admin.json
@@ -1,0 +1,8 @@
+{
+  "id": "admin",
+  "name": "Administrator",
+  "type": "person",
+  "description": "Full administrative access. Can manage roles, settings, and all content operations.",
+  "inherits": ["programme-manager", "publication-manager"],
+  "capabilities": ["git-push", "admin-settings", "role-management", "release-authorization"]
+}

--- a/.claude/skills/actors/author.json
+++ b/.claude/skills/actors/author.json
@@ -1,0 +1,8 @@
+{
+  "id": "author",
+  "name": "Author",
+  "type": "person",
+  "description": "Can create and modify content. Inherits all reviewer capabilities.",
+  "inherits": ["reviewer"],
+  "capabilities": ["git-push", "content-authoring"]
+}

--- a/.claude/skills/actors/business-analyst.json
+++ b/.claude/skills/actors/business-analyst.json
@@ -1,0 +1,12 @@
+{
+  "id": "business-analyst",
+  "name": "Business Analyst",
+  "type": "person",
+  "description": "L2 DAK component author who translates clinical guidelines into structured digital artifacts including BPMN processes, data dictionaries, decision logic, and indicators.",
+  "inherits": ["author"],
+  "capabilities": ["git-push", "bpmn-authoring", "dmn-authoring", "data-dictionary-authoring"],
+  "meta": {
+    "smartBaseAnalog": "SGAuthoring.Persona.BusinessAnalyst",
+    "lifecycle": ["author", "validate", "test"]
+  }
+}

--- a/.claude/skills/actors/clinical-sme.json
+++ b/.claude/skills/actors/clinical-sme.json
@@ -1,0 +1,12 @@
+{
+  "id": "clinical-sme",
+  "name": "Clinical Subject Matter Expert",
+  "type": "person",
+  "description": "Clinical validator and ground-truth provider who ensures clinical accuracy and completeness of authored content.",
+  "inherits": ["reviewer"],
+  "capabilities": ["clinical-validation"],
+  "meta": {
+    "smartBaseAnalog": "SGAuthoring.Persona.ClinicalSME",
+    "lifecycle": ["validate", "review", "feedback"]
+  }
+}

--- a/.claude/skills/actors/content-reviewer.json
+++ b/.claude/skills/actors/content-reviewer.json
@@ -1,0 +1,12 @@
+{
+  "id": "content-reviewer",
+  "name": "Content Reviewer",
+  "type": "person",
+  "description": "Formal approval and sign-off authority who gates phase transitions and ensures alignment with source guidelines.",
+  "inherits": ["reviewer"],
+  "capabilities": ["approval-authority"],
+  "meta": {
+    "smartBaseAnalog": "SGAuthoring.Persona.ContentReviewer",
+    "lifecycle": ["review"]
+  }
+}

--- a/.claude/skills/actors/fhir-modeller.json
+++ b/.claude/skills/actors/fhir-modeller.json
@@ -1,0 +1,12 @@
+{
+  "id": "fhir-modeller",
+  "name": "FHIR Modeller",
+  "type": "person",
+  "description": "L3 machine-readable artifact creator who translates L2 specifications into FHIR Implementation Guide artifacts using FSH, SUSHI, CQL, and IG Publisher.",
+  "inherits": ["author"],
+  "capabilities": ["git-push", "sushi-compiler", "ig-publisher", "fhir-validator", "cql-authoring"],
+  "meta": {
+    "smartBaseAnalog": "SGAuthoring.Persona.FHIRModeller",
+    "lifecycle": ["author", "validate", "test"]
+  }
+}

--- a/.claude/skills/actors/ig-publisher-service.json
+++ b/.claude/skills/actors/ig-publisher-service.json
@@ -1,0 +1,12 @@
+{
+  "id": "ig-publisher-service",
+  "name": "IG Publisher Service",
+  "type": "system",
+  "description": "System actor providing FHIR IG Publisher build and QA reporting.",
+  "inherits": [],
+  "capabilities": ["ig-publisher", "fhir-validator", "qa-reporting"],
+  "meta": {
+    "provider": "docker",
+    "image": "folio-assistant-smart-guidelines"
+  }
+}

--- a/.claude/skills/actors/lean-mcp.json
+++ b/.claude/skills/actors/lean-mcp.json
@@ -1,0 +1,12 @@
+{
+  "id": "lean-mcp",
+  "name": "Lean MCP Server",
+  "type": "system",
+  "description": "System actor providing Lean 4 proof checking and diagnostics via MCP protocol.",
+  "inherits": [],
+  "capabilities": ["lean-toolchain", "lean-diagnostics"],
+  "meta": {
+    "provider": "mcp",
+    "endpoint": "lean-mcp"
+  }
+}

--- a/.claude/skills/actors/programme-manager.json
+++ b/.claude/skills/actors/programme-manager.json
@@ -1,0 +1,12 @@
+{
+  "id": "programme-manager",
+  "name": "Programme Manager",
+  "type": "person",
+  "description": "Overall coordination and governance. Responsible for scope definition, team formation, resource allocation, timeline planning, and stakeholder engagement.",
+  "inherits": ["content-reviewer"],
+  "capabilities": ["git-push", "project-governance", "release-authorization"],
+  "meta": {
+    "smartBaseAnalog": "SGAuthoring.Persona.ProgrammeManager",
+    "lifecycle": ["plan", "review", "publish", "feedback"]
+  }
+}

--- a/.claude/skills/actors/publication-manager.json
+++ b/.claude/skills/actors/publication-manager.json
@@ -1,0 +1,12 @@
+{
+  "id": "publication-manager",
+  "name": "Publication Manager",
+  "type": "person",
+  "description": "Release and deployment manager responsible for IG configuration, builds, versioning, publication, and platform updates.",
+  "inherits": ["author"],
+  "capabilities": ["git-push", "ig-publisher", "jekyll", "release-management"],
+  "meta": {
+    "smartBaseAnalog": "SGAuthoring.Persona.PublicationManager",
+    "lifecycle": ["publish"]
+  }
+}

--- a/.claude/skills/actors/qc-reviewer.json
+++ b/.claude/skills/actors/qc-reviewer.json
@@ -1,0 +1,12 @@
+{
+  "id": "qc-reviewer",
+  "name": "QC Reviewer",
+  "type": "person",
+  "description": "Quality control reviewer who validates publication readiness across L1-L4 layers, runs QA reports, and verifies conformance.",
+  "inherits": ["reviewer"],
+  "capabilities": ["ig-publisher", "fhir-validator", "qa-reporting"],
+  "meta": {
+    "smartBaseAnalog": "SGAuthoring.Persona.QCReviewer",
+    "lifecycle": ["validate", "test"]
+  }
+}

--- a/.claude/skills/actors/reviewer.json
+++ b/.claude/skills/actors/reviewer.json
@@ -1,0 +1,8 @@
+{
+  "id": "reviewer",
+  "name": "Reviewer",
+  "type": "person",
+  "description": "Can view content and provide review comments. Cannot make direct changes.",
+  "inherits": ["viewer"],
+  "capabilities": ["review-comments"]
+}

--- a/.claude/skills/actors/technical-officer.json
+++ b/.claude/skills/actors/technical-officer.json
@@ -1,0 +1,12 @@
+{
+  "id": "technical-officer",
+  "name": "Technical Officer",
+  "type": "person",
+  "description": "Programme area coordinator and first-pass reviewer who bridges the development team and subject matter experts.",
+  "inherits": ["reviewer"],
+  "capabilities": ["git-push", "first-pass-review", "sme-coordination"],
+  "meta": {
+    "smartBaseAnalog": "SGAuthoring.Persona.TechnicalOfficer",
+    "lifecycle": ["review", "feedback"]
+  }
+}

--- a/.claude/skills/actors/terminologist.json
+++ b/.claude/skills/actors/terminologist.json
@@ -1,0 +1,12 @@
+{
+  "id": "terminologist",
+  "name": "Terminologist",
+  "type": "person",
+  "description": "Semantic interoperability and terminology governance specialist who maps data elements to standard terminologies (ICD-11, SNOMED CT, LOINC).",
+  "inherits": ["author"],
+  "capabilities": ["git-push", "terminology-management"],
+  "meta": {
+    "smartBaseAnalog": "SGAuthoring.Persona.Terminologist",
+    "lifecycle": ["author", "validate"]
+  }
+}

--- a/.claude/skills/actors/translator.json
+++ b/.claude/skills/actors/translator.json
@@ -1,0 +1,12 @@
+{
+  "id": "translator",
+  "name": "Translator",
+  "type": "person",
+  "description": "Localization specialist who adapts content for UN-supported languages.",
+  "inherits": ["author"],
+  "capabilities": ["git-push", "translation"],
+  "meta": {
+    "smartBaseAnalog": "SGAuthoring.Persona.Translator",
+    "lifecycle": ["author"]
+  }
+}

--- a/.claude/skills/actors/viewer.json
+++ b/.claude/skills/actors/viewer.json
@@ -1,0 +1,8 @@
+{
+  "id": "viewer",
+  "name": "Viewer",
+  "type": "person",
+  "description": "Base read-only role. Can view content but cannot make changes.",
+  "inherits": [],
+  "capabilities": []
+}

--- a/.claude/skills/capabilities/bun-runtime.json
+++ b/.claude/skills/capabilities/bun-runtime.json
@@ -1,0 +1,6 @@
+{
+  "id": "bun-runtime",
+  "name": "Bun Runtime",
+  "description": "Bun JavaScript/TypeScript runtime.",
+  "detection": { "method": "command", "command": "bun --version" }
+}

--- a/.claude/skills/capabilities/docker.json
+++ b/.claude/skills/capabilities/docker.json
@@ -1,0 +1,6 @@
+{
+  "id": "docker",
+  "name": "Docker",
+  "description": "Docker container runtime for building and running containerized skill environments.",
+  "detection": { "method": "command", "command": "docker info" }
+}

--- a/.claude/skills/capabilities/git-push.json
+++ b/.claude/skills/capabilities/git-push.json
@@ -1,0 +1,6 @@
+{
+  "id": "git-push",
+  "name": "Git Push",
+  "description": "Ability to push commits to the remote Git repository.",
+  "detection": { "method": "command", "command": "git remote -v" }
+}

--- a/.claude/skills/capabilities/graphviz.json
+++ b/.claude/skills/capabilities/graphviz.json
@@ -1,0 +1,6 @@
+{
+  "id": "graphviz",
+  "name": "Graphviz",
+  "description": "Graph visualization tool for generating diagrams.",
+  "detection": { "method": "command", "command": "dot -V" }
+}

--- a/.claude/skills/capabilities/ig-publisher.json
+++ b/.claude/skills/capabilities/ig-publisher.json
@@ -1,0 +1,7 @@
+{
+  "id": "ig-publisher",
+  "name": "FHIR IG Publisher",
+  "description": "HL7 FHIR Implementation Guide Publisher for building and validating FHIR IGs.",
+  "detection": { "method": "command", "command": "java -jar ${IG_PUBLISHER_JAR:-/opt/ig-publisher/publisher.jar} --version" },
+  "requires": ["java-runtime"]
+}

--- a/.claude/skills/capabilities/java-runtime.json
+++ b/.claude/skills/capabilities/java-runtime.json
@@ -1,0 +1,6 @@
+{
+  "id": "java-runtime",
+  "name": "Java Runtime",
+  "description": "Java Runtime Environment for running Java-based tools (IG Publisher, validators).",
+  "detection": { "method": "command", "command": "java -version" }
+}

--- a/.claude/skills/capabilities/jekyll.json
+++ b/.claude/skills/capabilities/jekyll.json
@@ -1,0 +1,6 @@
+{
+  "id": "jekyll",
+  "name": "Jekyll",
+  "description": "Jekyll static site generator for IG publication.",
+  "detection": { "method": "command", "command": "jekyll --version" }
+}

--- a/.claude/skills/capabilities/latex-compiler.json
+++ b/.claude/skills/capabilities/latex-compiler.json
@@ -1,0 +1,6 @@
+{
+  "id": "latex-compiler",
+  "name": "LaTeX Compiler",
+  "description": "Full LaTeX distribution with latexmk and biber for document compilation.",
+  "detection": { "method": "command", "command": "latexmk --version" }
+}

--- a/.claude/skills/capabilities/lean-mcp.json
+++ b/.claude/skills/capabilities/lean-mcp.json
@@ -1,0 +1,7 @@
+{
+  "id": "lean-mcp",
+  "name": "Lean MCP Server",
+  "description": "MCP server providing Lean 4 diagnostics, proof state, and goal information.",
+  "detection": { "method": "mcp-probe", "endpoint": "lean-mcp", "healthPath": "/health" },
+  "requires": ["lean-toolchain"]
+}

--- a/.claude/skills/capabilities/lean-toolchain.json
+++ b/.claude/skills/capabilities/lean-toolchain.json
@@ -1,0 +1,6 @@
+{
+  "id": "lean-toolchain",
+  "name": "Lean 4 Toolchain",
+  "description": "Lean 4 theorem prover and build system (elan + lake).",
+  "detection": { "method": "command", "command": "lean --version" }
+}

--- a/.claude/skills/capabilities/node-runtime.json
+++ b/.claude/skills/capabilities/node-runtime.json
@@ -1,0 +1,6 @@
+{
+  "id": "node-runtime",
+  "name": "Node.js Runtime",
+  "description": "Node.js runtime with npm package manager.",
+  "detection": { "method": "command", "command": "node --version" }
+}

--- a/.claude/skills/capabilities/plantuml.json
+++ b/.claude/skills/capabilities/plantuml.json
@@ -1,0 +1,7 @@
+{
+  "id": "plantuml",
+  "name": "PlantUML",
+  "description": "PlantUML diagram generator for UML, BPMN, and other diagram types.",
+  "detection": { "method": "command", "command": "plantuml -version" },
+  "requires": ["java-runtime", "graphviz"]
+}

--- a/.claude/skills/capabilities/python3.json
+++ b/.claude/skills/capabilities/python3.json
@@ -1,0 +1,6 @@
+{
+  "id": "python3",
+  "name": "Python 3",
+  "description": "Python 3 runtime with pip package manager.",
+  "detection": { "method": "command", "command": "python3 --version" }
+}

--- a/.claude/skills/capabilities/sushi-compiler.json
+++ b/.claude/skills/capabilities/sushi-compiler.json
@@ -1,0 +1,7 @@
+{
+  "id": "sushi-compiler",
+  "name": "SUSHI Compiler",
+  "description": "FSH (FHIR Shorthand) to FHIR JSON compiler.",
+  "detection": { "method": "command", "command": "sushi --version" },
+  "requires": ["node-runtime"]
+}

--- a/.claude/skills/hooks/session-start.sh
+++ b/.claude/skills/hooks/session-start.sh
@@ -12,25 +12,57 @@ echo "=== Folio Assistant Session Start ==="
 USER_EMAIL=$(git config user.email 2>/dev/null || echo "unknown")
 echo "User: $USER_EMAIL"
 
-# Probe capabilities
+# Probe capabilities using jq (no eval, no arbitrary command execution)
 echo ""
 echo "Checking capabilities..."
 for cap_file in "$SKILLS_DIR/capabilities/"*.json; do
   [ -f "$cap_file" ] || continue
   cap_name=$(basename "$cap_file" .json)
-  method=$(python3 -c "import json,sys; d=json.load(open('$cap_file')); print(d.get('detection',{}).get('method',''))" 2>/dev/null || echo "")
-  if [ "$method" = "command" ]; then
-    cmd=$(python3 -c "import json,sys; d=json.load(open('$cap_file')); print(d['detection']['command'])" 2>/dev/null || echo "")
-    if eval "$cmd" >/dev/null 2>&1; then
-      echo "  ✓ $cap_name"
-    else
-      echo "  ✗ $cap_name (not available)"
-    fi
-  elif [ "$method" = "always" ]; then
-    echo "  ✓ $cap_name (always)"
-  else
-    echo "  ? $cap_name ($method — skipped)"
-  fi
+  method=$(jq -r '.detection.method // ""' "$cap_file")
+
+  case "$method" in
+    command)
+      cmd=$(jq -r '.detection.command // ""' "$cap_file")
+      # Only allow known safe detection commands (no shell metacharacters)
+      if [[ "$cmd" =~ [;\|\&\$\`\(] ]]; then
+        echo "  ⚠ $cap_name (unsafe detection command, skipped)"
+        continue
+      fi
+      # Split command into array and execute without shell interpretation
+      read -ra cmd_parts <<< "$cmd"
+      if "${cmd_parts[@]}" >/dev/null 2>&1; then
+        echo "  ✓ $cap_name"
+      else
+        echo "  ✗ $cap_name (not available)"
+      fi
+      ;;
+    env-var)
+      var=$(jq -r '.detection.variable // ""' "$cap_file")
+      if [ -n "${!var:-}" ]; then
+        echo "  ✓ $cap_name"
+      else
+        echo "  ✗ $cap_name (env var $var not set)"
+      fi
+      ;;
+    file-exists)
+      path=$(jq -r '.detection.path // ""' "$cap_file")
+      if [ -e "$path" ]; then
+        echo "  ✓ $cap_name"
+      else
+        echo "  ✗ $cap_name (file not found: $path)"
+      fi
+      ;;
+    always)
+      echo "  ✓ $cap_name (always)"
+      ;;
+    mcp-probe)
+      endpoint=$(jq -r '.detection.endpoint // ""' "$cap_file")
+      echo "  ? $cap_name (mcp-probe: $endpoint — requires runtime check)"
+      ;;
+    *)
+      echo "  ? $cap_name ($method — unknown detection method)"
+      ;;
+  esac
 done
 
 echo ""

--- a/.claude/skills/hooks/session-start.sh
+++ b/.claude/skills/hooks/session-start.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Session start hook: detects role and probes capabilities
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILLS_DIR="$(dirname "$SCRIPT_DIR")"
+REPO_ROOT="$(dirname "$(dirname "$SKILLS_DIR")")"
+
+echo "=== Folio Assistant Session Start ==="
+
+# Detect user identity
+USER_EMAIL=$(git config user.email 2>/dev/null || echo "unknown")
+echo "User: $USER_EMAIL"
+
+# Probe capabilities
+echo ""
+echo "Checking capabilities..."
+for cap_file in "$SKILLS_DIR/capabilities/"*.json; do
+  [ -f "$cap_file" ] || continue
+  cap_name=$(basename "$cap_file" .json)
+  method=$(python3 -c "import json,sys; d=json.load(open('$cap_file')); print(d.get('detection',{}).get('method',''))" 2>/dev/null || echo "")
+  if [ "$method" = "command" ]; then
+    cmd=$(python3 -c "import json,sys; d=json.load(open('$cap_file')); print(d['detection']['command'])" 2>/dev/null || echo "")
+    if eval "$cmd" >/dev/null 2>&1; then
+      echo "  ✓ $cap_name"
+    else
+      echo "  ✗ $cap_name (not available)"
+    fi
+  elif [ "$method" = "always" ]; then
+    echo "  ✓ $cap_name (always)"
+  else
+    echo "  ? $cap_name ($method — skipped)"
+  fi
+done
+
+echo ""
+echo "Session initialized."

--- a/.claude/skills/local/bpmn-authoring.json
+++ b/.claude/skills/local/bpmn-authoring.json
@@ -1,0 +1,14 @@
+{
+  "id": "bpmn-authoring",
+  "name": "BPMN Authoring",
+  "description": "Author BPMN 2.0 business process diagrams for workflow modeling.",
+  "roles": ["business-analyst", "author", "admin"],
+  "requiredCapabilities": [
+    { "capabilityId": "graphviz", "degradation": "skip" }
+  ],
+  "routingPatterns": ["BPMN", "business process", "workflow diagram"],
+  "tags": ["smart-guidelines", "bpmn", "workflow"],
+  "package": "authoring-who-smart-guidelines",
+  "lifecycleStages": ["author"],
+  "schemaRef": "schemas/skills/bpmn-authoring"
+}

--- a/.claude/skills/local/content-author.json
+++ b/.claude/skills/local/content-author.json
@@ -1,0 +1,18 @@
+{
+  "id": "content-author",
+  "name": "Content Authoring",
+  "description": "Create and develop content artifacts according to the project plan.",
+  "roles": ["author", "business-analyst", "fhir-modeller", "terminologist", "admin"],
+  "requiredCapabilities": [
+    { "capabilityId": "git-push", "degradation": "warn" }
+  ],
+  "dependsOn": [
+    { "ref": "content-plan", "kind": "skill", "conformance": "SHOULD" },
+    { "ref": "req:content-lifecycle", "kind": "requirement", "conformance": "SHALL" }
+  ],
+  "routingPatterns": ["author", "create", "write", "develop content"],
+  "tags": ["lifecycle", "authoring"],
+  "package": "content-lifecycle",
+  "lifecycleStages": ["author"],
+  "schemaRef": "schemas/skills/content-author"
+}

--- a/.claude/skills/local/content-feedback.json
+++ b/.claude/skills/local/content-feedback.json
@@ -1,0 +1,16 @@
+{
+  "id": "content-feedback",
+  "name": "Content Feedback",
+  "description": "Gather, triage, and prioritize feedback on published content for future iterations.",
+  "roles": ["technical-officer", "programme-manager", "clinical-sme", "business-analyst", "admin"],
+  "requiredCapabilities": [],
+  "dependsOn": [
+    { "ref": "content-publish", "kind": "skill", "conformance": "SHOULD" },
+    { "ref": "req:content-lifecycle", "kind": "requirement", "conformance": "SHOULD" }
+  ],
+  "routingPatterns": ["feedback", "triage", "backlog", "implementer feedback"],
+  "tags": ["lifecycle", "feedback"],
+  "package": "content-lifecycle",
+  "lifecycleStages": ["feedback"],
+  "schemaRef": "schemas/skills/content-feedback"
+}

--- a/.claude/skills/local/content-plan.json
+++ b/.claude/skills/local/content-plan.json
@@ -1,0 +1,15 @@
+{
+  "id": "content-plan",
+  "name": "Content Planning",
+  "description": "Plan content development: scope, team, timeline, sprint cadence, governance.",
+  "roles": ["programme-manager", "admin"],
+  "requiredCapabilities": [],
+  "dependsOn": [
+    { "ref": "req:content-lifecycle", "kind": "requirement", "conformance": "SHALL" }
+  ],
+  "routingPatterns": ["plan", "scope", "timeline", "sprint", "team"],
+  "tags": ["lifecycle", "planning"],
+  "package": "content-lifecycle",
+  "lifecycleStages": ["plan"],
+  "schemaRef": "schemas/skills/content-plan"
+}

--- a/.claude/skills/local/content-publish.json
+++ b/.claude/skills/local/content-publish.json
@@ -1,0 +1,21 @@
+{
+  "id": "content-publish",
+  "name": "Content Publication",
+  "description": "Package, version, and publish approved content.",
+  "roles": ["publication-manager", "programme-manager", "admin"],
+  "requiredCapabilities": [
+    { "capabilityId": "git-push", "degradation": "fail" }
+  ],
+  "dependsOn": [
+    { "ref": "content-test", "kind": "skill", "conformance": "SHALL" },
+    { "ref": "req:content-lifecycle", "kind": "requirement", "conformance": "SHALL" }
+  ],
+  "scripts": [
+    { "path": "scripts/create-release.sh", "runtime": "bash", "phase": "execute" }
+  ],
+  "routingPatterns": ["publish", "release", "deploy", "version"],
+  "tags": ["lifecycle", "publication"],
+  "package": "content-lifecycle",
+  "lifecycleStages": ["publish"],
+  "schemaRef": "schemas/skills/content-publish"
+}

--- a/.claude/skills/local/content-review.json
+++ b/.claude/skills/local/content-review.json
@@ -1,0 +1,17 @@
+{
+  "id": "content-review",
+  "name": "Content Review",
+  "description": "Formal content review and approval workflow with phase gates (L2→L3, L3→publish).",
+  "roles": ["content-reviewer", "clinical-sme", "technical-officer", "admin"],
+  "requiredCapabilities": [
+    { "capabilityId": "git-push", "degradation": "warn" }
+  ],
+  "dependsOn": [
+    { "ref": "req:content-lifecycle", "kind": "requirement", "conformance": "SHALL" }
+  ],
+  "routingPatterns": ["review", "approve", "sign-off", "gate"],
+  "tags": ["review", "approval", "governance"],
+  "package": "authoring-who-smart-guidelines",
+  "lifecycleStages": ["review"],
+  "schemaRef": "schemas/skills/content-review"
+}

--- a/.claude/skills/local/content-test.json
+++ b/.claude/skills/local/content-test.json
@@ -1,0 +1,19 @@
+{
+  "id": "content-test",
+  "name": "Content Testing",
+  "description": "End-to-end testing of content artifacts in realistic scenarios.",
+  "roles": ["qc-reviewer", "fhir-modeller", "business-analyst", "admin"],
+  "requiredCapabilities": [],
+  "dependsOn": [
+    { "ref": "content-validate", "kind": "skill", "conformance": "SHALL" },
+    { "ref": "req:content-lifecycle", "kind": "requirement", "conformance": "SHALL" }
+  ],
+  "scripts": [
+    { "path": "scripts/run-tests.sh", "runtime": "bash", "phase": "execute" }
+  ],
+  "routingPatterns": ["test", "integration test", "regression", "test plan"],
+  "tags": ["lifecycle", "testing"],
+  "package": "content-lifecycle",
+  "lifecycleStages": ["test"],
+  "schemaRef": "schemas/skills/content-test"
+}

--- a/.claude/skills/local/content-validate.json
+++ b/.claude/skills/local/content-validate.json
@@ -1,0 +1,21 @@
+{
+  "id": "content-validate",
+  "name": "Content Validation",
+  "description": "Validate authored content against schemas, standards, and clinical accuracy.",
+  "roles": ["qc-reviewer", "fhir-modeller", "terminologist", "clinical-sme", "admin"],
+  "requiredCapabilities": [
+    { "capabilityId": "python3", "degradation": "warn" }
+  ],
+  "dependsOn": [
+    { "ref": "content-author", "kind": "skill", "conformance": "SHALL" },
+    { "ref": "req:content-lifecycle", "kind": "requirement", "conformance": "SHALL" }
+  ],
+  "scripts": [
+    { "path": "scripts/validate-content.sh", "runtime": "bash", "phase": "validate" }
+  ],
+  "routingPatterns": ["validate", "check", "verify", "schema validation"],
+  "tags": ["lifecycle", "validation"],
+  "package": "content-lifecycle",
+  "lifecycleStages": ["validate"],
+  "schemaRef": "schemas/skills/content-validate"
+}

--- a/.claude/skills/local/dmn-authoring.json
+++ b/.claude/skills/local/dmn-authoring.json
@@ -1,0 +1,12 @@
+{
+  "id": "dmn-authoring",
+  "name": "DMN Authoring",
+  "description": "Author DMN (Decision Model and Notation) decision tables for clinical decision logic.",
+  "roles": ["business-analyst", "author", "admin"],
+  "requiredCapabilities": [],
+  "routingPatterns": ["DMN", "decision table", "decision logic"],
+  "tags": ["smart-guidelines", "dmn", "decision-logic"],
+  "package": "authoring-who-smart-guidelines",
+  "lifecycleStages": ["author"],
+  "schemaRef": "schemas/skills/dmn-authoring"
+}

--- a/.claude/skills/local/fhir-validation.json
+++ b/.claude/skills/local/fhir-validation.json
@@ -1,0 +1,23 @@
+{
+  "id": "fhir-validation",
+  "name": "FHIR Validation",
+  "description": "Validate FHIR IG content: SUSHI compilation, IG Publisher QA, CRMI conformance checks.",
+  "roles": ["fhir-modeller", "qc-reviewer", "admin"],
+  "requiredCapabilities": [
+    { "capabilityId": "sushi-compiler", "degradation": "fail" },
+    { "capabilityId": "ig-publisher", "degradation": "warn" },
+    { "capabilityId": "java-runtime", "degradation": "fail" }
+  ],
+  "dependsOn": [
+    { "ref": "req:fhir-validation", "kind": "requirement", "conformance": "SHALL" }
+  ],
+  "scripts": [
+    { "path": "scripts/sushi-build.sh", "runtime": "bash", "phase": "validate" },
+    { "path": "scripts/ig-publisher-build.sh", "runtime": "bash", "phase": "validate" }
+  ],
+  "routingPatterns": ["validate FHIR", "QA", "sushi", "IG Publisher", "conformance"],
+  "tags": ["smart-guidelines", "fhir", "validation", "qa"],
+  "package": "authoring-who-smart-guidelines",
+  "lifecycleStages": ["validate", "test"],
+  "schemaRef": "schemas/skills/fhir-validation"
+}

--- a/.claude/skills/local/ig-publication.json
+++ b/.claude/skills/local/ig-publication.json
@@ -1,0 +1,24 @@
+{
+  "id": "ig-publication",
+  "name": "IG Publication",
+  "description": "Publish FHIR Implementation Guides: versioning, release branches, GitHub releases, platform deployment.",
+  "roles": ["publication-manager", "admin"],
+  "requiredCapabilities": [
+    { "capabilityId": "ig-publisher", "degradation": "fail" },
+    { "capabilityId": "git-push", "degradation": "fail" },
+    { "capabilityId": "jekyll", "degradation": "warn" }
+  ],
+  "dependsOn": [
+    { "ref": "fhir-validation", "kind": "skill", "conformance": "SHALL" },
+    { "ref": "req:content-lifecycle", "kind": "requirement", "conformance": "SHALL" }
+  ],
+  "scripts": [
+    { "path": "scripts/ig-publisher-build.sh", "runtime": "bash", "phase": "execute" },
+    { "path": "scripts/create-release.sh", "runtime": "bash", "phase": "post" }
+  ],
+  "routingPatterns": ["publish IG", "release", "version", "deploy"],
+  "tags": ["smart-guidelines", "fhir", "publication"],
+  "package": "authoring-who-smart-guidelines",
+  "lifecycleStages": ["publish"],
+  "schemaRef": "schemas/skills/ig-publication"
+}

--- a/.claude/skills/local/l2-dak-authoring.json
+++ b/.claude/skills/local/l2-dak-authoring.json
@@ -1,0 +1,17 @@
+{
+  "id": "l2-dak-authoring",
+  "name": "L2 DAK Authoring",
+  "description": "Author WHO SMART Guidelines L2 Digital Adaptation Kit components: personas, scenarios, processes, dictionaries, decision logic, indicators.",
+  "roles": ["business-analyst", "author", "admin"],
+  "requiredCapabilities": [
+    { "capabilityId": "git-push", "degradation": "warn" }
+  ],
+  "dependsOn": [
+    { "ref": "req:content-lifecycle", "kind": "requirement", "conformance": "SHALL" }
+  ],
+  "routingPatterns": ["L2", "DAK", "business process", "data dictionary", "decision logic", "indicator"],
+  "tags": ["smart-guidelines", "l2", "dak", "authoring"],
+  "package": "authoring-who-smart-guidelines",
+  "lifecycleStages": ["author", "validate"],
+  "schemaRef": "schemas/skills/l2-dak-authoring"
+}

--- a/.claude/skills/local/l3-fhir-authoring.json
+++ b/.claude/skills/local/l3-fhir-authoring.json
@@ -1,0 +1,23 @@
+{
+  "id": "l3-fhir-authoring",
+  "name": "L3 FHIR Authoring",
+  "description": "Author WHO SMART Guidelines L3 machine-readable FHIR artifacts: profiles, questionnaires, CQL, StructureMaps, measures.",
+  "roles": ["fhir-modeller", "author", "admin"],
+  "requiredCapabilities": [
+    { "capabilityId": "sushi-compiler", "degradation": "fail" },
+    { "capabilityId": "ig-publisher", "degradation": "warn" },
+    { "capabilityId": "node-runtime", "degradation": "fail" }
+  ],
+  "dependsOn": [
+    { "ref": "l2-dak-authoring", "kind": "skill", "conformance": "SHOULD" },
+    { "ref": "req:fhir-validation", "kind": "requirement", "conformance": "SHALL" }
+  ],
+  "scripts": [
+    { "path": "scripts/sushi-build.sh", "runtime": "bash", "phase": "validate" }
+  ],
+  "routingPatterns": ["L3", "FHIR", "FSH", "profile", "questionnaire", "CQL", "StructureMap"],
+  "tags": ["smart-guidelines", "l3", "fhir", "authoring"],
+  "package": "authoring-who-smart-guidelines",
+  "lifecycleStages": ["author", "validate"],
+  "schemaRef": "schemas/skills/l3-fhir-authoring"
+}

--- a/.claude/skills/local/latex-authoring.json
+++ b/.claude/skills/local/latex-authoring.json
@@ -1,0 +1,20 @@
+{
+  "id": "latex-authoring",
+  "name": "LaTeX Authoring",
+  "description": "Author and compile LaTeX documents including papers, reports, and presentations.",
+  "roles": ["author", "admin"],
+  "requiredCapabilities": [
+    { "capabilityId": "latex-compiler", "degradation": "fail" }
+  ],
+  "dependsOn": [
+    { "ref": "req:lean-verification", "kind": "requirement", "conformance": "SHOULD" }
+  ],
+  "scripts": [
+    { "path": "scripts/latex-build.sh", "runtime": "bash", "phase": "execute" }
+  ],
+  "routingPatterns": ["latex", "paper", "document", "compile pdf"],
+  "tags": ["math", "latex", "authoring"],
+  "package": "authoring-math",
+  "lifecycleStages": ["author", "publish"],
+  "schemaRef": "schemas/skills/latex-authoring"
+}

--- a/.claude/skills/local/lean-formalization.json
+++ b/.claude/skills/local/lean-formalization.json
@@ -1,0 +1,22 @@
+{
+  "id": "lean-formalization",
+  "name": "Lean Formalization",
+  "description": "Formalize mathematical content in Lean 4, creating verified proofs from source material.",
+  "roles": ["author", "admin"],
+  "requiredCapabilities": [
+    { "capabilityId": "lean-toolchain", "degradation": "fail" },
+    { "capabilityId": "lean-mcp", "degradation": "fallback", "fallbackCapabilityId": "lean-toolchain" }
+  ],
+  "dependsOn": [
+    { "ref": "req:lean-verification", "kind": "requirement", "conformance": "SHALL" }
+  ],
+  "scripts": [
+    { "path": "scripts/lean-build.sh", "runtime": "bash", "phase": "validate" }
+  ],
+  "mcpServices": ["lean-mcp"],
+  "routingPatterns": ["formalize", "prove", "lean", "theorem"],
+  "tags": ["math", "lean", "formalization"],
+  "package": "authoring-math",
+  "lifecycleStages": ["author", "validate"],
+  "schemaRef": "schemas/skills/lean-formalization"
+}

--- a/.claude/skills/local/proof-verification.json
+++ b/.claude/skills/local/proof-verification.json
@@ -1,0 +1,21 @@
+{
+  "id": "proof-verification",
+  "name": "Proof Verification",
+  "description": "Verify Lean 4 proofs, track sorry obligations, and report build diagnostics.",
+  "roles": ["author", "qc-reviewer", "admin"],
+  "requiredCapabilities": [
+    { "capabilityId": "lean-toolchain", "degradation": "fail" }
+  ],
+  "dependsOn": [
+    { "ref": "req:lean-verification", "kind": "requirement", "conformance": "SHALL" }
+  ],
+  "scripts": [
+    { "path": "scripts/verify-proofs.sh", "runtime": "bash", "phase": "validate" }
+  ],
+  "mcpServices": ["lean-mcp"],
+  "routingPatterns": ["verify", "check proofs", "sorry", "proof obligations"],
+  "tags": ["math", "lean", "verification", "qa"],
+  "package": "authoring-math",
+  "lifecycleStages": ["validate", "test"],
+  "schemaRef": "schemas/skills/proof-verification"
+}

--- a/.claude/skills/local/quality-control.json
+++ b/.claude/skills/local/quality-control.json
@@ -1,0 +1,17 @@
+{
+  "id": "quality-control",
+  "name": "Quality Control",
+  "description": "Run QA checks, review publication checklists, validate conformance, and test functionality.",
+  "roles": ["qc-reviewer", "admin"],
+  "requiredCapabilities": [
+    { "capabilityId": "ig-publisher", "degradation": "skip" }
+  ],
+  "scripts": [
+    { "path": "scripts/run-qa.sh", "runtime": "bash", "phase": "validate" }
+  ],
+  "routingPatterns": ["QC", "quality control", "checklist", "qa report"],
+  "tags": ["qa", "review"],
+  "package": "authoring-who-smart-guidelines",
+  "lifecycleStages": ["validate", "test"],
+  "schemaRef": "schemas/skills/quality-control"
+}

--- a/.claude/skills/local/terminology-management.json
+++ b/.claude/skills/local/terminology-management.json
@@ -1,0 +1,17 @@
+{
+  "id": "terminology-management",
+  "name": "Terminology Management",
+  "description": "Manage terminology: CodeSystems, ValueSets, ConceptMaps. Map to ICD-11, SNOMED CT, LOINC, WHO FIC.",
+  "roles": ["terminologist", "fhir-modeller", "admin"],
+  "requiredCapabilities": [
+    { "capabilityId": "sushi-compiler", "degradation": "warn" }
+  ],
+  "scripts": [
+    { "path": "scripts/validate-terminology.py", "runtime": "python", "phase": "validate" }
+  ],
+  "routingPatterns": ["terminology", "CodeSystem", "ValueSet", "ConceptMap", "SNOMED", "ICD", "LOINC"],
+  "tags": ["smart-guidelines", "terminology", "fhir"],
+  "package": "authoring-who-smart-guidelines",
+  "lifecycleStages": ["author", "validate"],
+  "schemaRef": "schemas/skills/terminology-management"
+}

--- a/.claude/skills/requirements/commit-hygiene.json
+++ b/.claude/skills/requirements/commit-hygiene.json
@@ -1,0 +1,28 @@
+{
+  "id": "req:commit-hygiene",
+  "title": "Commit Hygiene",
+  "description": "All commits must be clean: no build artifacts, no secrets, pinned dependencies.",
+  "derivedFrom": ["req:agent-workflow"],
+  "actors": ["author", "admin"],
+  "statements": [
+    {
+      "key": "no-build-artifacts",
+      "label": "No build artifacts in commits",
+      "conformance": "SHALL",
+      "requirement": "Commits SHALL NOT include generated build artifacts (dist/, node_modules/, *.class, etc.)."
+    },
+    {
+      "key": "no-secrets",
+      "label": "No secrets in commits",
+      "conformance": "SHALL",
+      "requirement": "Commits SHALL NOT include secrets, API keys, tokens, or credentials."
+    },
+    {
+      "key": "pin-dependencies",
+      "label": "Pin dependency versions",
+      "conformance": "SHALL",
+      "requirement": "All dependency versions SHALL be pinned or locked (package-lock.json, requirements.txt with versions)."
+    }
+  ],
+  "tags": ["common", "git"]
+}

--- a/.claude/skills/requirements/content-lifecycle.json
+++ b/.claude/skills/requirements/content-lifecycle.json
@@ -1,0 +1,61 @@
+{
+  "id": "req:content-lifecycle",
+  "title": "Content Development Lifecycle",
+  "description": "Content must follow the plan → author → validate → review → test → publish → feedback lifecycle with appropriate phase gates.",
+  "derivedFrom": ["req:agent-workflow"],
+  "actors": ["author", "reviewer", "content-reviewer", "qc-reviewer", "publication-manager", "programme-manager"],
+  "statements": [
+    {
+      "key": "plan-before-author",
+      "label": "Planning precedes authoring",
+      "conformance": "SHALL",
+      "requirement": "Content authoring MUST NOT begin until a project plan with defined scope and team is established.",
+      "actors": ["programme-manager"],
+      "satisfiedBy": [{ "kind": "skill", "ref": "content-plan" }]
+    },
+    {
+      "key": "validate-before-review",
+      "label": "Validation precedes review",
+      "conformance": "SHALL",
+      "requirement": "Content MUST pass automated validation (schema, FHIR, Lean) before entering formal review.",
+      "dependsOn": ["plan-before-author"],
+      "satisfiedBy": [{ "kind": "skill", "ref": "content-validate" }]
+    },
+    {
+      "key": "review-before-test",
+      "label": "Review precedes testing",
+      "conformance": "SHALL",
+      "requirement": "Content MUST receive formal review approval before integration testing.",
+      "dependsOn": ["validate-before-review"],
+      "actors": ["content-reviewer"],
+      "satisfiedBy": [{ "kind": "skill", "ref": "content-review" }]
+    },
+    {
+      "key": "test-before-publish",
+      "label": "Testing precedes publication",
+      "conformance": "SHALL",
+      "requirement": "Content MUST pass all tests before publication.",
+      "dependsOn": ["review-before-test"],
+      "actors": ["qc-reviewer"],
+      "satisfiedBy": [{ "kind": "skill", "ref": "content-test" }]
+    },
+    {
+      "key": "publish-authorized",
+      "label": "Publication requires authorization",
+      "conformance": "SHALL",
+      "requirement": "Publication MUST be authorized by the Programme Manager or designated authority.",
+      "dependsOn": ["test-before-publish"],
+      "actors": ["programme-manager", "publication-manager"],
+      "satisfiedBy": [{ "kind": "skill", "ref": "content-publish" }]
+    },
+    {
+      "key": "feedback-collected",
+      "label": "Feedback collected post-publication",
+      "conformance": "SHOULD",
+      "requirement": "Feedback SHOULD be collected from implementers and users after publication and triaged for the next iteration.",
+      "dependsOn": ["publish-authorized"],
+      "satisfiedBy": [{ "kind": "skill", "ref": "content-feedback" }]
+    }
+  ],
+  "tags": ["common", "lifecycle"]
+}

--- a/.claude/skills/requirements/fhir-validation.json
+++ b/.claude/skills/requirements/fhir-validation.json
@@ -1,0 +1,38 @@
+{
+  "id": "req:fhir-validation",
+  "title": "FHIR Validation Requirements",
+  "description": "FHIR Implementation Guide content must pass SUSHI compilation, IG Publisher QA, and conformance validation.",
+  "derivedFrom": ["req:content-lifecycle"],
+  "actors": ["fhir-modeller", "qc-reviewer"],
+  "statements": [
+    {
+      "key": "sushi-compile",
+      "label": "SUSHI compilation succeeds",
+      "conformance": "SHALL",
+      "requirement": "All FSH files SHALL compile successfully with SUSHI before IG Publisher build.",
+      "satisfiedBy": [{ "kind": "capability", "ref": "sushi-compiler" }]
+    },
+    {
+      "key": "ig-publisher-qa",
+      "label": "IG Publisher QA passes",
+      "conformance": "SHALL",
+      "requirement": "The IG Publisher build SHALL complete with no errors in qa.html.",
+      "dependsOn": ["sushi-compile"],
+      "satisfiedBy": [{ "kind": "capability", "ref": "ig-publisher" }]
+    },
+    {
+      "key": "crmi-conformance",
+      "label": "CRMI profile conformance",
+      "conformance": "SHOULD",
+      "requirement": "Resources SHOULD conform to CRMI profiles (Shareable, Publishable, Computable, Executable) as applicable."
+    },
+    {
+      "key": "terminology-bindings",
+      "label": "Terminology bindings valid",
+      "conformance": "SHALL",
+      "requirement": "All terminology bindings SHALL reference valid ValueSets with resolvable codes.",
+      "actors": ["terminologist"]
+    }
+  ],
+  "tags": ["smart-guidelines", "fhir"]
+}

--- a/.claude/skills/requirements/lean-verification.json
+++ b/.claude/skills/requirements/lean-verification.json
@@ -1,0 +1,29 @@
+{
+  "id": "req:lean-verification",
+  "title": "Lean Proof Verification Requirements",
+  "description": "Formal mathematics content must have verified Lean 4 proofs with proper sorry tracking.",
+  "derivedFrom": ["req:content-lifecycle"],
+  "actors": ["author"],
+  "statements": [
+    {
+      "key": "lean-compiles",
+      "label": "Lean project compiles",
+      "conformance": "SHALL",
+      "requirement": "The Lean 4 project SHALL compile with `lake build` without errors.",
+      "satisfiedBy": [{ "kind": "capability", "ref": "lean-toolchain" }]
+    },
+    {
+      "key": "sorry-tracking",
+      "label": "Sorry annotations tracked",
+      "conformance": "SHALL",
+      "requirement": "All `sorry` placeholders SHALL be annotated with reference to the corresponding proof obligation."
+    },
+    {
+      "key": "citation-match",
+      "label": "Citations match bibliography",
+      "conformance": "SHALL",
+      "requirement": "All citations in LaTeX documents SHALL have corresponding bibliography entries."
+    }
+  ],
+  "tags": ["math", "lean"]
+}

--- a/.claude/skills/requirements/session-start.json
+++ b/.claude/skills/requirements/session-start.json
@@ -1,0 +1,31 @@
+{
+  "id": "req:session-start",
+  "title": "Session Start Protocol",
+  "description": "Every agent session must detect the user role and check environment capabilities before proceeding.",
+  "derivedFrom": ["req:agent-workflow"],
+  "actors": ["viewer", "reviewer", "author", "admin"],
+  "statements": [
+    {
+      "key": "detect-role",
+      "label": "Detect user role",
+      "conformance": "SHALL",
+      "requirement": "The agent MUST determine the user's role at session start by checking identity sources against the role assignment table.",
+      "satisfiedBy": [{ "kind": "capability", "ref": "role-detection" }]
+    },
+    {
+      "key": "check-capabilities",
+      "label": "Check environment capabilities",
+      "conformance": "SHALL",
+      "requirement": "The agent MUST probe for all capabilities referenced by skills the user's role can access.",
+      "dependsOn": ["detect-role"]
+    },
+    {
+      "key": "check-todos",
+      "label": "Check open todos",
+      "conformance": "SHOULD",
+      "requirement": "The agent SHOULD check for open todos and present a summary to the user.",
+      "dependsOn": ["detect-role"]
+    }
+  ],
+  "tags": ["common", "session"]
+}

--- a/.claude/skills/roles/role-assignments.json
+++ b/.claude/skills/roles/role-assignments.json
@@ -1,0 +1,22 @@
+{
+  "assignments": [
+    {
+      "userPattern": "litlfred@gmail.com",
+      "identitySource": "git-config",
+      "actorId": "admin",
+      "priority": 100
+    },
+    {
+      "userPattern": "*@who.int",
+      "identitySource": "git-config",
+      "actorId": "author",
+      "priority": 50
+    },
+    {
+      "userPattern": "*",
+      "identitySource": "default",
+      "actorId": "viewer",
+      "priority": 0
+    }
+  ]
+}

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+.git/
+.env
+.env.*
+*.log
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+node_modules/
+dist/
+*.js
+*.js.map
+*.d.ts
+!schemas/generated/*.json
+.env
+.env.*
+*.log
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,10 @@ dist/
 *.js
 *.js.map
 *.d.ts
-!schemas/generated/*.json
 .env
 .env.*
 *.log
 .DS_Store
+
+# Generated files — regenerate with `npm run generate:all`
+schemas/generated/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,114 @@
+# =============================================================================
+# folio-assistant — Ubuntu 24.04 LTS base image
+# =============================================================================
+# Multi-stage build that merges dependencies from all skill packages.
+# Each skill package declares its requirements in package-manifest.json;
+# this Dockerfile is the union of all declared APT, pip, npm, and setup deps.
+#
+# Build:   docker build -t folio-assistant .
+# Run:     docker run -it folio-assistant
+# =============================================================================
+
+FROM ubuntu:24.04 AS base
+
+LABEL org.opencontainers.image.title="folio-assistant"
+LABEL org.opencontainers.image.description="Cross-repository agent skills framework with unified skill management, RBAC, and capability detection"
+LABEL org.opencontainers.image.source="https://github.com/litlfred/folio-assistant"
+LABEL org.opencontainers.image.licenses="MIT"
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=UTC
+
+# ─── System packages (union of all skill package aptPackages) ─────────────────
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    # Core tools
+    curl \
+    wget \
+    ca-certificates \
+    unzip \
+    jq \
+    git \
+    git-lfs \
+    build-essential \
+    cmake \
+    pkg-config \
+    # Python
+    python3 \
+    python3-pip \
+    python3-venv \
+    # Node.js (via nodesource for LTS)
+    nodejs \
+    npm \
+    # Java (for FHIR IG Publisher)
+    openjdk-21-jre-headless \
+    # Ruby (for Jekyll / IG Publisher)
+    ruby-full \
+    # Diagramming
+    graphviz \
+    plantuml \
+    # LaTeX (for math authoring)
+    texlive-full \
+    latexmk \
+    biber \
+    pandoc \
+    # Libraries
+    libgmp-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# ─── Node.js global packages ─────────────────────────────────────────────────
+RUN npm install -g \
+    typescript \
+    ts-node \
+    fsh-sushi
+
+# ─── Python packages ─────────────────────────────────────────────────────────
+RUN pip3 install --no-cache-dir --break-system-packages \
+    matplotlib \
+    numpy \
+    sympy \
+    jupyter \
+    fhir.resources \
+    fhirpathpy \
+    requests \
+    pyyaml \
+    jsonschema \
+    lxml \
+    zod-to-json-schema 2>/dev/null || true
+
+# ─── Ruby gems ───────────────────────────────────────────────────────────────
+RUN gem install jekyll bundler
+
+# ─── FHIR IG Publisher ───────────────────────────────────────────────────────
+RUN mkdir -p /opt/ig-publisher \
+    && curl -L -o /opt/ig-publisher/publisher.jar \
+       https://github.com/HL7/fhir-ig-publisher/releases/latest/download/publisher.jar
+
+ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
+ENV IG_PUBLISHER_JAR=/opt/ig-publisher/publisher.jar
+
+# ─── Lean 4 toolchain ────────────────────────────────────────────────────────
+RUN curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+    | sh -s -- -y --default-toolchain leanprover/lean4:v4.16.0 \
+    && echo 'export PATH="$HOME/.elan/bin:$PATH"' >> /etc/profile.d/lean.sh
+
+ENV LEAN_HOME=/root/.elan
+ENV PATH="/root/.elan/bin:${PATH}"
+
+# ─── Application setup ───────────────────────────────────────────────────────
+WORKDIR /workspace
+
+COPY package.json tsconfig.json ./
+COPY schemas/ schemas/
+COPY skills/ skills/
+COPY scripts/ scripts/
+COPY .claude/ .claude/
+
+# Install npm dependencies
+RUN npm install --production 2>/dev/null || true
+
+# Generate schemas and registry
+RUN npx ts-node scripts/generate-schemas.ts 2>/dev/null || true
+RUN npx ts-node scripts/generate-docs.ts 2>/dev/null || true
+RUN npx ts-node scripts/generate-registry.ts 2>/dev/null || true
+
+CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,23 +72,29 @@ RUN pip3 install --no-cache-dir --break-system-packages \
     requests \
     pyyaml \
     jsonschema \
-    lxml \
-    zod-to-json-schema 2>/dev/null || true
+    lxml
 
 # ─── Ruby gems ───────────────────────────────────────────────────────────────
 RUN gem install jekyll bundler
 
-# ─── FHIR IG Publisher ───────────────────────────────────────────────────────
+# ─── FHIR IG Publisher (pinned version for reproducibility) ──────────────────
+# Pin to a specific release; update this ARG when upgrading.
+ARG IG_PUBLISHER_VERSION=1.7.4
 RUN mkdir -p /opt/ig-publisher \
-    && curl -L -o /opt/ig-publisher/publisher.jar \
-       https://github.com/HL7/fhir-ig-publisher/releases/latest/download/publisher.jar
+    && curl -fSL -o /opt/ig-publisher/publisher.jar \
+       "https://github.com/HL7/fhir-ig-publisher/releases/download/${IG_PUBLISHER_VERSION}/publisher.jar"
 
 ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
 ENV IG_PUBLISHER_JAR=/opt/ig-publisher/publisher.jar
 
 # ─── Lean 4 toolchain ────────────────────────────────────────────────────────
-RUN curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
-    | sh -s -- -y --default-toolchain leanprover/lean4:v4.16.0 \
+# Download the installer, verify it's a shell script, then execute it.
+ARG ELAN_VERSION=v3.1.1
+RUN curl -fSL -o /tmp/elan-init.sh \
+       "https://raw.githubusercontent.com/leanprover/elan/${ELAN_VERSION}/elan-init.sh" \
+    && head -1 /tmp/elan-init.sh | grep -q '^#!' \
+    && sh /tmp/elan-init.sh -y --default-toolchain leanprover/lean4:v4.16.0 \
+    && rm /tmp/elan-init.sh \
     && echo 'export PATH="$HOME/.elan/bin:$PATH"' >> /etc/profile.d/lean.sh
 
 ENV LEAN_HOME=/root/.elan
@@ -104,11 +110,11 @@ COPY scripts/ scripts/
 COPY .claude/ .claude/
 
 # Install npm dependencies
-RUN npm install --production 2>/dev/null || true
+RUN npm install --production
 
 # Generate schemas and registry
-RUN npx ts-node scripts/generate-schemas.ts 2>/dev/null || true
-RUN npx ts-node scripts/generate-docs.ts 2>/dev/null || true
-RUN npx ts-node scripts/generate-registry.ts 2>/dev/null || true
+RUN npx ts-node scripts/generate-schemas.ts
+RUN npx ts-node scripts/generate-docs.ts
+RUN npx ts-node scripts/generate-registry.ts
 
 CMD ["/bin/bash"]

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@folio-assistant/core",
+  "version": "0.1.0",
+  "description": "Cross-repository agent skills framework with unified skill management, RBAC, and capability detection",
+  "type": "module",
+  "main": "schemas/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "generate:schemas": "ts-node scripts/generate-schemas.ts",
+    "generate:docs": "ts-node scripts/generate-docs.ts",
+    "generate:registry": "ts-node scripts/generate-registry.ts",
+    "generate:all": "npm run generate:schemas && npm run generate:docs && npm run generate:registry",
+    "validate": "ts-node scripts/validate-skills.ts",
+    "docker:build": "docker build -t folio-assistant .",
+    "docker:build:math": "docker build -f skills/authoring-math/Dockerfile -t folio-assistant-math .",
+    "docker:build:smart": "docker build -f skills/authoring-who-smart-guidelines/Dockerfile -t folio-assistant-smart ."
+  },
+  "dependencies": {
+    "zod": "^3.23.0",
+    "zod-to-json-schema": "^3.23.0",
+    "typescript-json-schema": "^0.65.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.0",
+    "ts-node": "^10.9.0",
+    "@types/node": "^22.0.0"
+  },
+  "license": "MIT"
+}

--- a/schemas/builders.ts
+++ b/schemas/builders.ts
@@ -1,0 +1,67 @@
+/**
+ * @module @folio-assistant/schemas/builders
+ * @description Builder functions for constructing validated framework objects.
+ *
+ * Each builder validates the input against its Zod schema and returns
+ * the typed object, providing compile-time AND runtime safety.
+ */
+
+import type {
+  ActorDefinition,
+  CapabilityDefinition,
+  SkillDefinition,
+  Requirement,
+  SkillRegistry,
+  RoleAssignment,
+  DockerRequirements,
+  SkillPackageManifest,
+  RemotePackageRef,
+} from "./types.js";
+
+import {
+  ActorDefinitionSchema,
+  CapabilityDefinitionSchema,
+  SkillDefinitionSchema,
+  RequirementSchema,
+  SkillRegistrySchema,
+  RoleAssignmentSchema,
+  DockerRequirementsSchema,
+  SkillPackageManifestSchema,
+  RemotePackageRefSchema,
+} from "./constraints.js";
+
+export function actor(def: ActorDefinition): ActorDefinition {
+  return ActorDefinitionSchema.parse(def);
+}
+
+export function capability(def: CapabilityDefinition): CapabilityDefinition {
+  return CapabilityDefinitionSchema.parse(def);
+}
+
+export function skill(def: SkillDefinition): SkillDefinition {
+  return SkillDefinitionSchema.parse(def);
+}
+
+export function requirement(def: Requirement): Requirement {
+  return RequirementSchema.parse(def);
+}
+
+export function registry(def: SkillRegistry): SkillRegistry {
+  return SkillRegistrySchema.parse(def);
+}
+
+export function roleAssignment(def: RoleAssignment): RoleAssignment {
+  return RoleAssignmentSchema.parse(def);
+}
+
+export function dockerRequirements(def: DockerRequirements): DockerRequirements {
+  return DockerRequirementsSchema.parse(def);
+}
+
+export function packageManifest(def: SkillPackageManifest): SkillPackageManifest {
+  return SkillPackageManifestSchema.parse(def);
+}
+
+export function remotePackage(def: RemotePackageRef): RemotePackageRef {
+  return RemotePackageRefSchema.parse(def);
+}

--- a/schemas/constraints.ts
+++ b/schemas/constraints.ts
@@ -1,0 +1,226 @@
+/**
+ * @module @folio-assistant/schemas/constraints
+ * @description Zod validation schemas for all framework types.
+ *
+ * These schemas provide runtime validation and are used by the
+ * schema generation scripts to produce JSON Schema files.
+ */
+
+import { z } from "zod";
+
+// ─── Enumerations ────────────────────────────────────────────────────────────
+
+export const ActorTypeSchema = z.enum(["person", "system"]);
+export const ConformanceSchema = z.enum(["SHALL", "SHOULD", "MAY", "SHALL NOT"]);
+export const DegradationStrategySchema = z.enum(["fail", "warn", "skip", "fallback"]);
+export const ScriptRuntimeSchema = z.enum(["bash", "python", "typescript", "bun"]);
+export const ScriptPhaseSchema = z.enum(["pre", "execute", "validate", "post"]);
+export const ValidatorScopeSchema = z.enum(["file", "block", "chapter", "project"]);
+export const HookEventSchema = z.enum([
+  "SessionStart", "PostToolUse", "PreCommit", "PostCommit", "UserPromptSubmit",
+]);
+export const IdentitySourceSchema = z.enum([
+  "git-config", "github-oauth", "google-oauth", "env-var", "bearer-token", "default",
+]);
+export const SatisfiedByKindSchema = z.enum(["skill", "capability", "requirement-statement"]);
+export const DependencyKindSchema = z.enum(["skill", "requirement"]);
+export const LifecycleStageSchema = z.enum([
+  "plan", "author", "validate", "review", "test", "publish", "feedback", "retire",
+]);
+
+// ─── Capability Detection ────────────────────────────────────────────────────
+
+export const CapabilityDetectionSchema = z.discriminatedUnion("method", [
+  z.object({ method: z.literal("command"), command: z.string(), expectExitCode: z.number().optional() }),
+  z.object({ method: z.literal("env-var"), variable: z.string() }),
+  z.object({ method: z.literal("file-exists"), path: z.string() }),
+  z.object({ method: z.literal("mcp-probe"), endpoint: z.string(), healthPath: z.string().optional() }),
+  z.object({ method: z.literal("always") }),
+]);
+
+// ─── ActorDefinition ─────────────────────────────────────────────────────────
+
+export const ActorDefinitionSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  type: ActorTypeSchema,
+  description: z.string(),
+  inherits: z.array(z.string()),
+  capabilities: z.array(z.string()),
+  meta: z.record(z.unknown()).optional(),
+});
+
+// ─── CapabilityDefinition ────────────────────────────────────────────────────
+
+export const CapabilityDefinitionSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string(),
+  detection: CapabilityDetectionSchema,
+  requires: z.array(z.string()).optional(),
+});
+
+// ─── SkillDefinition ─────────────────────────────────────────────────────────
+
+export const SkillCapabilityRefSchema = z.object({
+  capabilityId: z.string(),
+  degradation: DegradationStrategySchema,
+  fallbackCapabilityId: z.string().optional(),
+});
+
+export const SkillDependencySchema = z.object({
+  ref: z.string(),
+  kind: DependencyKindSchema,
+  conformance: ConformanceSchema,
+});
+
+export const SkillScriptSchema = z.object({
+  path: z.string(),
+  runtime: ScriptRuntimeSchema,
+  phase: ScriptPhaseSchema,
+  args: z.array(z.string()).optional(),
+});
+
+export const SkillValidatorSchema = z.object({
+  id: z.string(),
+  path: z.string(),
+  runtime: ScriptRuntimeSchema,
+  scope: ValidatorScopeSchema,
+});
+
+export const SkillDefinitionSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string(),
+  roles: z.array(z.string()),
+  requiredCapabilities: z.array(SkillCapabilityRefSchema),
+  dependsOn: z.array(SkillDependencySchema).optional(),
+  allowedTools: z.array(z.string()).optional(),
+  scripts: z.array(SkillScriptSchema).optional(),
+  mcpServices: z.array(z.string()).optional(),
+  validators: z.array(SkillValidatorSchema).optional(),
+  routingPatterns: z.array(z.string()).optional(),
+  tags: z.array(z.string()).optional(),
+  package: z.string().optional(),
+  lifecycleStages: z.array(LifecycleStageSchema).optional(),
+  schemaRef: z.string().optional(),
+});
+
+// ─── Requirement ─────────────────────────────────────────────────────────────
+
+export const SatisfiedByRefSchema = z.object({
+  kind: SatisfiedByKindSchema,
+  ref: z.string(),
+});
+
+export const RequirementStatementSchema = z.object({
+  key: z.string().min(1),
+  label: z.string(),
+  conformance: ConformanceSchema,
+  requirement: z.string(),
+  actors: z.array(z.string()).optional(),
+  satisfiedBy: z.array(SatisfiedByRefSchema).optional(),
+  dependsOn: z.array(z.string()).optional(),
+});
+
+export const RequirementSchema = z.object({
+  id: z.string().min(1),
+  title: z.string(),
+  description: z.string(),
+  derivedFrom: z.array(z.string()).optional(),
+  actors: z.array(z.string()),
+  statements: z.array(RequirementStatementSchema),
+  tags: z.array(z.string()).optional(),
+});
+
+// ─── Registry ────────────────────────────────────────────────────────────────
+
+export const SkillPackageRefSchema = z.object({
+  name: z.string(),
+  repo: z.string(),
+  path: z.string(),
+  ref: z.string(),
+  skills: z.array(z.string()),
+});
+
+export const HookCommandSchema = z.object({
+  type: z.literal("command"),
+  command: z.string(),
+  timeout: z.number().optional(),
+});
+
+export const SessionHookSchema = z.object({
+  event: HookEventSchema,
+  matcher: z.string().optional(),
+  commands: z.array(HookCommandSchema),
+});
+
+export const RoleAssignmentSchema = z.object({
+  userPattern: z.string(),
+  identitySource: IdentitySourceSchema,
+  actorId: z.string(),
+  priority: z.number(),
+});
+
+export const SkillRegistrySchema = z.object({
+  schemaVersion: z.literal("1.0"),
+  repository: z.string(),
+  actors: z.array(ActorDefinitionSchema),
+  capabilities: z.array(CapabilityDefinitionSchema),
+  skills: z.array(SkillDefinitionSchema),
+  requirements: z.array(RequirementSchema),
+  packages: z.array(SkillPackageRefSchema),
+  hooks: z.array(SessionHookSchema),
+});
+
+// ─── Docker Requirements ─────────────────────────────────────────────────────
+
+export const DockerRequirementsSchema = z.object({
+  baseImage: z.string().default("ubuntu:24.04"),
+  aptPackages: z.array(z.string()),
+  pipPackages: z.array(z.string()).optional(),
+  npmPackages: z.array(z.string()).optional(),
+  setupCommands: z.array(z.string()).optional(),
+  exposePorts: z.array(z.number()).optional(),
+  env: z.record(z.string()).optional(),
+  labels: z.record(z.string()).optional(),
+});
+
+export const SkillPackageManifestSchema = z.object({
+  name: z.string().min(1),
+  version: z.string(),
+  description: z.string(),
+  skills: z.array(z.string()),
+  docker: DockerRequirementsSchema,
+  providesCapabilities: z.array(z.string()).optional(),
+  requiresCapabilities: z.array(z.string()).optional(),
+  lifecycleStages: z.array(LifecycleStageSchema).optional(),
+  schemas: z.array(z.string()).optional(),
+});
+
+// ─── Remote Package Reference ────────────────────────────────────────────────
+
+export const RemoteSyncStrategySchema = z.enum(["shallow-clone", "sparse-checkout", "subtree"]);
+
+export const RemoteSyncConfigSchema = z.object({
+  strategy: RemoteSyncStrategySchema,
+  frequency: z.enum(["daily", "weekly", "monthly", "manual"]),
+  autoUpdate: z.boolean(),
+});
+
+export const RemotePackageRefSchema = z.object({
+  name: z.string().min(1),
+  description: z.string(),
+  repo: z.string().url(),
+  ref: z.string(),
+  path: z.string(),
+  maintainer: z.string(),
+  sync: RemoteSyncConfigSchema,
+  wrapper: z.object({
+    description: z.string(),
+    docker: DockerRequirementsSchema,
+    providesCapabilities: z.array(z.string()).optional(),
+    skills: z.array(z.string()),
+    lifecycleStages: z.array(LifecycleStageSchema).optional(),
+  }),
+});

--- a/schemas/index.ts
+++ b/schemas/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @module @folio-assistant/schemas
+ * @description Core schema package for the agent skills framework.
+ *
+ * Re-exports all types, Zod validation schemas, and builder functions.
+ */
+
+export * from "./types.js";
+export * from "./constraints.js";
+export * from "./builders.js";

--- a/schemas/skills/bpmn-authoring/input.schema.json
+++ b/schemas/skills/bpmn-authoring/input.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/bpmn-authoring/input.schema.json",
+  "title": "BPMN Authoring Input",
+  "description": "Input schema for BPMN 2.0 business process authoring.",
+  "type": "object",
+  "required": ["processName"],
+  "properties": {
+    "processName": {
+      "type": "string",
+      "description": "Name of the business process to model."
+    },
+    "sourceWorkflow": {
+      "type": "string",
+      "description": "Textual description or reference to the workflow to model."
+    },
+    "existingBpmn": {
+      "type": "string",
+      "description": "Path to existing BPMN file to update."
+    },
+    "participants": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Actor/participant IDs involved in the process."
+    }
+  }
+}

--- a/schemas/skills/bpmn-authoring/output.schema.json
+++ b/schemas/skills/bpmn-authoring/output.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/bpmn-authoring/output.schema.json",
+  "title": "BPMN Authoring Output",
+  "description": "Output schema for BPMN 2.0 business process authoring.",
+  "type": "object",
+  "required": ["bpmnFile"],
+  "properties": {
+    "bpmnFile": {
+      "type": "string",
+      "description": "Path to the generated/updated BPMN file."
+    },
+    "diagramFile": {
+      "type": "string",
+      "description": "Path to the rendered diagram (SVG/PNG)."
+    },
+    "taskCount": { "type": "integer" },
+    "gatewayCount": { "type": "integer" },
+    "participantCount": { "type": "integer" }
+  }
+}

--- a/schemas/skills/content-author/input.schema.json
+++ b/schemas/skills/content-author/input.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/content-author/input.schema.json",
+  "title": "Content Author Input",
+  "description": "Input schema for general content authoring.",
+  "type": "object",
+  "required": ["contentType"],
+  "properties": {
+    "contentType": {
+      "type": "string",
+      "enum": ["document", "fhir-ig", "lean-proof", "bpmn", "data-dictionary"],
+      "description": "Type of content to author."
+    },
+    "sourceRef": { "type": "string", "description": "Reference to source material." },
+    "outputDir": { "type": "string", "description": "Output directory for authored content." }
+  }
+}

--- a/schemas/skills/content-author/output.schema.json
+++ b/schemas/skills/content-author/output.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/content-author/output.schema.json",
+  "title": "Content Author Output",
+  "description": "Output schema for general content authoring.",
+  "type": "object",
+  "required": ["artifacts"],
+  "properties": {
+    "artifacts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["path", "type"],
+        "properties": {
+          "path": { "type": "string" },
+          "type": { "type": "string" },
+          "status": { "type": "string", "enum": ["draft", "ready-for-validation"] }
+        }
+      }
+    }
+  }
+}

--- a/schemas/skills/content-feedback/input.schema.json
+++ b/schemas/skills/content-feedback/input.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/content-feedback/input.schema.json",
+  "title": "Content Feedback Input",
+  "description": "Input schema for feedback collection and triage.",
+  "type": "object",
+  "required": ["source"],
+  "properties": {
+    "source": {
+      "type": "string",
+      "enum": ["github-issues", "survey", "implementation-report", "clinical-review"],
+      "description": "Source of feedback."
+    },
+    "publishedVersion": { "type": "string", "description": "Version the feedback relates to." },
+    "feedbackItems": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["description"],
+        "properties": {
+          "description": { "type": "string" },
+          "severity": { "type": "string", "enum": ["critical", "major", "minor", "enhancement"] },
+          "component": { "type": "string" },
+          "reporter": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/schemas/skills/content-feedback/output.schema.json
+++ b/schemas/skills/content-feedback/output.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/content-feedback/output.schema.json",
+  "title": "Content Feedback Output",
+  "description": "Output schema for triaged feedback.",
+  "type": "object",
+  "required": ["triagedItems"],
+  "properties": {
+    "triagedItems": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "priority", "disposition"],
+        "properties": {
+          "id": { "type": "string" },
+          "priority": { "type": "string", "enum": ["P0", "P1", "P2", "P3"] },
+          "disposition": { "type": "string", "enum": ["backlog", "next-sprint", "wont-fix", "duplicate", "needs-info"] },
+          "assignee": { "type": "string" },
+          "linkedIssue": { "type": "string" }
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "properties": {
+        "total": { "type": "integer" },
+        "critical": { "type": "integer" },
+        "major": { "type": "integer" },
+        "minor": { "type": "integer" },
+        "enhancement": { "type": "integer" }
+      }
+    }
+  }
+}

--- a/schemas/skills/content-plan/input.schema.json
+++ b/schemas/skills/content-plan/input.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/content-plan/input.schema.json",
+  "title": "Content Plan Input",
+  "description": "Input schema for content planning — scope, team, timeline, governance.",
+  "type": "object",
+  "required": ["projectName"],
+  "properties": {
+    "projectName": { "type": "string" },
+    "scope": { "type": "string", "description": "Description of the content scope." },
+    "targetDate": { "type": "string", "format": "date" },
+    "teamSize": { "type": "integer", "minimum": 1 },
+    "sprintDuration": { "type": "string", "enum": ["1w", "2w", "3w", "4w"], "default": "2w" }
+  }
+}

--- a/schemas/skills/content-plan/output.schema.json
+++ b/schemas/skills/content-plan/output.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/content-plan/output.schema.json",
+  "title": "Content Plan Output",
+  "description": "Output schema for content planning.",
+  "type": "object",
+  "required": ["plan"],
+  "properties": {
+    "plan": {
+      "type": "object",
+      "required": ["projectName", "sprints", "team"],
+      "properties": {
+        "projectName": { "type": "string" },
+        "sprints": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "number": { "type": "integer" },
+              "startDate": { "type": "string", "format": "date" },
+              "endDate": { "type": "string", "format": "date" },
+              "goals": { "type": "array", "items": { "type": "string" } }
+            }
+          }
+        },
+        "team": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "actorId": { "type": "string" },
+              "name": { "type": "string" },
+              "responsibilities": { "type": "array", "items": { "type": "string" } }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/skills/content-publish/input.schema.json
+++ b/schemas/skills/content-publish/input.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/content-publish/input.schema.json",
+  "title": "Content Publish Input",
+  "description": "Input schema for content publication.",
+  "type": "object",
+  "required": ["versionIncrement"],
+  "properties": {
+    "versionIncrement": { "type": "string", "enum": ["major", "minor", "patch"] },
+    "releaseNotes": { "type": "string" },
+    "target": {
+      "type": "string",
+      "enum": ["github-release", "npm", "fhir-registry", "arxiv"],
+      "description": "Publication target."
+    }
+  }
+}

--- a/schemas/skills/content-publish/output.schema.json
+++ b/schemas/skills/content-publish/output.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/content-publish/output.schema.json",
+  "title": "Content Publish Output",
+  "description": "Output schema for content publication.",
+  "type": "object",
+  "required": ["version", "status"],
+  "properties": {
+    "version": { "type": "string" },
+    "status": { "type": "string", "enum": ["published", "failed"] },
+    "publishedUrl": { "type": "string" },
+    "releaseTag": { "type": "string" }
+  }
+}

--- a/schemas/skills/content-review/input.schema.json
+++ b/schemas/skills/content-review/input.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/content-review/input.schema.json",
+  "title": "Content Review Input",
+  "description": "Input schema for formal content review and approval workflow.",
+  "type": "object",
+  "required": ["reviewType", "contentRef"],
+  "properties": {
+    "reviewType": {
+      "type": "string",
+      "enum": ["l2-to-l3-gate", "l3-to-publish-gate", "change-assessment", "final-signoff"],
+      "description": "Type of review phase gate."
+    },
+    "contentRef": {
+      "type": "string",
+      "description": "Git ref or path to the content being reviewed."
+    },
+    "previousVersion": {
+      "type": "string",
+      "description": "Git ref of the previous approved version (for diff)."
+    },
+    "validationReport": {
+      "type": "string",
+      "description": "Path to the validation report for this content."
+    }
+  }
+}

--- a/schemas/skills/content-review/output.schema.json
+++ b/schemas/skills/content-review/output.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/content-review/output.schema.json",
+  "title": "Content Review Output",
+  "description": "Output schema for content review decisions.",
+  "type": "object",
+  "required": ["decision"],
+  "properties": {
+    "decision": {
+      "type": "string",
+      "enum": ["approve", "request-changes", "reject"]
+    },
+    "reviewer": { "type": "string" },
+    "reviewDate": { "type": "string", "format": "date-time" },
+    "comments": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "location": { "type": "string" },
+          "severity": { "type": "string", "enum": ["blocking", "suggestion", "praise"] },
+          "comment": { "type": "string" }
+        }
+      }
+    },
+    "conditions": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Conditions that must be met before the approval is final."
+    }
+  }
+}

--- a/schemas/skills/content-test/input.schema.json
+++ b/schemas/skills/content-test/input.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/content-test/input.schema.json",
+  "title": "Content Test Input",
+  "description": "Input schema for end-to-end content testing.",
+  "type": "object",
+  "required": ["targetPath"],
+  "properties": {
+    "targetPath": { "type": "string" },
+    "testPlan": { "type": "string", "description": "Path to test plan file." },
+    "testData": { "type": "string", "description": "Path to test data directory." },
+    "regressionBaseline": { "type": "string", "description": "Git ref for regression baseline." }
+  }
+}

--- a/schemas/skills/content-test/output.schema.json
+++ b/schemas/skills/content-test/output.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/content-test/output.schema.json",
+  "title": "Content Test Output",
+  "description": "Output schema for content testing results.",
+  "type": "object",
+  "required": ["overallStatus", "testResults"],
+  "properties": {
+    "overallStatus": { "type": "string", "enum": ["pass", "fail"] },
+    "testResults": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["testId", "status"],
+        "properties": {
+          "testId": { "type": "string" },
+          "status": { "type": "string", "enum": ["pass", "fail", "skipped"] },
+          "message": { "type": "string" },
+          "duration": { "type": "number" }
+        }
+      }
+    },
+    "coverage": {
+      "type": "object",
+      "properties": {
+        "total": { "type": "integer" },
+        "passed": { "type": "integer" },
+        "failed": { "type": "integer" },
+        "skipped": { "type": "integer" }
+      }
+    }
+  }
+}

--- a/schemas/skills/content-validate/input.schema.json
+++ b/schemas/skills/content-validate/input.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/content-validate/input.schema.json",
+  "title": "Content Validate Input",
+  "description": "Input schema for content validation.",
+  "type": "object",
+  "required": ["targetPath"],
+  "properties": {
+    "targetPath": { "type": "string", "description": "Path to content to validate." },
+    "validationRules": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Specific validation rule IDs to run (empty = all applicable)."
+    },
+    "schemaRefs": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Schema files to validate against."
+    }
+  }
+}

--- a/schemas/skills/content-validate/output.schema.json
+++ b/schemas/skills/content-validate/output.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/content-validate/output.schema.json",
+  "title": "Content Validate Output",
+  "description": "Output schema for content validation results.",
+  "type": "object",
+  "required": ["overallStatus", "results"],
+  "properties": {
+    "overallStatus": { "type": "string", "enum": ["pass", "warnings", "errors"] },
+    "results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["rule", "status"],
+        "properties": {
+          "rule": { "type": "string" },
+          "status": { "type": "string", "enum": ["pass", "fail", "warning", "skipped"] },
+          "message": { "type": "string" },
+          "location": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/schemas/skills/dmn-authoring/input.schema.json
+++ b/schemas/skills/dmn-authoring/input.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/dmn-authoring/input.schema.json",
+  "title": "DMN Authoring Input",
+  "description": "Input schema for DMN (Decision Model and Notation) decision table authoring.",
+  "type": "object",
+  "required": ["decisionName", "inputVariables"],
+  "properties": {
+    "decisionName": {
+      "type": "string",
+      "description": "Name of the decision to model."
+    },
+    "inputVariables": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "type"],
+        "properties": {
+          "name": { "type": "string" },
+          "type": { "type": "string", "enum": ["string", "integer", "boolean", "date", "codeable-concept"] }
+        }
+      }
+    },
+    "sourceLogic": {
+      "type": "string",
+      "description": "Reference to the clinical decision logic being modeled."
+    }
+  }
+}

--- a/schemas/skills/dmn-authoring/output.schema.json
+++ b/schemas/skills/dmn-authoring/output.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/dmn-authoring/output.schema.json",
+  "title": "DMN Authoring Output",
+  "description": "Output schema for DMN decision table authoring.",
+  "type": "object",
+  "required": ["dmnFile"],
+  "properties": {
+    "dmnFile": { "type": "string" },
+    "decisionTableCount": { "type": "integer" },
+    "ruleCount": { "type": "integer" },
+    "hitPolicy": { "type": "string", "enum": ["UNIQUE", "FIRST", "PRIORITY", "ANY", "COLLECT", "RULE ORDER"] }
+  }
+}

--- a/schemas/skills/fhir-validation/input.schema.json
+++ b/schemas/skills/fhir-validation/input.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/fhir-validation/input.schema.json",
+  "title": "FHIR Validation Input",
+  "description": "Input schema for FHIR validation — runs SUSHI, IG Publisher QA, and conformance checks.",
+  "type": "object",
+  "required": ["igRoot"],
+  "properties": {
+    "igRoot": {
+      "type": "string",
+      "description": "Path to the IG repository root."
+    },
+    "validationLevel": {
+      "type": "string",
+      "enum": ["sushi-only", "publisher-qa", "full"],
+      "default": "full",
+      "description": "Level of validation to perform."
+    },
+    "targetProfiles": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Specific CRMI profiles to validate against (Shareable, Publishable, Computable, Executable)."
+    }
+  }
+}

--- a/schemas/skills/fhir-validation/output.schema.json
+++ b/schemas/skills/fhir-validation/output.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/fhir-validation/output.schema.json",
+  "title": "FHIR Validation Output",
+  "description": "Output schema for FHIR validation results.",
+  "type": "object",
+  "required": ["overallStatus"],
+  "properties": {
+    "overallStatus": {
+      "type": "string",
+      "enum": ["pass", "warnings", "errors"]
+    },
+    "sushiResult": {
+      "type": "object",
+      "properties": {
+        "status": { "type": "string" },
+        "errors": { "type": "integer" },
+        "warnings": { "type": "integer" }
+      }
+    },
+    "publisherResult": {
+      "type": "object",
+      "properties": {
+        "status": { "type": "string" },
+        "qaHtmlPath": { "type": "string" },
+        "errorCount": { "type": "integer" },
+        "warningCount": { "type": "integer" },
+        "infoCount": { "type": "integer" }
+      }
+    },
+    "conformanceResults": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "resource": { "type": "string" },
+          "profile": { "type": "string" },
+          "status": { "type": "string", "enum": ["conformant", "non-conformant"] },
+          "issues": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    }
+  }
+}

--- a/schemas/skills/ig-publication/input.schema.json
+++ b/schemas/skills/ig-publication/input.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/ig-publication/input.schema.json",
+  "title": "IG Publication Input",
+  "description": "Input schema for FHIR Implementation Guide publication.",
+  "type": "object",
+  "required": ["igRoot", "versionIncrement"],
+  "properties": {
+    "igRoot": {
+      "type": "string",
+      "description": "Path to the IG repository root."
+    },
+    "versionIncrement": {
+      "type": "string",
+      "enum": ["major", "minor", "patch"],
+      "description": "Semantic version increment type."
+    },
+    "releaseNotes": {
+      "type": "string",
+      "description": "Release notes for this publication."
+    },
+    "publicationTarget": {
+      "type": "string",
+      "enum": ["github-pages", "smart-who-int", "both"],
+      "default": "github-pages"
+    }
+  }
+}

--- a/schemas/skills/ig-publication/output.schema.json
+++ b/schemas/skills/ig-publication/output.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/ig-publication/output.schema.json",
+  "title": "IG Publication Output",
+  "description": "Output schema for FHIR IG publication.",
+  "type": "object",
+  "required": ["version", "publishedUrl"],
+  "properties": {
+    "version": { "type": "string" },
+    "publishedUrl": { "type": "string" },
+    "releaseTag": { "type": "string" },
+    "releaseBranch": { "type": "string" },
+    "publicationRequestPath": { "type": "string" },
+    "buildStatus": {
+      "type": "string",
+      "enum": ["success", "failed"]
+    }
+  }
+}

--- a/schemas/skills/l2-dak-authoring/input.schema.json
+++ b/schemas/skills/l2-dak-authoring/input.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/l2-dak-authoring/input.schema.json",
+  "title": "L2 DAK Authoring Input",
+  "description": "Input schema for L2 Digital Adaptation Kit authoring. Translates WHO clinical guidelines into structured digital artifacts.",
+  "type": "object",
+  "required": ["dakComponent", "sourceGuideline"],
+  "properties": {
+    "dakComponent": {
+      "type": "string",
+      "enum": [
+        "personas",
+        "user-scenarios",
+        "business-processes",
+        "data-dictionary",
+        "decision-logic",
+        "scheduling-logic",
+        "indicators",
+        "functional-requirements",
+        "non-functional-requirements"
+      ],
+      "description": "Which DAK component to author."
+    },
+    "sourceGuideline": {
+      "type": "string",
+      "description": "Reference to the WHO L1 guideline being adapted."
+    },
+    "existingContent": {
+      "type": "string",
+      "description": "Path to existing content being iterated on (if any)."
+    },
+    "sprintNumber": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Current sprint/iteration number."
+    }
+  }
+}

--- a/schemas/skills/l2-dak-authoring/output.schema.json
+++ b/schemas/skills/l2-dak-authoring/output.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/l2-dak-authoring/output.schema.json",
+  "title": "L2 DAK Authoring Output",
+  "description": "Output schema for L2 DAK authoring.",
+  "type": "object",
+  "required": ["artifacts", "status"],
+  "properties": {
+    "artifacts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["path", "type"],
+        "properties": {
+          "path": { "type": "string" },
+          "type": { "type": "string", "enum": ["bpmn", "dmn", "spreadsheet", "markdown", "fsh"] },
+          "description": { "type": "string" }
+        }
+      }
+    },
+    "status": {
+      "type": "string",
+      "enum": ["draft", "ready-for-review", "approved"]
+    },
+    "validationIssues": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "severity": { "type": "string", "enum": ["error", "warning", "info"] },
+          "message": { "type": "string" },
+          "location": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/schemas/skills/l3-fhir-authoring/input.schema.json
+++ b/schemas/skills/l3-fhir-authoring/input.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/l3-fhir-authoring/input.schema.json",
+  "title": "L3 FHIR Authoring Input",
+  "description": "Input schema for L3 FHIR IG authoring. Creates machine-readable FHIR artifacts from L2 DAK specifications.",
+  "type": "object",
+  "required": ["artifactType", "l2Source"],
+  "properties": {
+    "artifactType": {
+      "type": "string",
+      "enum": [
+        "logical-model",
+        "profile",
+        "questionnaire",
+        "cql-library",
+        "structure-map",
+        "plan-definition",
+        "measure",
+        "test-case",
+        "actor-definition",
+        "requirements"
+      ],
+      "description": "Type of FHIR artifact to author."
+    },
+    "l2Source": {
+      "type": "string",
+      "description": "Path or reference to the L2 DAK source material."
+    },
+    "fshOutputDir": {
+      "type": "string",
+      "default": "input/fsh",
+      "description": "Directory for FSH output files."
+    },
+    "igRoot": {
+      "type": "string",
+      "description": "IG repository root directory."
+    }
+  }
+}

--- a/schemas/skills/l3-fhir-authoring/output.schema.json
+++ b/schemas/skills/l3-fhir-authoring/output.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/l3-fhir-authoring/output.schema.json",
+  "title": "L3 FHIR Authoring Output",
+  "description": "Output schema for L3 FHIR IG authoring.",
+  "type": "object",
+  "required": ["fshFiles", "sushiResult"],
+  "properties": {
+    "fshFiles": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["path", "resourceType"],
+        "properties": {
+          "path": { "type": "string" },
+          "resourceType": { "type": "string" },
+          "resourceId": { "type": "string" }
+        }
+      }
+    },
+    "sushiResult": {
+      "type": "object",
+      "properties": {
+        "status": { "type": "string", "enum": ["success", "warnings", "errors"] },
+        "resourceCount": { "type": "integer" },
+        "errorCount": { "type": "integer" },
+        "warningCount": { "type": "integer" }
+      }
+    },
+    "generatedResources": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "path": { "type": "string" },
+          "resourceType": { "type": "string" },
+          "url": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/schemas/skills/latex-authoring/input.schema.json
+++ b/schemas/skills/latex-authoring/input.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/latex-authoring/input.schema.json",
+  "title": "LaTeX Authoring Input",
+  "description": "Input schema for the latex-authoring skill.",
+  "type": "object",
+  "required": ["documentClass", "mainFile"],
+  "properties": {
+    "documentClass": {
+      "type": "string",
+      "enum": ["article", "book", "report", "beamer"],
+      "description": "LaTeX document class."
+    },
+    "mainFile": {
+      "type": "string",
+      "description": "Path to the main .tex file."
+    },
+    "bibliographyFile": {
+      "type": "string",
+      "description": "Path to the .bib bibliography file."
+    },
+    "outputFormat": {
+      "type": "string",
+      "enum": ["pdf", "dvi", "ps"],
+      "default": "pdf"
+    }
+  }
+}

--- a/schemas/skills/latex-authoring/output.schema.json
+++ b/schemas/skills/latex-authoring/output.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/latex-authoring/output.schema.json",
+  "title": "LaTeX Authoring Output",
+  "description": "Output schema for the latex-authoring skill.",
+  "type": "object",
+  "required": ["outputFile", "buildStatus"],
+  "properties": {
+    "outputFile": {
+      "type": "string",
+      "description": "Path to the compiled output (PDF, etc.)."
+    },
+    "buildStatus": {
+      "type": "string",
+      "enum": ["success", "warnings", "errors"]
+    },
+    "warnings": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "pageCount": {
+      "type": "integer",
+      "minimum": 0
+    }
+  }
+}

--- a/schemas/skills/lean-formalization/input.schema.json
+++ b/schemas/skills/lean-formalization/input.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/lean-formalization/input.schema.json",
+  "title": "Lean Formalization Input",
+  "description": "Input schema for the lean-formalization skill. Describes source material to be formalized in Lean 4.",
+  "type": "object",
+  "required": ["sourceFile", "targetModule"],
+  "properties": {
+    "sourceFile": {
+      "type": "string",
+      "description": "Path to the source material (LaTeX, markdown, or existing Lean file) to formalize."
+    },
+    "targetModule": {
+      "type": "string",
+      "description": "Lean module path for the output (e.g. 'Qou.CategoryTheory.Functors')."
+    },
+    "proofStrategy": {
+      "type": "string",
+      "enum": ["tactic", "term", "mixed"],
+      "default": "tactic",
+      "description": "Preferred proof style."
+    },
+    "dependencies": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Lean package dependencies (lake packages)."
+    }
+  }
+}

--- a/schemas/skills/lean-formalization/output.schema.json
+++ b/schemas/skills/lean-formalization/output.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/lean-formalization/output.schema.json",
+  "title": "Lean Formalization Output",
+  "description": "Output schema for the lean-formalization skill.",
+  "type": "object",
+  "required": ["leanFiles", "buildStatus"],
+  "properties": {
+    "leanFiles": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["path", "module"],
+        "properties": {
+          "path": { "type": "string" },
+          "module": { "type": "string" },
+          "sorryCount": { "type": "integer", "minimum": 0 }
+        }
+      }
+    },
+    "buildStatus": {
+      "type": "string",
+      "enum": ["success", "warnings", "errors"]
+    },
+    "diagnostics": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "file": { "type": "string" },
+          "line": { "type": "integer" },
+          "severity": { "type": "string", "enum": ["error", "warning", "info"] },
+          "message": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/schemas/skills/proof-verification/input.schema.json
+++ b/schemas/skills/proof-verification/input.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/proof-verification/input.schema.json",
+  "title": "Proof Verification Input",
+  "description": "Input schema for the proof-verification skill. Verifies Lean proofs and tracks sorry obligations.",
+  "type": "object",
+  "required": ["projectRoot"],
+  "properties": {
+    "projectRoot": {
+      "type": "string",
+      "description": "Path to the Lean project root (containing lakefile.lean)."
+    },
+    "targetFiles": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Specific files to verify (empty = entire project)."
+    },
+    "trackSorries": {
+      "type": "boolean",
+      "default": true,
+      "description": "Whether to track and report sorry placeholders."
+    }
+  }
+}

--- a/schemas/skills/proof-verification/output.schema.json
+++ b/schemas/skills/proof-verification/output.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/proof-verification/output.schema.json",
+  "title": "Proof Verification Output",
+  "description": "Output schema for the proof-verification skill.",
+  "type": "object",
+  "required": ["verified", "sorryCount"],
+  "properties": {
+    "verified": { "type": "boolean" },
+    "sorryCount": { "type": "integer", "minimum": 0 },
+    "sorries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["file", "line", "obligation"],
+        "properties": {
+          "file": { "type": "string" },
+          "line": { "type": "integer" },
+          "obligation": { "type": "string" },
+          "reference": { "type": "string" }
+        }
+      }
+    },
+    "errors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "file": { "type": "string" },
+          "line": { "type": "integer" },
+          "message": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/schemas/skills/quality-control/input.schema.json
+++ b/schemas/skills/quality-control/input.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/quality-control/input.schema.json",
+  "title": "Quality Control Input",
+  "description": "Input schema for quality control checks across content lifecycle.",
+  "type": "object",
+  "required": ["checkType", "targetPath"],
+  "properties": {
+    "checkType": {
+      "type": "string",
+      "enum": ["qa-report", "publication-checklist", "conformance-validation", "functionality-test", "cross-component-consistency"],
+      "description": "Type of QC check to perform."
+    },
+    "targetPath": {
+      "type": "string",
+      "description": "Path to content being checked."
+    },
+    "checklistSections": {
+      "type": "array",
+      "items": { "type": "string", "enum": ["L1", "L2", "L3", "L4", "global"] },
+      "description": "Publication checklist sections to review."
+    }
+  }
+}

--- a/schemas/skills/quality-control/output.schema.json
+++ b/schemas/skills/quality-control/output.schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/quality-control/output.schema.json",
+  "title": "Quality Control Output",
+  "description": "Output schema for quality control results.",
+  "type": "object",
+  "required": ["overallResult"],
+  "properties": {
+    "overallResult": {
+      "type": "string",
+      "enum": ["pass", "pass-with-warnings", "fail"]
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["severity", "category", "message"],
+        "properties": {
+          "severity": { "type": "string", "enum": ["error", "warning", "info"] },
+          "category": { "type": "string" },
+          "message": { "type": "string" },
+          "location": { "type": "string" },
+          "remediation": { "type": "string" }
+        }
+      }
+    },
+    "checklistResults": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string",
+        "enum": ["pass", "fail", "not-applicable"]
+      }
+    }
+  }
+}

--- a/schemas/skills/terminology-management/input.schema.json
+++ b/schemas/skills/terminology-management/input.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/terminology-management/input.schema.json",
+  "title": "Terminology Management Input",
+  "description": "Input schema for terminology management — CodeSystems, ValueSets, ConceptMaps.",
+  "type": "object",
+  "required": ["operation"],
+  "properties": {
+    "operation": {
+      "type": "string",
+      "enum": ["create-codesystem", "create-valueset", "create-conceptmap", "validate-bindings", "map-to-standard"],
+      "description": "Terminology operation to perform."
+    },
+    "targetStandard": {
+      "type": "string",
+      "enum": ["ICD-11", "SNOMED-CT", "LOINC", "IPS", "WHO-FIC", "WHO-ATC"],
+      "description": "Target standard terminology for mapping."
+    },
+    "inputFile": {
+      "type": "string",
+      "description": "Path to input terminology resource (FSH, JSON, CSV)."
+    }
+  }
+}

--- a/schemas/skills/terminology-management/output.schema.json
+++ b/schemas/skills/terminology-management/output.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/litlfred/folio-assistant/schemas/skills/terminology-management/output.schema.json",
+  "title": "Terminology Management Output",
+  "description": "Output schema for terminology management operations.",
+  "type": "object",
+  "required": ["resources"],
+  "properties": {
+    "resources": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["path", "resourceType"],
+        "properties": {
+          "path": { "type": "string" },
+          "resourceType": { "type": "string", "enum": ["CodeSystem", "ValueSet", "ConceptMap"] },
+          "url": { "type": "string" },
+          "conceptCount": { "type": "integer" }
+        }
+      }
+    },
+    "unmappedConcepts": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Concepts that could not be mapped to the target standard."
+    }
+  }
+}

--- a/schemas/types.ts
+++ b/schemas/types.ts
@@ -1,0 +1,364 @@
+/**
+ * @module @folio-assistant/schemas
+ * @description Core TypeScript schema definitions for the agent skills framework.
+ *
+ * Aligned with FHIR R5 resource model (ActorDefinition, Requirements, CapabilityStatement).
+ * TypeScript is the authoritative schema; JSON Schema is a generated artifact.
+ *
+ * @see {@link https://hl7.org/fhir/R5/actordefinition.html} FHIR R5 ActorDefinition
+ * @see {@link https://hl7.org/fhir/R5/requirements.html} FHIR R5 Requirements
+ */
+
+// ─── Enumerations ────────────────────────────────────────────────────────────
+
+/** Actor classification: human user or automated system. */
+export type ActorType = "person" | "system";
+
+/** FHIR R5 conformance verbs for requirement statements. */
+export type Conformance = "SHALL" | "SHOULD" | "MAY" | "SHALL NOT";
+
+/** Behavior when a required capability is absent at runtime. */
+export type DegradationStrategy = "fail" | "warn" | "skip" | "fallback";
+
+/** Script execution runtimes. */
+export type ScriptRuntime = "bash" | "python" | "typescript" | "bun";
+
+/** Lifecycle phase in which a script runs. */
+export type ScriptPhase = "pre" | "execute" | "validate" | "post";
+
+/** Scope of a validator's operation. */
+export type ValidatorScope = "file" | "block" | "chapter" | "project";
+
+/** Hook events that trigger session lifecycle actions. */
+export type HookEvent =
+  | "SessionStart"
+  | "PostToolUse"
+  | "PreCommit"
+  | "PostCommit"
+  | "UserPromptSubmit";
+
+/** Identity source for role assignment. */
+export type IdentitySource =
+  | "git-config"
+  | "github-oauth"
+  | "google-oauth"
+  | "env-var"
+  | "bearer-token"
+  | "default";
+
+/** What satisfies a requirement statement. */
+export type SatisfiedByKind = "skill" | "capability" | "requirement-statement";
+
+/** Dependency target kind. */
+export type DependencyKind = "skill" | "requirement";
+
+// ─── Content Lifecycle ───────────────────────────────────────────────────────
+
+/** Stages in the content development lifecycle. */
+export type LifecycleStage =
+  | "plan"
+  | "author"
+  | "validate"
+  | "review"
+  | "test"
+  | "publish"
+  | "feedback"
+  | "retire";
+
+// ─── Capability Detection ────────────────────────────────────────────────────
+
+/** How to probe whether a capability is available in the environment. */
+export type CapabilityDetection =
+  | { method: "command"; command: string; expectExitCode?: number }
+  | { method: "env-var"; variable: string }
+  | { method: "file-exists"; path: string }
+  | { method: "mcp-probe"; endpoint: string; healthPath?: string }
+  | { method: "always" };
+
+// ─── ActorDefinition ─────────────────────────────────────────────────────────
+
+/**
+ * A human role or system service.
+ * Maps to FHIR R5 `ActorDefinition`.
+ *
+ * @example
+ * ```typescript
+ * const businessAnalyst: ActorDefinition = {
+ *   id: "business-analyst",
+ *   name: "Business Analyst",
+ *   type: "person",
+ *   description: "L2 DAK component author who translates clinical guidelines into structured digital artifacts",
+ *   inherits: ["viewer"],
+ *   capabilities: ["git-push", "bpmn-authoring", "dmn-authoring"],
+ * };
+ * ```
+ */
+export interface ActorDefinition {
+  id: string;
+  name: string;
+  type: ActorType;
+  description: string;
+  /** Actor IDs this role inherits from (DAG). */
+  inherits: string[];
+  /** Capability IDs this actor possesses. */
+  capabilities: string[];
+  /** Domain-specific metadata. */
+  meta?: Record<string, unknown>;
+}
+
+// ─── CapabilityDefinition ────────────────────────────────────────────────────
+
+/**
+ * A concrete capability that tools, services, or environments provide.
+ * Skills declare which capabilities they require; actors declare which they possess.
+ */
+export interface CapabilityDefinition {
+  id: string;
+  name: string;
+  description: string;
+  detection: CapabilityDetection;
+  /** Other capability IDs this depends on. */
+  requires?: string[];
+}
+
+// ─── SkillDefinition ─────────────────────────────────────────────────────────
+
+/**
+ * The core type. A skill has typed metadata (who can invoke it, what it needs,
+ * what it validates) and a companion markdown file with instructions the agent reads.
+ */
+export interface SkillDefinition {
+  id: string;
+  name: string;
+  description: string;
+  /** Actor IDs that may invoke this skill (inheritance applies). */
+  roles: string[];
+  /** Capabilities required from the environment. */
+  requiredCapabilities: SkillCapabilityRef[];
+  /** Dependencies on other skills or requirements. */
+  dependsOn?: SkillDependency[];
+  /** Agent tools this skill may use. */
+  allowedTools?: string[];
+  /** Scripts this skill invokes. */
+  scripts?: SkillScript[];
+  /** MCP service IDs this skill uses. */
+  mcpServices?: string[];
+  /** Validators to run when this skill makes changes. */
+  validators?: SkillValidator[];
+  /** Request patterns for auto-routing. */
+  routingPatterns?: string[];
+  /** Tags for grouping/filtering. */
+  tags?: string[];
+  /** Source package (undefined = local). */
+  package?: string;
+  /** Content lifecycle stage(s) this skill operates in. */
+  lifecycleStages?: LifecycleStage[];
+  /** JSON Schema ID associated with this skill's input/output (if any). */
+  schemaRef?: string;
+}
+
+export interface SkillCapabilityRef {
+  capabilityId: string;
+  degradation: DegradationStrategy;
+  fallbackCapabilityId?: string;
+}
+
+export interface SkillDependency {
+  ref: string;
+  kind: DependencyKind;
+  conformance: Conformance;
+}
+
+export interface SkillScript {
+  /** Path relative to repo root. */
+  path: string;
+  runtime: ScriptRuntime;
+  phase: ScriptPhase;
+  args?: string[];
+}
+
+export interface SkillValidator {
+  id: string;
+  path: string;
+  runtime: ScriptRuntime;
+  scope: ValidatorScope;
+}
+
+// ─── Requirement ─────────────────────────────────────────────────────────────
+
+/**
+ * Models workflow rules agents must follow.
+ * Maps to FHIR R5 `Requirements` resource.
+ */
+export interface Requirement {
+  id: string;
+  title: string;
+  description: string;
+  /** Parent requirement IDs (hierarchy). */
+  derivedFrom?: string[];
+  /** Actor IDs involved. */
+  actors: string[];
+  statements: RequirementStatement[];
+  tags?: string[];
+}
+
+export interface RequirementStatement {
+  key: string;
+  label: string;
+  conformance: Conformance;
+  requirement: string;
+  actors?: string[];
+  /** What satisfies this statement (traceable). */
+  satisfiedBy?: SatisfiedByRef[];
+  /** Other statement keys this depends on (ordering). */
+  dependsOn?: string[];
+}
+
+export interface SatisfiedByRef {
+  kind: SatisfiedByKind;
+  ref: string;
+}
+
+// ─── SkillRegistry ───────────────────────────────────────────────────────────
+
+/** Central manifest listing all skills, actors, capabilities, and requirements. */
+export interface SkillRegistry {
+  schemaVersion: "1.0";
+  repository: string;
+  actors: ActorDefinition[];
+  capabilities: CapabilityDefinition[];
+  skills: SkillDefinition[];
+  requirements: Requirement[];
+  packages: SkillPackageRef[];
+  hooks: SessionHook[];
+}
+
+export interface SkillPackageRef {
+  name: string;
+  repo: string;
+  path: string;
+  ref: string;
+  skills: string[];
+}
+
+export interface SessionHook {
+  event: HookEvent;
+  matcher?: string;
+  commands: HookCommand[];
+}
+
+export interface HookCommand {
+  type: "command";
+  command: string;
+  timeout?: number;
+}
+
+// ─── RoleAssignment ──────────────────────────────────────────────────────────
+
+/** Maps user identities to actor roles. Evaluated at session start. */
+export interface RoleAssignment {
+  userPattern: string;
+  identitySource: IdentitySource;
+  actorId: string;
+  /** Higher priority wins when multiple patterns match. */
+  priority: number;
+}
+
+// ─── Docker Requirements ─────────────────────────────────────────────────────
+
+/**
+ * Docker packaging requirements for a skill package.
+ * Uses OCI image spec labels convention.
+ *
+ * @see {@link https://github.com/opencontainers/image-spec/blob/main/annotations.md} OCI Annotations
+ */
+export interface DockerRequirements {
+  /** Base image (default: ubuntu:24.04). */
+  baseImage: string;
+  /** APT packages required. */
+  aptPackages: string[];
+  /** pip packages required. */
+  pipPackages?: string[];
+  /** npm packages required (global). */
+  npmPackages?: string[];
+  /** Additional setup commands. */
+  setupCommands?: string[];
+  /** Ports to expose. */
+  exposePorts?: number[];
+  /** Environment variables to set. */
+  env?: Record<string, string>;
+  /** OCI image labels. */
+  labels?: Record<string, string>;
+}
+
+// ─── Skill Package Manifest ──────────────────────────────────────────────────
+
+/**
+ * Manifest for a skill package — the standard way for each package
+ * to declare its Docker/system requirements.
+ *
+ * Every skill package directory MUST contain a `package-manifest.json`
+ * conforming to this interface.
+ */
+export interface SkillPackageManifest {
+  name: string;
+  version: string;
+  description: string;
+  /** Skills provided by this package. */
+  skills: string[];
+  /** Docker packaging requirements. */
+  docker: DockerRequirements;
+  /** Capabilities this package provides. */
+  providesCapabilities?: string[];
+  /** Capabilities this package requires from the host. */
+  requiresCapabilities?: string[];
+  /** Content lifecycle stages this package covers. */
+  lifecycleStages?: LifecycleStage[];
+  /** Schema files associated with this package. */
+  schemas?: string[];
+}
+
+// ─── Remote Package Reference ────────────────────────────────────────────────
+
+/** Sync strategy for remote packages. */
+export type RemoteSyncStrategy = "shallow-clone" | "sparse-checkout" | "subtree";
+
+/** Sync configuration for a remote package. */
+export interface RemoteSyncConfig {
+  strategy: RemoteSyncStrategy;
+  /** How often to check for updates. */
+  frequency: "daily" | "weekly" | "monthly" | "manual";
+  /** Whether agents can auto-update the local copy. */
+  autoUpdate: boolean;
+}
+
+/**
+ * Reference to an external skill package maintained in another repository.
+ * The agent can sync and update the local wrapper while the upstream
+ * package is maintained independently.
+ *
+ * Each remote package gets a light wrapper in `skills/remote-packages/`
+ * that provides `SkillPackageManifest`-compatible Docker requirements.
+ */
+export interface RemotePackageRef {
+  name: string;
+  description: string;
+  /** Git repository URL. */
+  repo: string;
+  /** Git ref to track (branch, tag, or commit). */
+  ref: string;
+  /** Path within the repo (default: "/"). */
+  path: string;
+  /** Upstream maintainer (org or user). */
+  maintainer: string;
+  /** Sync configuration. */
+  sync: RemoteSyncConfig;
+  /** Light wrapper providing SkillPackageManifest compliance. */
+  wrapper: {
+    description: string;
+    docker: DockerRequirements;
+    providesCapabilities?: string[];
+    skills: string[];
+    lifecycleStages?: LifecycleStage[];
+  };
+}

--- a/schemas/types.ts
+++ b/schemas/types.ts
@@ -1,6 +1,9 @@
 /**
  * @module @folio-assistant/schemas
- * @description Core TypeScript schema definitions for the agent skills framework.
+ * @description Core TypeScript type definitions for the agent skills framework.
+ *
+ * ALL types are inferred from Zod schemas in constraints.ts, which is the
+ * single source of truth. This eliminates drift between types and validation.
  *
  * Aligned with FHIR R5 resource model (ActorDefinition, Requirements, CapabilityStatement).
  * TypeScript is the authoritative schema; JSON Schema is a generated artifact.
@@ -9,73 +12,91 @@
  * @see {@link https://hl7.org/fhir/R5/requirements.html} FHIR R5 Requirements
  */
 
+import { z } from "zod";
+
+import {
+  ActorTypeSchema,
+  ConformanceSchema,
+  DegradationStrategySchema,
+  ScriptRuntimeSchema,
+  ScriptPhaseSchema,
+  ValidatorScopeSchema,
+  HookEventSchema,
+  IdentitySourceSchema,
+  SatisfiedByKindSchema,
+  DependencyKindSchema,
+  LifecycleStageSchema,
+  RemoteSyncStrategySchema,
+  CapabilityDetectionSchema,
+  ActorDefinitionSchema,
+  CapabilityDefinitionSchema,
+  SkillCapabilityRefSchema,
+  SkillDependencySchema,
+  SkillScriptSchema,
+  SkillValidatorSchema,
+  SkillDefinitionSchema,
+  SatisfiedByRefSchema,
+  RequirementStatementSchema,
+  RequirementSchema,
+  SkillPackageRefSchema,
+  HookCommandSchema,
+  SessionHookSchema,
+  SkillRegistrySchema,
+  RoleAssignmentSchema,
+  DockerRequirementsSchema,
+  SkillPackageManifestSchema,
+  RemoteSyncConfigSchema,
+  RemotePackageRefSchema,
+} from "./constraints.js";
+
 // ─── Enumerations ────────────────────────────────────────────────────────────
 
 /** Actor classification: human user or automated system. */
-export type ActorType = "person" | "system";
+export type ActorType = z.infer<typeof ActorTypeSchema>;
 
 /** FHIR R5 conformance verbs for requirement statements. */
-export type Conformance = "SHALL" | "SHOULD" | "MAY" | "SHALL NOT";
+export type Conformance = z.infer<typeof ConformanceSchema>;
 
 /** Behavior when a required capability is absent at runtime. */
-export type DegradationStrategy = "fail" | "warn" | "skip" | "fallback";
+export type DegradationStrategy = z.infer<typeof DegradationStrategySchema>;
 
 /** Script execution runtimes. */
-export type ScriptRuntime = "bash" | "python" | "typescript" | "bun";
+export type ScriptRuntime = z.infer<typeof ScriptRuntimeSchema>;
 
 /** Lifecycle phase in which a script runs. */
-export type ScriptPhase = "pre" | "execute" | "validate" | "post";
+export type ScriptPhase = z.infer<typeof ScriptPhaseSchema>;
 
 /** Scope of a validator's operation. */
-export type ValidatorScope = "file" | "block" | "chapter" | "project";
+export type ValidatorScope = z.infer<typeof ValidatorScopeSchema>;
 
 /** Hook events that trigger session lifecycle actions. */
-export type HookEvent =
-  | "SessionStart"
-  | "PostToolUse"
-  | "PreCommit"
-  | "PostCommit"
-  | "UserPromptSubmit";
+export type HookEvent = z.infer<typeof HookEventSchema>;
 
 /** Identity source for role assignment. */
-export type IdentitySource =
-  | "git-config"
-  | "github-oauth"
-  | "google-oauth"
-  | "env-var"
-  | "bearer-token"
-  | "default";
+export type IdentitySource = z.infer<typeof IdentitySourceSchema>;
 
 /** What satisfies a requirement statement. */
-export type SatisfiedByKind = "skill" | "capability" | "requirement-statement";
+export type SatisfiedByKind = z.infer<typeof SatisfiedByKindSchema>;
 
 /** Dependency target kind. */
-export type DependencyKind = "skill" | "requirement";
+export type DependencyKind = z.infer<typeof DependencyKindSchema>;
 
 // ─── Content Lifecycle ───────────────────────────────────────────────────────
 
 /** Stages in the content development lifecycle. */
-export type LifecycleStage =
-  | "plan"
-  | "author"
-  | "validate"
-  | "review"
-  | "test"
-  | "publish"
-  | "feedback"
-  | "retire";
+export type LifecycleStage = z.infer<typeof LifecycleStageSchema>;
+
+// ─── Remote Package ──────────────────────────────────────────────────────────
+
+/** Sync strategy for remote packages. */
+export type RemoteSyncStrategy = z.infer<typeof RemoteSyncStrategySchema>;
 
 // ─── Capability Detection ────────────────────────────────────────────────────
 
 /** How to probe whether a capability is available in the environment. */
-export type CapabilityDetection =
-  | { method: "command"; command: string; expectExitCode?: number }
-  | { method: "env-var"; variable: string }
-  | { method: "file-exists"; path: string }
-  | { method: "mcp-probe"; endpoint: string; healthPath?: string }
-  | { method: "always" };
+export type CapabilityDetection = z.infer<typeof CapabilityDetectionSchema>;
 
-// ─── ActorDefinition ─────────────────────────────────────────────────────────
+// ─── Core Types ──────────────────────────────────────────────────────────────
 
 /**
  * A human role or system service.
@@ -87,182 +108,50 @@ export type CapabilityDetection =
  *   id: "business-analyst",
  *   name: "Business Analyst",
  *   type: "person",
- *   description: "L2 DAK component author who translates clinical guidelines into structured digital artifacts",
+ *   description: "L2 DAK component author",
  *   inherits: ["viewer"],
- *   capabilities: ["git-push", "bpmn-authoring", "dmn-authoring"],
+ *   capabilities: ["git-push", "bpmn-authoring"],
  * };
  * ```
  */
-export interface ActorDefinition {
-  id: string;
-  name: string;
-  type: ActorType;
-  description: string;
-  /** Actor IDs this role inherits from (DAG). */
-  inherits: string[];
-  /** Capability IDs this actor possesses. */
-  capabilities: string[];
-  /** Domain-specific metadata. */
-  meta?: Record<string, unknown>;
-}
+export type ActorDefinition = z.infer<typeof ActorDefinitionSchema>;
 
-// ─── CapabilityDefinition ────────────────────────────────────────────────────
+/** A concrete capability that tools, services, or environments provide. */
+export type CapabilityDefinition = z.infer<typeof CapabilityDefinitionSchema>;
 
-/**
- * A concrete capability that tools, services, or environments provide.
- * Skills declare which capabilities they require; actors declare which they possess.
- */
-export interface CapabilityDefinition {
-  id: string;
-  name: string;
-  description: string;
-  detection: CapabilityDetection;
-  /** Other capability IDs this depends on. */
-  requires?: string[];
-}
-
-// ─── SkillDefinition ─────────────────────────────────────────────────────────
+export type SkillCapabilityRef = z.infer<typeof SkillCapabilityRefSchema>;
+export type SkillDependency = z.infer<typeof SkillDependencySchema>;
+export type SkillScript = z.infer<typeof SkillScriptSchema>;
+export type SkillValidator = z.infer<typeof SkillValidatorSchema>;
 
 /**
  * The core type. A skill has typed metadata (who can invoke it, what it needs,
  * what it validates) and a companion markdown file with instructions the agent reads.
  */
-export interface SkillDefinition {
-  id: string;
-  name: string;
-  description: string;
-  /** Actor IDs that may invoke this skill (inheritance applies). */
-  roles: string[];
-  /** Capabilities required from the environment. */
-  requiredCapabilities: SkillCapabilityRef[];
-  /** Dependencies on other skills or requirements. */
-  dependsOn?: SkillDependency[];
-  /** Agent tools this skill may use. */
-  allowedTools?: string[];
-  /** Scripts this skill invokes. */
-  scripts?: SkillScript[];
-  /** MCP service IDs this skill uses. */
-  mcpServices?: string[];
-  /** Validators to run when this skill makes changes. */
-  validators?: SkillValidator[];
-  /** Request patterns for auto-routing. */
-  routingPatterns?: string[];
-  /** Tags for grouping/filtering. */
-  tags?: string[];
-  /** Source package (undefined = local). */
-  package?: string;
-  /** Content lifecycle stage(s) this skill operates in. */
-  lifecycleStages?: LifecycleStage[];
-  /** JSON Schema ID associated with this skill's input/output (if any). */
-  schemaRef?: string;
-}
-
-export interface SkillCapabilityRef {
-  capabilityId: string;
-  degradation: DegradationStrategy;
-  fallbackCapabilityId?: string;
-}
-
-export interface SkillDependency {
-  ref: string;
-  kind: DependencyKind;
-  conformance: Conformance;
-}
-
-export interface SkillScript {
-  /** Path relative to repo root. */
-  path: string;
-  runtime: ScriptRuntime;
-  phase: ScriptPhase;
-  args?: string[];
-}
-
-export interface SkillValidator {
-  id: string;
-  path: string;
-  runtime: ScriptRuntime;
-  scope: ValidatorScope;
-}
+export type SkillDefinition = z.infer<typeof SkillDefinitionSchema>;
 
 // ─── Requirement ─────────────────────────────────────────────────────────────
+
+export type SatisfiedByRef = z.infer<typeof SatisfiedByRefSchema>;
+export type RequirementStatement = z.infer<typeof RequirementStatementSchema>;
 
 /**
  * Models workflow rules agents must follow.
  * Maps to FHIR R5 `Requirements` resource.
  */
-export interface Requirement {
-  id: string;
-  title: string;
-  description: string;
-  /** Parent requirement IDs (hierarchy). */
-  derivedFrom?: string[];
-  /** Actor IDs involved. */
-  actors: string[];
-  statements: RequirementStatement[];
-  tags?: string[];
-}
+export type Requirement = z.infer<typeof RequirementSchema>;
 
-export interface RequirementStatement {
-  key: string;
-  label: string;
-  conformance: Conformance;
-  requirement: string;
-  actors?: string[];
-  /** What satisfies this statement (traceable). */
-  satisfiedBy?: SatisfiedByRef[];
-  /** Other statement keys this depends on (ordering). */
-  dependsOn?: string[];
-}
+// ─── Registry ────────────────────────────────────────────────────────────────
 
-export interface SatisfiedByRef {
-  kind: SatisfiedByKind;
-  ref: string;
-}
-
-// ─── SkillRegistry ───────────────────────────────────────────────────────────
+export type SkillPackageRef = z.infer<typeof SkillPackageRefSchema>;
+export type HookCommand = z.infer<typeof HookCommandSchema>;
+export type SessionHook = z.infer<typeof SessionHookSchema>;
 
 /** Central manifest listing all skills, actors, capabilities, and requirements. */
-export interface SkillRegistry {
-  schemaVersion: "1.0";
-  repository: string;
-  actors: ActorDefinition[];
-  capabilities: CapabilityDefinition[];
-  skills: SkillDefinition[];
-  requirements: Requirement[];
-  packages: SkillPackageRef[];
-  hooks: SessionHook[];
-}
-
-export interface SkillPackageRef {
-  name: string;
-  repo: string;
-  path: string;
-  ref: string;
-  skills: string[];
-}
-
-export interface SessionHook {
-  event: HookEvent;
-  matcher?: string;
-  commands: HookCommand[];
-}
-
-export interface HookCommand {
-  type: "command";
-  command: string;
-  timeout?: number;
-}
-
-// ─── RoleAssignment ──────────────────────────────────────────────────────────
+export type SkillRegistry = z.infer<typeof SkillRegistrySchema>;
 
 /** Maps user identities to actor roles. Evaluated at session start. */
-export interface RoleAssignment {
-  userPattern: string;
-  identitySource: IdentitySource;
-  actorId: string;
-  /** Higher priority wins when multiple patterns match. */
-  priority: number;
-}
+export type RoleAssignment = z.infer<typeof RoleAssignmentSchema>;
 
 // ─── Docker Requirements ─────────────────────────────────────────────────────
 
@@ -270,95 +159,27 @@ export interface RoleAssignment {
  * Docker packaging requirements for a skill package.
  * Uses OCI image spec labels convention.
  *
- * @see {@link https://github.com/opencontainers/image-spec/blob/main/annotations.md} OCI Annotations
+ * @see {@link https://github.com/opencontainers/image-spec/blob/main/annotations.md}
  */
-export interface DockerRequirements {
-  /** Base image (default: ubuntu:24.04). */
-  baseImage: string;
-  /** APT packages required. */
-  aptPackages: string[];
-  /** pip packages required. */
-  pipPackages?: string[];
-  /** npm packages required (global). */
-  npmPackages?: string[];
-  /** Additional setup commands. */
-  setupCommands?: string[];
-  /** Ports to expose. */
-  exposePorts?: number[];
-  /** Environment variables to set. */
-  env?: Record<string, string>;
-  /** OCI image labels. */
-  labels?: Record<string, string>;
-}
-
-// ─── Skill Package Manifest ──────────────────────────────────────────────────
+export type DockerRequirements = z.infer<typeof DockerRequirementsSchema>;
 
 /**
  * Manifest for a skill package — the standard way for each package
  * to declare its Docker/system requirements.
  *
  * Every skill package directory MUST contain a `package-manifest.json`
- * conforming to this interface.
+ * conforming to this type.
  */
-export interface SkillPackageManifest {
-  name: string;
-  version: string;
-  description: string;
-  /** Skills provided by this package. */
-  skills: string[];
-  /** Docker packaging requirements. */
-  docker: DockerRequirements;
-  /** Capabilities this package provides. */
-  providesCapabilities?: string[];
-  /** Capabilities this package requires from the host. */
-  requiresCapabilities?: string[];
-  /** Content lifecycle stages this package covers. */
-  lifecycleStages?: LifecycleStage[];
-  /** Schema files associated with this package. */
-  schemas?: string[];
-}
+export type SkillPackageManifest = z.infer<typeof SkillPackageManifestSchema>;
 
 // ─── Remote Package Reference ────────────────────────────────────────────────
 
-/** Sync strategy for remote packages. */
-export type RemoteSyncStrategy = "shallow-clone" | "sparse-checkout" | "subtree";
-
 /** Sync configuration for a remote package. */
-export interface RemoteSyncConfig {
-  strategy: RemoteSyncStrategy;
-  /** How often to check for updates. */
-  frequency: "daily" | "weekly" | "monthly" | "manual";
-  /** Whether agents can auto-update the local copy. */
-  autoUpdate: boolean;
-}
+export type RemoteSyncConfig = z.infer<typeof RemoteSyncConfigSchema>;
 
 /**
  * Reference to an external skill package maintained in another repository.
- * The agent can sync and update the local wrapper while the upstream
- * package is maintained independently.
- *
  * Each remote package gets a light wrapper in `skills/remote-packages/`
  * that provides `SkillPackageManifest`-compatible Docker requirements.
  */
-export interface RemotePackageRef {
-  name: string;
-  description: string;
-  /** Git repository URL. */
-  repo: string;
-  /** Git ref to track (branch, tag, or commit). */
-  ref: string;
-  /** Path within the repo (default: "/"). */
-  path: string;
-  /** Upstream maintainer (org or user). */
-  maintainer: string;
-  /** Sync configuration. */
-  sync: RemoteSyncConfig;
-  /** Light wrapper providing SkillPackageManifest compliance. */
-  wrapper: {
-    description: string;
-    docker: DockerRequirements;
-    providesCapabilities?: string[];
-    skills: string[];
-    lifecycleStages?: LifecycleStage[];
-  };
-}
+export type RemotePackageRef = z.infer<typeof RemotePackageRefSchema>;

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -91,6 +91,33 @@ function timestamp(): string {
   return new Date().toISOString().replace(/T.*/, "");
 }
 
+/**
+ * Compute the transitive closure of an actor's identity: the actor itself
+ * plus all actors that inherit from it (directly or transitively).
+ * This lets us check "can this actor invoke a skill?" by testing whether
+ * any of the skill's allowed roles are in this set.
+ */
+function getTransitiveRoles(actorId: string): Set<string> {
+  const result = new Set<string>([actorId]);
+  const queue = [actorId];
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    // Find actors whose `inherits` includes `current` — those are children
+    // that also satisfy the role check. But we actually want ancestors:
+    // if this actor inherits from X, then this actor can do anything X can.
+    const actor = actors.find(a => a.data.id === current);
+    if (actor?.data.inherits) {
+      for (const parentId of actor.data.inherits) {
+        if (!result.has(parentId)) {
+          result.add(parentId);
+          queue.push(parentId);
+        }
+      }
+    }
+  }
+  return result;
+}
+
 // ─── Load all data ───────────────────────────────────────────────────────────
 
 const actors = loadJsonDir(join(rootDir, ".claude", "skills", "actors"));
@@ -376,8 +403,11 @@ function generateActorsMd(): string {
       }
     }
 
-    // Which skills can this actor invoke?
-    const accessibleSkills = skills.filter(s => s.data.roles?.some((r: string) => r === d.id || actors.find(a2 => a2.data.id === r)?.data.inherits?.includes(d.id)));
+    // Which skills can this actor invoke? (full transitive inheritance)
+    const effectiveRoles = getTransitiveRoles(d.id);
+    const accessibleSkills = skills.filter(s =>
+      s.data.roles?.some((r: string) => effectiveRoles.has(r))
+    );
     if (accessibleSkills.length) {
       L.push(`**Accessible Skills:** ${accessibleSkills.map(s => `\`${s.data.id}\``).join(", ")}  `);
     }

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -1,0 +1,759 @@
+#!/usr/bin/env ts-node
+/**
+ * @module generate-docs
+ * @description Auto-generates COMPREHENSIVE schema documentation from all sources:
+ *
+ *   1. Core framework schemas (Zod → JSON Schema → Markdown)
+ *   2. Per-skill input/output schemas (schemas/skills/*)
+ *   3. SkillDefinition instances (.claude/skills/local/*.json) with schemaRef links
+ *   4. ActorDefinition instances (.claude/skills/actors/*.json)
+ *   5. CapabilityDefinition instances (.claude/skills/capabilities/*.json)
+ *   6. Requirement instances (.claude/skills/requirements/*.json)
+ *   7. Skill package manifests (skills/*/package-manifest.json) with Docker deps
+ *
+ * Produces:
+ *   - schemas/generated/SCHEMAS.md       — complete schema reference
+ *   - schemas/generated/SKILLS.md        — all skills with their schemas
+ *   - schemas/generated/ACTORS.md        — actor hierarchy and capabilities
+ *   - schemas/generated/CAPABILITIES.md  — capability catalog with detection
+ *   - schemas/generated/REQUIREMENTS.md  — requirements and conformance
+ *   - schemas/generated/PACKAGES.md      — skill packages and Docker deps
+ *   - schemas/generated/LIFECYCLE.md     — content lifecycle overview
+ *   - schemas/generated/index.json       — machine-readable catalog
+ *
+ * Usage: npx ts-node scripts/generate-docs.ts
+ */
+
+import { zodToJsonSchema } from "zod-to-json-schema";
+import { writeFileSync, mkdirSync, readdirSync, readFileSync, existsSync } from "fs";
+import { join, dirname, relative } from "path";
+import { fileURLToPath } from "url";
+
+import {
+  ActorDefinitionSchema,
+  CapabilityDefinitionSchema,
+  SkillDefinitionSchema,
+  RequirementSchema,
+  SkillRegistrySchema,
+  RoleAssignmentSchema,
+  DockerRequirementsSchema,
+  SkillPackageManifestSchema,
+  RemotePackageRefSchema,
+} from "../schemas/constraints.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(__dirname, "..");
+const outDir = join(rootDir, "schemas", "generated");
+
+mkdirSync(outDir, { recursive: true });
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function loadJsonDir(dir: string): { name: string; data: any }[] {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter(f => f.endsWith(".json"))
+    .map(f => {
+      try {
+        return { name: f.replace(".json", ""), data: JSON.parse(readFileSync(join(dir, f), "utf-8")) };
+      } catch { return null; }
+    })
+    .filter(Boolean) as any[];
+}
+
+function formatType(def: any): string {
+  if (!def) return "`any`";
+  if (def.type === "array") return `${formatType(def.items || {})}[]`;
+  if (def.type) return `\`${def.type}\``;
+  if (def.enum) return def.enum.map((e: string) => `\`"${e}"\``).join(" | ");
+  if (def.anyOf) return def.anyOf.map((a: any) => formatType(a)).join(" | ");
+  if (def.oneOf) return def.oneOf.map((a: any) => formatType(a)).join(" | ");
+  if (def.const) return `\`"${def.const}"\``;
+  if (def.$ref) return `\`${def.$ref.split("/").pop()}\``;
+  return "`object`";
+}
+
+function jsonSchemaPropsTable(schema: any): string[] {
+  const lines: string[] = [];
+  const props = schema?.properties || {};
+  if (Object.keys(props).length === 0) return lines;
+  const req = schema?.required || [];
+  lines.push("| Property | Type | Required | Description |");
+  lines.push("|----------|------|----------|-------------|");
+  for (const [k, v] of Object.entries(props)) {
+    const d = v as any;
+    lines.push(`| \`${k}\` | ${formatType(d)} | ${req.includes(k) ? "Yes" : "No"} | ${d.description || ""} |`);
+  }
+  return lines;
+}
+
+function timestamp(): string {
+  return new Date().toISOString().replace(/T.*/, "");
+}
+
+// ─── Load all data ───────────────────────────────────────────────────────────
+
+const actors = loadJsonDir(join(rootDir, ".claude", "skills", "actors"));
+const capabilities = loadJsonDir(join(rootDir, ".claude", "skills", "capabilities"));
+const requirements = loadJsonDir(join(rootDir, ".claude", "skills", "requirements"));
+const skills = loadJsonDir(join(rootDir, ".claude", "skills", "local"));
+const remotePackages = loadJsonDir(join(rootDir, "skills", "remote-packages"));
+const skillSchemaDirs = existsSync(join(rootDir, "schemas", "skills"))
+  ? readdirSync(join(rootDir, "schemas", "skills"), { withFileTypes: true }).filter(d => d.isDirectory()).map(d => d.name)
+  : [];
+const packages = loadJsonDir(join(rootDir, "skills")).length > 0
+  ? readdirSync(join(rootDir, "skills"), { withFileTypes: true })
+      .filter(d => d.isDirectory())
+      .map(d => {
+        const mp = join(rootDir, "skills", d.name, "package-manifest.json");
+        try { return { name: d.name, data: JSON.parse(readFileSync(mp, "utf-8")) }; }
+        catch { return null; }
+      })
+      .filter(Boolean) as any[]
+  : [];
+
+// ─── 1. SCHEMAS.md — Core framework schemas ─────────────────────────────────
+
+function generateSchemasMd(): string {
+  const L: string[] = [];
+  L.push("# Schema Reference");
+  L.push("");
+  L.push(`> **Auto-generated** on ${timestamp()} — Do not edit manually. Run \`npm run generate:docs\` to regenerate.`);
+  L.push("");
+
+  const coreEntries = [
+    { name: "ActorDefinition", schema: ActorDefinitionSchema, desc: "A human role or system service. Roles form a DAG via `inherits`.", fhir: "ActorDefinition", cat: "Core" },
+    { name: "CapabilityDefinition", schema: CapabilityDefinitionSchema, desc: "A concrete capability that tools/services/environments provide.", fhir: "CapabilityStatement", cat: "Core" },
+    { name: "SkillDefinition", schema: SkillDefinitionSchema, desc: "Core skill type with metadata, capabilities, dependencies, and schemaRef.", cat: "Core" },
+    { name: "Requirement", schema: RequirementSchema, desc: "Workflow rules agents must follow (FHIR R5 conformance verbs).", fhir: "Requirements", cat: "Core" },
+    { name: "SkillRegistry", schema: SkillRegistrySchema, desc: "Central manifest of all skills, actors, capabilities, and requirements.", cat: "Registry" },
+    { name: "RoleAssignment", schema: RoleAssignmentSchema, desc: "Maps user identities to actor roles at session start.", cat: "Registry" },
+    { name: "DockerRequirements", schema: DockerRequirementsSchema, desc: "Docker packaging requirements (OCI image spec labels).", cat: "Packaging" },
+    { name: "SkillPackageManifest", schema: SkillPackageManifestSchema, desc: "Skill package manifest declaring Docker/system requirements.", cat: "Packaging" },
+    { name: "RemotePackageRef", schema: RemotePackageRefSchema, desc: "Reference to an external skill package maintained in another repository, with sync config and Docker wrapper.", cat: "Packaging" },
+  ];
+
+  // TOC
+  L.push("## Table of Contents");
+  L.push("");
+  L.push("### Core Framework Schemas");
+  for (const e of coreEntries) {
+    L.push(`- [${e.name}](#${e.name.toLowerCase()})${e.fhir ? ` _(FHIR R5: ${e.fhir})_` : ""}`);
+  }
+  L.push("");
+  L.push("### Skill-Specific Schemas");
+  for (const sd of skillSchemaDirs) {
+    L.push(`- [${sd}](#skill-schema-${sd})`);
+  }
+  L.push("");
+  L.push("### Related Documentation");
+  L.push("- [Skills Catalog](./SKILLS.md)");
+  L.push("- [Actors & Roles](./ACTORS.md)");
+  L.push("- [Capabilities](./CAPABILITIES.md)");
+  L.push("- [Requirements](./REQUIREMENTS.md)");
+  L.push("- [Packages & Docker](./PACKAGES.md)");
+  L.push("- [Content Lifecycle](./LIFECYCLE.md)");
+  L.push("");
+  L.push("---");
+  L.push("");
+
+  // Core schemas
+  for (const e of coreEntries) {
+    const js = zodToJsonSchema(e.schema, { name: e.name, $refStrategy: "none" });
+    L.push(`## ${e.name}`);
+    L.push("");
+    L.push(e.desc);
+    L.push("");
+    if (e.fhir) L.push(`**FHIR R5 Analog:** \`${e.fhir}\`  `);
+    L.push(`**JSON Schema:** [\`${e.name}.schema.json\`](./${e.name}.schema.json)`);
+    L.push("");
+    L.push(...jsonSchemaPropsTable(js));
+    L.push("");
+    L.push("<details><summary>Full JSON Schema</summary>");
+    L.push("");
+    L.push("```json");
+    L.push(JSON.stringify(js, null, 2));
+    L.push("```");
+    L.push("</details>");
+    L.push("");
+    L.push("---");
+    L.push("");
+  }
+
+  // Skill-specific schemas
+  L.push("# Skill-Specific Schemas");
+  L.push("");
+  L.push("Each skill with an MCP server, Python module, Node.js script, or shell script implementation");
+  L.push("has input/output schemas under `schemas/skills/<skill-id>/`. Skills reference these via `schemaRef`.");
+  L.push("");
+
+  for (const sd of skillSchemaDirs) {
+    L.push(`## <a id="skill-schema-${sd}"></a>${sd}`);
+    L.push("");
+
+    // Find the matching skill definition
+    const skillDef = skills.find(s => s.data.id === sd || s.name === sd);
+    if (skillDef) {
+      L.push(`**Skill:** ${skillDef.data.name || sd}  `);
+      L.push(`**Package:** ${skillDef.data.package || "local"}  `);
+      L.push(`**Lifecycle:** ${(skillDef.data.lifecycleStages || []).join(", ")}  `);
+      if (skillDef.data.mcpServices?.length) L.push(`**MCP Services:** ${skillDef.data.mcpServices.join(", ")}  `);
+      if (skillDef.data.scripts?.length) L.push(`**Scripts:** ${skillDef.data.scripts.map((s: any) => `\`${s.path}\` (${s.runtime})`).join(", ")}  `);
+      L.push("");
+    }
+
+    const schemaDir = join(rootDir, "schemas", "skills", sd);
+    for (const schemaFile of ["input.schema.json", "output.schema.json"]) {
+      const fp = join(schemaDir, schemaFile);
+      if (!existsSync(fp)) continue;
+      try {
+        const schema = JSON.parse(readFileSync(fp, "utf-8"));
+        const label = schemaFile.replace(".schema.json", "").toUpperCase();
+        L.push(`### ${label}`);
+        L.push("");
+        L.push(`**Title:** ${schema.title || "—"}  `);
+        L.push(`**Description:** ${schema.description || "—"}`);
+        L.push("");
+        L.push(...jsonSchemaPropsTable(schema));
+        L.push("");
+        L.push(`<details><summary>${schemaFile}</summary>`);
+        L.push("");
+        L.push("```json");
+        L.push(JSON.stringify(schema, null, 2));
+        L.push("```");
+        L.push("</details>");
+        L.push("");
+      } catch {}
+    }
+    L.push("---");
+    L.push("");
+  }
+
+  return L.join("\n");
+}
+
+// ─── 2. SKILLS.md — All skills with schema associations ─────────────────────
+
+function generateSkillsMd(): string {
+  const L: string[] = [];
+  L.push("# Skills Catalog");
+  L.push("");
+  L.push(`> **Auto-generated** on ${timestamp()} — Do not edit manually.`);
+  L.push("");
+  L.push("Every skill with an MCP server, Python/Node/shell script, or external implementation");
+  L.push("is associated with input/output schemas via `schemaRef`.");
+  L.push("");
+
+  // Group by package
+  const byPackage: Record<string, typeof skills> = {};
+  for (const s of skills) {
+    const pkg = s.data.package || "local";
+    (byPackage[pkg] ??= []).push(s);
+  }
+
+  L.push("## Summary");
+  L.push("");
+  L.push(`| Skill | Package | Lifecycle | Schema | MCP | Scripts |`);
+  L.push(`|-------|---------|-----------|--------|-----|---------|`);
+  for (const s of skills) {
+    const d = s.data;
+    const hasSchema = d.schemaRef ? "Yes" : "—";
+    const hasMcp = d.mcpServices?.length ? d.mcpServices.join(", ") : "—";
+    const hasScripts = d.scripts?.length ? `${d.scripts.length} script(s)` : "—";
+    L.push(`| **${d.name || s.name}** | ${d.package || "local"} | ${(d.lifecycleStages || []).join(", ")} | ${hasSchema} | ${hasMcp} | ${hasScripts} |`);
+  }
+  L.push("");
+
+  // Detail per package
+  for (const [pkg, pkgSkills] of Object.entries(byPackage)) {
+    L.push(`## Package: ${pkg}`);
+    L.push("");
+    for (const s of pkgSkills) {
+      const d = s.data;
+      L.push(`### ${d.name || s.name}`);
+      L.push("");
+      L.push(`**ID:** \`${d.id}\`  `);
+      L.push(`**Description:** ${d.description}  `);
+      L.push(`**Roles:** ${(d.roles || []).map((r: string) => `\`${r}\``).join(", ")}  `);
+      L.push(`**Lifecycle:** ${(d.lifecycleStages || []).join(" → ")}  `);
+
+      if (d.schemaRef) {
+        L.push(`**Schema:** [\`${d.schemaRef}\`](../../${d.schemaRef}/)  `);
+        // Link to input/output schemas
+        const inputPath = join(rootDir, d.schemaRef, "input.schema.json");
+        const outputPath = join(rootDir, d.schemaRef, "output.schema.json");
+        if (existsSync(inputPath)) L.push(`  - [Input Schema](../../${d.schemaRef}/input.schema.json)  `);
+        if (existsSync(outputPath)) L.push(`  - [Output Schema](../../${d.schemaRef}/output.schema.json)  `);
+      }
+
+      if (d.mcpServices?.length) {
+        L.push(`**MCP Services:** ${d.mcpServices.join(", ")}  `);
+      }
+      if (d.scripts?.length) {
+        L.push(`**Scripts:**  `);
+        for (const sc of d.scripts) {
+          L.push(`  - \`${sc.path}\` (${sc.runtime}, phase: ${sc.phase})  `);
+        }
+      }
+
+      if (d.requiredCapabilities?.length) {
+        L.push(`**Required Capabilities:**  `);
+        for (const c of d.requiredCapabilities) {
+          L.push(`  - \`${c.capabilityId}\` (${c.degradation}${c.fallbackCapabilityId ? ` → ${c.fallbackCapabilityId}` : ""})  `);
+        }
+      }
+
+      if (d.dependsOn?.length) {
+        L.push(`**Dependencies:**  `);
+        for (const dep of d.dependsOn) {
+          L.push(`  - \`${dep.ref}\` (${dep.kind}, ${dep.conformance})  `);
+        }
+      }
+
+      if (d.routingPatterns?.length) {
+        L.push(`**Routing Patterns:** ${d.routingPatterns.map((p: string) => `\`${p}\``).join(", ")}  `);
+      }
+
+      L.push("");
+    }
+  }
+  return L.join("\n");
+}
+
+// ─── 3. ACTORS.md ────────────────────────────────────────────────────────────
+
+function generateActorsMd(): string {
+  const L: string[] = [];
+  L.push("# Actors & Roles");
+  L.push("");
+  L.push(`> **Auto-generated** on ${timestamp()} — Do not edit manually.`);
+  L.push("");
+
+  // Hierarchy
+  L.push("## Role Hierarchy");
+  L.push("");
+  L.push("```");
+  // Build hierarchy tree
+  const roots = actors.filter(a => !a.data.inherits?.length);
+  function printTree(id: string, indent: string): void {
+    const actor = actors.find(a => a.data.id === id);
+    if (!actor) return;
+    L.push(`${indent}${actor.data.id} (${actor.data.type}) — ${actor.data.name}`);
+    const children = actors.filter(a => a.data.inherits?.includes(id));
+    for (const c of children) {
+      printTree(c.data.id, indent + "  ");
+    }
+  }
+  for (const r of roots) printTree(r.data.id, "");
+  L.push("```");
+  L.push("");
+
+  // Detail table
+  L.push("## Actor Definitions");
+  L.push("");
+  L.push("| ID | Name | Type | Inherits | Capabilities |");
+  L.push("|----|------|------|----------|-------------|");
+  for (const a of actors) {
+    const d = a.data;
+    L.push(`| \`${d.id}\` | ${d.name} | ${d.type} | ${(d.inherits || []).map((i: string) => `\`${i}\``).join(", ") || "—"} | ${(d.capabilities || []).map((c: string) => `\`${c}\``).join(", ") || "—"} |`);
+  }
+  L.push("");
+
+  // Detail sections
+  for (const a of actors) {
+    const d = a.data;
+    L.push(`### ${d.name}`);
+    L.push("");
+    L.push(`**ID:** \`${d.id}\`  `);
+    L.push(`**Type:** ${d.type}  `);
+    L.push(`**Description:** ${d.description}  `);
+    if (d.inherits?.length) L.push(`**Inherits:** ${d.inherits.map((i: string) => `\`${i}\``).join(", ")}  `);
+    if (d.capabilities?.length) L.push(`**Capabilities:** ${d.capabilities.map((c: string) => `\`${c}\``).join(", ")}  `);
+    if (d.meta) {
+      L.push(`**Metadata:**  `);
+      for (const [k, v] of Object.entries(d.meta)) {
+        L.push(`  - ${k}: ${typeof v === "object" ? JSON.stringify(v) : v}  `);
+      }
+    }
+
+    // Which skills can this actor invoke?
+    const accessibleSkills = skills.filter(s => s.data.roles?.some((r: string) => r === d.id || actors.find(a2 => a2.data.id === r)?.data.inherits?.includes(d.id)));
+    if (accessibleSkills.length) {
+      L.push(`**Accessible Skills:** ${accessibleSkills.map(s => `\`${s.data.id}\``).join(", ")}  `);
+    }
+    L.push("");
+  }
+
+  return L.join("\n");
+}
+
+// ─── 4. CAPABILITIES.md ─────────────────────────────────────────────────────
+
+function generateCapabilitiesMd(): string {
+  const L: string[] = [];
+  L.push("# Capabilities");
+  L.push("");
+  L.push(`> **Auto-generated** on ${timestamp()} — Do not edit manually.`);
+  L.push("");
+  L.push("| ID | Name | Detection | Requires |");
+  L.push("|----|------|-----------|----------|");
+  for (const c of capabilities) {
+    const d = c.data;
+    const det = d.detection;
+    let detStr = det.method;
+    if (det.method === "command") detStr = `command: \`${det.command}\``;
+    else if (det.method === "env-var") detStr = `env: \`${det.variable}\``;
+    else if (det.method === "file-exists") detStr = `file: \`${det.path}\``;
+    else if (det.method === "mcp-probe") detStr = `mcp: \`${det.endpoint}\``;
+    L.push(`| \`${d.id}\` | ${d.name} | ${detStr} | ${(d.requires || []).map((r: string) => `\`${r}\``).join(", ") || "—"} |`);
+  }
+  L.push("");
+
+  for (const c of capabilities) {
+    const d = c.data;
+    L.push(`### ${d.name}`);
+    L.push("");
+    L.push(`**ID:** \`${d.id}\`  `);
+    L.push(`**Description:** ${d.description}  `);
+    L.push(`**Detection:** \`${JSON.stringify(d.detection)}\`  `);
+    if (d.requires?.length) L.push(`**Requires:** ${d.requires.map((r: string) => `\`${r}\``).join(", ")}  `);
+    // Which skills need this?
+    const neededBy = skills.filter(s => s.data.requiredCapabilities?.some((rc: any) => rc.capabilityId === d.id));
+    if (neededBy.length) L.push(`**Required by skills:** ${neededBy.map(s => `\`${s.data.id}\``).join(", ")}  `);
+    // Which actors provide this?
+    const providedBy = actors.filter(a => a.data.capabilities?.includes(d.id));
+    if (providedBy.length) L.push(`**Provided by actors:** ${providedBy.map(a => `\`${a.data.id}\``).join(", ")}  `);
+    L.push("");
+  }
+  return L.join("\n");
+}
+
+// ─── 5. REQUIREMENTS.md ─────────────────────────────────────────────────────
+
+function generateRequirementsMd(): string {
+  const L: string[] = [];
+  L.push("# Requirements");
+  L.push("");
+  L.push(`> **Auto-generated** on ${timestamp()} — Do not edit manually.`);
+  L.push("");
+
+  for (const r of requirements) {
+    const d = r.data;
+    L.push(`## ${d.title}`);
+    L.push("");
+    L.push(`**ID:** \`${d.id}\`  `);
+    L.push(`**Description:** ${d.description}  `);
+    if (d.derivedFrom?.length) L.push(`**Derived from:** ${d.derivedFrom.map((df: string) => `\`${df}\``).join(", ")}  `);
+    L.push(`**Actors:** ${(d.actors || []).map((a: string) => `\`${a}\``).join(", ")}  `);
+    if (d.tags?.length) L.push(`**Tags:** ${d.tags.join(", ")}  `);
+    L.push("");
+
+    L.push("| Key | Label | Conformance | Requirement | Satisfied By |");
+    L.push("|-----|-------|-------------|-------------|-------------|");
+    for (const s of d.statements || []) {
+      const satBy = (s.satisfiedBy || []).map((sb: any) => `\`${sb.kind}:${sb.ref}\``).join(", ") || "—";
+      L.push(`| \`${s.key}\` | ${s.label} | **${s.conformance}** | ${s.requirement} | ${satBy} |`);
+    }
+    L.push("");
+  }
+  return L.join("\n");
+}
+
+// ─── 6. PACKAGES.md — Docker deps ───────────────────────────────────────────
+
+function generatePackagesMd(): string {
+  const L: string[] = [];
+  L.push("# Skill Packages & Docker Dependencies");
+  L.push("");
+  L.push(`> **Auto-generated** on ${timestamp()} — Do not edit manually.`);
+  L.push("");
+  L.push("Each skill package declares its Docker/system requirements in `package-manifest.json`");
+  L.push("conforming to the [SkillPackageManifest](./SCHEMAS.md#skillpackagemanifest) schema.");
+  L.push("The Dockerfile merges all package requirements into a single Ubuntu 24.04 LTS image.");
+  L.push("");
+
+  // Summary table
+  L.push("## Package Summary");
+  L.push("");
+  L.push("| Package | Version | Skills | Base Image | APT | Pip | NPM |");
+  L.push("|---------|---------|--------|------------|-----|-----|-----|");
+  for (const p of packages) {
+    const d = p.data;
+    L.push(`| **${d.name}** | ${d.version} | ${d.skills?.length || 0} | ${d.docker?.baseImage || "ubuntu:24.04"} | ${d.docker?.aptPackages?.length || 0} | ${d.docker?.pipPackages?.length || 0} | ${d.docker?.npmPackages?.length || 0} |`);
+  }
+  L.push("");
+
+  // Detail per package
+  for (const p of packages) {
+    const d = p.data;
+    L.push(`## ${d.name}`);
+    L.push("");
+    L.push(`**Version:** ${d.version}  `);
+    L.push(`**Description:** ${d.description}  `);
+    L.push(`**Lifecycle Stages:** ${(d.lifecycleStages || []).join(", ")}  `);
+    L.push("");
+
+    L.push("### Skills");
+    L.push("");
+    for (const sk of d.skills || []) {
+      const skillDef = skills.find(s => s.data.id === sk);
+      if (skillDef) {
+        L.push(`- **${sk}** — ${skillDef.data.description} ${skillDef.data.schemaRef ? `([schema](../../${skillDef.data.schemaRef}/))` : ""}`);
+      } else {
+        L.push(`- **${sk}**`);
+      }
+    }
+    L.push("");
+
+    L.push("### Docker Requirements");
+    L.push("");
+    L.push(`**Base Image:** \`${d.docker?.baseImage || "ubuntu:24.04"}\``);
+    L.push("");
+
+    if (d.docker?.aptPackages?.length) {
+      L.push("**APT Packages:**");
+      L.push("```");
+      L.push(d.docker.aptPackages.join("\n"));
+      L.push("```");
+      L.push("");
+    }
+    if (d.docker?.pipPackages?.length) {
+      L.push("**Pip Packages:**");
+      L.push("```");
+      L.push(d.docker.pipPackages.join("\n"));
+      L.push("```");
+      L.push("");
+    }
+    if (d.docker?.npmPackages?.length) {
+      L.push("**NPM Packages:**");
+      L.push("```");
+      L.push(d.docker.npmPackages.join("\n"));
+      L.push("```");
+      L.push("");
+    }
+    if (d.docker?.setupCommands?.length) {
+      L.push("**Setup Commands:**");
+      L.push("```bash");
+      for (const cmd of d.docker.setupCommands) L.push(cmd);
+      L.push("```");
+      L.push("");
+    }
+    if (d.docker?.env && Object.keys(d.docker.env).length) {
+      L.push("**Environment Variables:**");
+      L.push("```");
+      for (const [k, v] of Object.entries(d.docker.env)) L.push(`${k}=${v}`);
+      L.push("```");
+      L.push("");
+    }
+    if (d.docker?.exposePorts?.length) {
+      L.push(`**Exposed Ports:** ${d.docker.exposePorts.join(", ")}`);
+      L.push("");
+    }
+    if (d.docker?.labels && Object.keys(d.docker.labels).length) {
+      L.push("**OCI Labels:**");
+      for (const [k, v] of Object.entries(d.docker.labels)) L.push(`- \`${k}\`: ${v}`);
+      L.push("");
+    }
+
+    if (d.providesCapabilities?.length) {
+      L.push(`**Provides Capabilities:** ${d.providesCapabilities.map((c: string) => `\`${c}\``).join(", ")}  `);
+    }
+    if (d.requiresCapabilities?.length) {
+      L.push(`**Requires Capabilities:** ${d.requiresCapabilities.map((c: string) => `\`${c}\``).join(", ")}  `);
+    }
+    if (d.schemas?.length) {
+      L.push(`**Associated Schemas:** ${d.schemas.join(", ")}  `);
+    }
+    L.push("");
+    L.push("---");
+    L.push("");
+  }
+
+  // Remote packages
+  if (remotePackages.length) {
+    L.push("# Remote Packages");
+    L.push("");
+    L.push("Remote packages are maintained in external repositories. A light wrapper in");
+    L.push("`skills/remote-packages/` provides `SkillPackageManifest`-compatible Docker requirements.");
+    L.push("Agents can sync and update these automatically based on the sync configuration.");
+    L.push("");
+    L.push("| Package | Maintainer | Repo | Strategy | Frequency | Skills |");
+    L.push("|---------|-----------|------|----------|-----------|--------|");
+    for (const rp of remotePackages) {
+      const d = rp.data;
+      L.push(`| **${d.name}** | ${d.maintainer} | \`${d.repo}\` | ${d.sync?.strategy} | ${d.sync?.frequency} | ${d.wrapper?.skills?.join(", ") || "—"} |`);
+    }
+    L.push("");
+
+    for (const rp of remotePackages) {
+      const d = rp.data;
+      L.push(`## ${d.name}`);
+      L.push("");
+      L.push(`**Description:** ${d.description}  `);
+      L.push(`**Repository:** \`${d.repo}\`  `);
+      L.push(`**Ref:** \`${d.ref}\`  `);
+      L.push(`**Maintainer:** ${d.maintainer}  `);
+      L.push(`**Sync Strategy:** ${d.sync?.strategy} (${d.sync?.frequency}, autoUpdate: ${d.sync?.autoUpdate})  `);
+      L.push("");
+      L.push("### Wrapper Docker Requirements");
+      L.push("");
+      const wd = d.wrapper?.docker;
+      if (wd) {
+        L.push(`**Base Image:** \`${wd.baseImage || "ubuntu:24.04"}\``);
+        if (wd.aptPackages?.length) { L.push(""); L.push("**APT:** " + wd.aptPackages.join(", ")); }
+        if (wd.pipPackages?.length) { L.push(""); L.push("**Pip:** " + wd.pipPackages.join(", ")); }
+        if (wd.npmPackages?.length) { L.push(""); L.push("**NPM:** " + wd.npmPackages.join(", ")); }
+      }
+      L.push("");
+      if (d.wrapper?.providesCapabilities?.length) {
+        L.push(`**Provides Capabilities:** ${d.wrapper.providesCapabilities.map((c: string) => `\`${c}\``).join(", ")}  `);
+      }
+      if (d.wrapper?.skills?.length) {
+        L.push(`**Skills:** ${d.wrapper.skills.join(", ")}  `);
+      }
+      if (d.wrapper?.lifecycleStages?.length) {
+        L.push(`**Lifecycle:** ${d.wrapper.lifecycleStages.join(", ")}  `);
+      }
+      L.push("");
+      L.push("---");
+      L.push("");
+    }
+  }
+
+  return L.join("\n");
+}
+
+// ─── 7. LIFECYCLE.md ─────────────────────────────────────────────────────────
+
+function generateLifecycleMd(): string {
+  const L: string[] = [];
+  L.push("# Content Development Lifecycle");
+  L.push("");
+  L.push(`> **Auto-generated** on ${timestamp()} — Do not edit manually.`);
+  L.push("");
+
+  const stages = ["plan", "author", "validate", "review", "test", "publish", "feedback", "retire"];
+
+  L.push("## Lifecycle Flow");
+  L.push("");
+  L.push("```");
+  L.push(stages.join(" → "));
+  L.push("```");
+  L.push("");
+
+  L.push("## Stage Details");
+  L.push("");
+
+  for (const stage of stages) {
+    const stageSkills = skills.filter(s => s.data.lifecycleStages?.includes(stage));
+    const stageActors = new Set<string>();
+    for (const s of stageSkills) for (const r of s.data.roles || []) stageActors.add(r);
+
+    L.push(`### ${stage.charAt(0).toUpperCase() + stage.slice(1)}`);
+    L.push("");
+    L.push(`**Skills:** ${stageSkills.map(s => `[\`${s.data.id}\`](#)`).join(", ") || "None"}  `);
+    L.push(`**Actors:** ${[...stageActors].map(a => `\`${a}\``).join(", ") || "None"}  `);
+    L.push("");
+
+    if (stageSkills.length) {
+      L.push("| Skill | Description | Schema |");
+      L.push("|-------|-------------|--------|");
+      for (const s of stageSkills) {
+        const schemaLink = s.data.schemaRef ? `[schema](../../${s.data.schemaRef}/)` : "—";
+        L.push(`| \`${s.data.id}\` | ${s.data.description} | ${schemaLink} |`);
+      }
+      L.push("");
+    }
+  }
+
+  // Requirements that govern the lifecycle
+  L.push("## Lifecycle Requirements");
+  L.push("");
+  const lifecycleReqs = requirements.filter(r => r.data.tags?.includes("lifecycle") || r.data.id?.includes("lifecycle"));
+  for (const r of lifecycleReqs) {
+    L.push(`### ${r.data.title}`);
+    L.push("");
+    L.push(`**ID:** \`${r.data.id}\`  `);
+    L.push(`**Description:** ${r.data.description}`);
+    L.push("");
+    for (const s of r.data.statements || []) {
+      L.push(`- **${s.conformance}** \`${s.key}\`: ${s.requirement}`);
+    }
+    L.push("");
+  }
+
+  return L.join("\n");
+}
+
+// ─── 8. Catalog JSON ─────────────────────────────────────────────────────────
+
+function generateCatalog(): object {
+  return {
+    generatedAt: new Date().toISOString(),
+    schemaVersion: "1.0",
+    coreSchemas: [
+      "ActorDefinition", "CapabilityDefinition", "SkillDefinition", "Requirement",
+      "SkillRegistry", "RoleAssignment", "DockerRequirements", "SkillPackageManifest", "RemotePackageRef",
+    ].map(name => ({
+      name,
+      jsonSchemaFile: `${name}.schema.json`,
+    })),
+    skillSchemas: skillSchemaDirs.map(sd => ({
+      skillId: sd,
+      inputSchema: `skills/${sd}/input.schema.json`,
+      outputSchema: `skills/${sd}/output.schema.json`,
+      linkedSkill: skills.find(s => s.data.id === sd)?.data.id || null,
+    })),
+    skills: skills.map(s => ({
+      id: s.data.id,
+      name: s.data.name,
+      package: s.data.package || "local",
+      schemaRef: s.data.schemaRef || null,
+      hasMcp: !!(s.data.mcpServices?.length),
+      hasScripts: !!(s.data.scripts?.length),
+      lifecycleStages: s.data.lifecycleStages || [],
+    })),
+    actors: actors.map(a => ({ id: a.data.id, name: a.data.name, type: a.data.type })),
+    capabilities: capabilities.map(c => ({ id: c.data.id, name: c.data.name })),
+    requirements: requirements.map(r => ({ id: r.data.id, title: r.data.title })),
+    packages: packages.map(p => ({ name: p.data.name, version: p.data.version, skills: p.data.skills })),
+    remotePackages: remotePackages.map(rp => ({
+      name: rp.data.name,
+      repo: rp.data.repo,
+      maintainer: rp.data.maintainer,
+      syncStrategy: rp.data.sync?.strategy,
+      skills: rp.data.wrapper?.skills || [],
+    })),
+  };
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+
+console.log("Generating comprehensive schema documentation...\n");
+
+const docs: [string, () => string][] = [
+  ["SCHEMAS.md", generateSchemasMd],
+  ["SKILLS.md", generateSkillsMd],
+  ["ACTORS.md", generateActorsMd],
+  ["CAPABILITIES.md", generateCapabilitiesMd],
+  ["REQUIREMENTS.md", generateRequirementsMd],
+  ["PACKAGES.md", generatePackagesMd],
+  ["LIFECYCLE.md", generateLifecycleMd],
+];
+
+for (const [file, gen] of docs) {
+  writeFileSync(join(outDir, file), gen());
+  console.log(`  ✓ schemas/generated/${file}`);
+}
+
+writeFileSync(join(outDir, "index.json"), JSON.stringify(generateCatalog(), null, 2) + "\n");
+console.log("  ✓ schemas/generated/index.json");
+
+console.log(`\nGenerated ${docs.length + 1} documentation files.`);
+console.log(`  Core schemas: 8`);
+console.log(`  Skill schemas: ${skillSchemaDirs.length} (input + output each)`);
+console.log(`  Skills: ${skills.length}`);
+console.log(`  Actors: ${actors.length}`);
+console.log(`  Capabilities: ${capabilities.length}`);
+console.log(`  Requirements: ${requirements.length}`);
+console.log(`  Packages: ${packages.length}`);

--- a/scripts/generate-registry.ts
+++ b/scripts/generate-registry.ts
@@ -1,0 +1,108 @@
+#!/usr/bin/env ts-node
+/**
+ * @module generate-registry
+ * @description Scans .claude/skills/ and skills/ directories to produce a unified SkillRegistry.
+ *
+ * Outputs:
+ *   - .claude/skills/registry.json
+ *
+ * Usage: npx ts-node scripts/generate-registry.ts
+ */
+
+import { readFileSync, writeFileSync, readdirSync, existsSync, mkdirSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(__dirname, "..");
+
+interface RegistryOutput {
+  schemaVersion: "1.0";
+  repository: string;
+  generatedAt: string;
+  actors: any[];
+  capabilities: any[];
+  skills: any[];
+  requirements: any[];
+  packages: any[];
+  hooks: any[];
+}
+
+function loadJsonFiles(dir: string): any[] {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter(f => f.endsWith(".json"))
+    .map(f => {
+      try {
+        return JSON.parse(readFileSync(join(dir, f), "utf-8"));
+      } catch {
+        console.warn(`  ⚠ Failed to parse ${join(dir, f)}`);
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+function loadPackageManifests(): any[] {
+  const skillsDir = join(rootDir, "skills");
+  if (!existsSync(skillsDir)) return [];
+  return readdirSync(skillsDir, { withFileTypes: true })
+    .filter(d => d.isDirectory())
+    .map(d => {
+      const manifestPath = join(skillsDir, d.name, "package-manifest.json");
+      if (!existsSync(manifestPath)) return null;
+      try {
+        return JSON.parse(readFileSync(manifestPath, "utf-8"));
+      } catch {
+        console.warn(`  ⚠ Failed to parse ${manifestPath}`);
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+
+console.log("Generating skill registry...\n");
+
+const pkg = JSON.parse(readFileSync(join(rootDir, "package.json"), "utf-8"));
+
+const registry: RegistryOutput = {
+  schemaVersion: "1.0",
+  repository: pkg.name || "folio-assistant",
+  generatedAt: new Date().toISOString(),
+  actors: loadJsonFiles(join(rootDir, ".claude", "skills", "actors")),
+  capabilities: loadJsonFiles(join(rootDir, ".claude", "skills", "capabilities")),
+  skills: loadJsonFiles(join(rootDir, ".claude", "skills", "local")),
+  requirements: loadJsonFiles(join(rootDir, ".claude", "skills", "requirements")),
+  packages: loadPackageManifests(),
+  hooks: [],
+};
+
+// Load hooks from settings if they exist
+const settingsPath = join(rootDir, ".claude", "settings.json");
+if (existsSync(settingsPath)) {
+  try {
+    const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+    if (settings.hooks) {
+      registry.hooks = Object.entries(settings.hooks).map(([event, config]: [string, any]) => ({
+        event,
+        commands: Array.isArray(config) ? config : [config],
+      }));
+    }
+  } catch {
+    console.warn("  ⚠ Failed to parse .claude/settings.json");
+  }
+}
+
+const outDir = join(rootDir, ".claude", "skills");
+mkdirSync(outDir, { recursive: true });
+writeFileSync(join(outDir, "registry.json"), JSON.stringify(registry, null, 2) + "\n");
+
+console.log(`  ✓ .claude/skills/registry.json`);
+console.log(`    Actors: ${registry.actors.length}`);
+console.log(`    Capabilities: ${registry.capabilities.length}`);
+console.log(`    Skills: ${registry.skills.length}`);
+console.log(`    Requirements: ${registry.requirements.length}`);
+console.log(`    Packages: ${registry.packages.length}`);
+console.log("\nDone.");

--- a/scripts/generate-schemas.ts
+++ b/scripts/generate-schemas.ts
@@ -1,0 +1,79 @@
+#!/usr/bin/env ts-node
+/**
+ * @module generate-schemas
+ * @description Generates JSON Schema files from Zod schemas.
+ *
+ * Reads all Zod schemas from schemas/constraints.ts and writes
+ * corresponding JSON Schema files to schemas/generated/.
+ *
+ * Usage: npx ts-node scripts/generate-schemas.ts
+ */
+
+import { zodToJsonSchema } from "zod-to-json-schema";
+import { writeFileSync, mkdirSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+import {
+  ActorDefinitionSchema,
+  CapabilityDefinitionSchema,
+  SkillDefinitionSchema,
+  RequirementSchema,
+  SkillRegistrySchema,
+  RoleAssignmentSchema,
+  DockerRequirementsSchema,
+  SkillPackageManifestSchema,
+  SkillCapabilityRefSchema,
+  SkillDependencySchema,
+  SkillScriptSchema,
+  SkillValidatorSchema,
+  RequirementStatementSchema,
+  SatisfiedByRefSchema,
+  SessionHookSchema,
+  HookCommandSchema,
+  SkillPackageRefSchema,
+  RemotePackageRefSchema,
+  RemoteSyncConfigSchema,
+} from "../schemas/constraints.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const outDir = join(__dirname, "..", "schemas", "generated");
+
+mkdirSync(outDir, { recursive: true });
+
+const schemas = {
+  "ActorDefinition": ActorDefinitionSchema,
+  "CapabilityDefinition": CapabilityDefinitionSchema,
+  "SkillDefinition": SkillDefinitionSchema,
+  "SkillCapabilityRef": SkillCapabilityRefSchema,
+  "SkillDependency": SkillDependencySchema,
+  "SkillScript": SkillScriptSchema,
+  "SkillValidator": SkillValidatorSchema,
+  "Requirement": RequirementSchema,
+  "RequirementStatement": RequirementStatementSchema,
+  "SatisfiedByRef": SatisfiedByRefSchema,
+  "SkillRegistry": SkillRegistrySchema,
+  "SkillPackageRef": SkillPackageRefSchema,
+  "SessionHook": SessionHookSchema,
+  "HookCommand": HookCommandSchema,
+  "RoleAssignment": RoleAssignmentSchema,
+  "DockerRequirements": DockerRequirementsSchema,
+  "SkillPackageManifest": SkillPackageManifestSchema,
+  "RemotePackageRef": RemotePackageRefSchema,
+  "RemoteSyncConfig": RemoteSyncConfigSchema,
+};
+
+console.log("Generating JSON Schemas...\n");
+
+for (const [name, schema] of Object.entries(schemas)) {
+  const jsonSchema = zodToJsonSchema(schema, {
+    name,
+    $refStrategy: "none",
+  });
+
+  const filePath = join(outDir, `${name}.schema.json`);
+  writeFileSync(filePath, JSON.stringify(jsonSchema, null, 2) + "\n");
+  console.log(`  ✓ ${name}.schema.json`);
+}
+
+console.log(`\nGenerated ${Object.keys(schemas).length} JSON Schema files in schemas/generated/`);

--- a/scripts/validate-skills.ts
+++ b/scripts/validate-skills.ts
@@ -1,0 +1,87 @@
+#!/usr/bin/env ts-node
+/**
+ * @module validate-skills
+ * @description Validates all skill package manifests against SkillPackageManifest schema
+ * and all .claude/skills/ JSON files against their respective schemas.
+ *
+ * Usage: npx ts-node scripts/validate-skills.ts
+ */
+
+import { readFileSync, readdirSync, existsSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+import {
+  SkillPackageManifestSchema,
+  ActorDefinitionSchema,
+  CapabilityDefinitionSchema,
+  RequirementSchema,
+  SkillDefinitionSchema,
+} from "../schemas/constraints.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(__dirname, "..");
+
+let errors = 0;
+let validated = 0;
+
+function validateDir(dir: string, schema: any, label: string): void {
+  if (!existsSync(dir)) return;
+  for (const file of readdirSync(dir).filter(f => f.endsWith(".json"))) {
+    const path = join(dir, file);
+    try {
+      const data = JSON.parse(readFileSync(path, "utf-8"));
+      schema.parse(data);
+      console.log(`  ✓ ${label}/${file}`);
+      validated++;
+    } catch (e: any) {
+      console.error(`  ✗ ${label}/${file}: ${e.message}`);
+      errors++;
+    }
+  }
+}
+
+console.log("Validating skill framework files...\n");
+
+// Validate actors
+validateDir(
+  join(rootDir, ".claude", "skills", "actors"),
+  ActorDefinitionSchema,
+  "actors",
+);
+
+// Validate capabilities
+validateDir(
+  join(rootDir, ".claude", "skills", "capabilities"),
+  CapabilityDefinitionSchema,
+  "capabilities",
+);
+
+// Validate requirements
+validateDir(
+  join(rootDir, ".claude", "skills", "requirements"),
+  RequirementSchema,
+  "requirements",
+);
+
+// Validate skill package manifests
+const skillsDir = join(rootDir, "skills");
+if (existsSync(skillsDir)) {
+  for (const pkg of readdirSync(skillsDir, { withFileTypes: true }).filter(d => d.isDirectory())) {
+    const manifestPath = join(skillsDir, pkg.name, "package-manifest.json");
+    if (existsSync(manifestPath)) {
+      try {
+        const data = JSON.parse(readFileSync(manifestPath, "utf-8"));
+        SkillPackageManifestSchema.parse(data);
+        console.log(`  ✓ skills/${pkg.name}/package-manifest.json`);
+        validated++;
+      } catch (e: any) {
+        console.error(`  ✗ skills/${pkg.name}/package-manifest.json: ${e.message}`);
+        errors++;
+      }
+    }
+  }
+}
+
+console.log(`\nValidated: ${validated}, Errors: ${errors}`);
+process.exit(errors > 0 ? 1 : 0);

--- a/skills/authoring-math/package-manifest.json
+++ b/skills/authoring-math/package-manifest.json
@@ -1,0 +1,82 @@
+{
+  "name": "authoring-math",
+  "version": "0.1.0",
+  "description": "Formal mathematics authoring skills for Lean 4 proofs, LaTeX documents, and category theory formalization",
+  "skills": [
+    "lean-formalization",
+    "latex-authoring",
+    "proof-verification",
+    "scientific-visualization",
+    "hypothesis-generation",
+    "scientific-critical-thinking"
+  ],
+  "docker": {
+    "baseImage": "ubuntu:24.04",
+    "aptPackages": [
+      "curl",
+      "git",
+      "git-lfs",
+      "build-essential",
+      "cmake",
+      "pkg-config",
+      "libgmp-dev",
+      "python3",
+      "python3-pip",
+      "python3-venv",
+      "nodejs",
+      "npm",
+      "texlive-full",
+      "latexmk",
+      "biber",
+      "pandoc",
+      "graphviz",
+      "ca-certificates",
+      "wget",
+      "unzip"
+    ],
+    "pipPackages": [
+      "matplotlib",
+      "numpy",
+      "sympy",
+      "jupyter"
+    ],
+    "npmPackages": [
+      "typescript",
+      "ts-node",
+      "bun"
+    ],
+    "setupCommands": [
+      "curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh | sh -s -- -y --default-toolchain leanprover/lean4:v4.16.0",
+      "echo 'export PATH=\"$HOME/.elan/bin:$PATH\"' >> /etc/profile.d/lean.sh"
+    ],
+    "env": {
+      "LEAN_HOME": "/root/.elan",
+      "PATH": "/root/.elan/bin:${PATH}"
+    },
+    "labels": {
+      "org.opencontainers.image.title": "folio-assistant-math",
+      "org.opencontainers.image.description": "Formal mathematics authoring environment with Lean 4 and LaTeX",
+      "org.opencontainers.image.source": "https://github.com/litlfred/folio-assistant"
+    }
+  },
+  "providesCapabilities": [
+    "lean-toolchain",
+    "latex-compiler",
+    "bun-runtime",
+    "python3",
+    "graphviz"
+  ],
+  "requiresCapabilities": [
+    "git-push"
+  ],
+  "lifecycleStages": [
+    "author",
+    "validate",
+    "review",
+    "test"
+  ],
+  "schemas": [
+    "schemas/generated/SkillDefinition.schema.json",
+    "schemas/generated/SkillPackageManifest.schema.json"
+  ]
+}

--- a/skills/authoring-who-smart-guidelines/package-manifest.json
+++ b/skills/authoring-who-smart-guidelines/package-manifest.json
@@ -1,0 +1,96 @@
+{
+  "name": "authoring-who-smart-guidelines",
+  "version": "0.1.0",
+  "description": "WHO SMART Guidelines authoring skills for FHIR Implementation Guides, BPMN workflows, and DAK lifecycle management",
+  "skills": [
+    "l2-dak-authoring",
+    "l3-fhir-authoring",
+    "bpmn-authoring",
+    "dmn-authoring",
+    "terminology-management",
+    "fhir-validation",
+    "ig-publication",
+    "quality-control",
+    "content-review"
+  ],
+  "docker": {
+    "baseImage": "ubuntu:24.04",
+    "aptPackages": [
+      "curl",
+      "git",
+      "git-lfs",
+      "build-essential",
+      "python3",
+      "python3-pip",
+      "python3-venv",
+      "nodejs",
+      "npm",
+      "openjdk-21-jre-headless",
+      "ruby-full",
+      "graphviz",
+      "plantuml",
+      "ca-certificates",
+      "wget",
+      "unzip",
+      "jq"
+    ],
+    "pipPackages": [
+      "fhir.resources",
+      "fhirpathpy",
+      "requests",
+      "pyyaml",
+      "jsonschema",
+      "lxml"
+    ],
+    "npmPackages": [
+      "fsh-sushi",
+      "typescript",
+      "ts-node"
+    ],
+    "setupCommands": [
+      "mkdir -p /opt/ig-publisher && curl -L -o /opt/ig-publisher/publisher.jar https://github.com/HL7/fhir-ig-publisher/releases/latest/download/publisher.jar",
+      "gem install jekyll bundler",
+      "echo 'export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64' >> /etc/profile.d/java.sh"
+    ],
+    "exposePorts": [
+      4000
+    ],
+    "env": {
+      "JAVA_HOME": "/usr/lib/jvm/java-21-openjdk-amd64",
+      "IG_PUBLISHER_JAR": "/opt/ig-publisher/publisher.jar",
+      "PATH": "/usr/local/bin:${PATH}"
+    },
+    "labels": {
+      "org.opencontainers.image.title": "folio-assistant-smart-guidelines",
+      "org.opencontainers.image.description": "WHO SMART Guidelines authoring environment with FHIR IG Publisher, SUSHI, and validation tools",
+      "org.opencontainers.image.source": "https://github.com/litlfred/folio-assistant"
+    }
+  },
+  "providesCapabilities": [
+    "ig-publisher",
+    "sushi-compiler",
+    "fhir-validator",
+    "java-runtime",
+    "python3",
+    "jekyll",
+    "plantuml",
+    "graphviz"
+  ],
+  "requiresCapabilities": [
+    "git-push",
+    "docker"
+  ],
+  "lifecycleStages": [
+    "plan",
+    "author",
+    "validate",
+    "review",
+    "test",
+    "publish"
+  ],
+  "schemas": [
+    "schemas/generated/SkillDefinition.schema.json",
+    "schemas/generated/SkillPackageManifest.schema.json",
+    "schemas/generated/Requirement.schema.json"
+  ]
+}

--- a/skills/content-lifecycle/content-author.md
+++ b/skills/content-lifecycle/content-author.md
@@ -1,0 +1,27 @@
+# Content Authoring
+
+Create and develop content artifacts according to the project plan.
+
+## Responsibilities
+- Translate source material into structured digital artifacts
+- Create business process diagrams (BPMN 2.0)
+- Author data dictionaries and core data elements
+- Develop decision-support logic
+- Create user scenarios and personas
+- Author functional and non-functional requirements
+- Define indicators and measures
+
+## Actors
+- Business Analyst (L2 authoring lead)
+- FHIR Modeller (L3 authoring lead)
+- Terminologist (terminology governance)
+- Clinical SME (clinical validation)
+
+## Inputs
+- Project plan
+- Source guidelines/recommendations
+- Existing content (if iterating)
+
+## Outputs
+- Authored content artifacts
+- Draft versions ready for validation

--- a/skills/content-lifecycle/content-feedback.md
+++ b/skills/content-lifecycle/content-feedback.md
@@ -1,0 +1,28 @@
+# Content Feedback Collection
+
+Gather and triage feedback on published content for future iterations.
+
+## Responsibilities
+- Collect feedback from implementers and users
+- Triage feedback by severity and scope
+- Map feedback to specific content components
+- Create issues/tickets for actionable feedback
+- Prioritize feedback for next iteration
+- Coordinate with clinical SMEs for clinical feedback
+- Track feedback resolution across versions
+
+## Actors
+- Technical Officer (triage lead)
+- Programme Manager (prioritization)
+- Clinical SME (clinical feedback assessment)
+- Business Analyst (implementer feedback)
+
+## Inputs
+- Published content (current version)
+- User/implementer feedback (issues, comments, surveys)
+- Country implementation reports
+
+## Outputs
+- Triaged feedback log
+- Prioritized backlog for next iteration
+- Change requests linked to feedback

--- a/skills/content-lifecycle/content-plan.md
+++ b/skills/content-lifecycle/content-plan.md
@@ -1,0 +1,26 @@
+# Content Planning
+
+Plan content development by defining scope, team, timeline, and sprint cadence.
+
+## Responsibilities
+- Define content scope and objectives
+- Form development team (roles, responsibilities)
+- Establish governance model (RASCI matrix)
+- Plan iteration/sprint cadence
+- Coordinate stakeholder engagement
+- Define acceptance criteria
+
+## Actors
+- Programme Manager (lead)
+- Technical Officer (support)
+
+## Inputs
+- Stakeholder requirements
+- Existing guidelines or source material
+- Resource constraints
+
+## Outputs
+- Project plan document
+- Team roster with role assignments
+- Sprint/iteration schedule
+- Governance model (RASCI)

--- a/skills/content-lifecycle/content-publish.md
+++ b/skills/content-lifecycle/content-publish.md
@@ -1,0 +1,27 @@
+# Content Publication
+
+Package, version, and publish approved content.
+
+## Responsibilities
+- Update version numbers (semantic versioning: major.minor.patch)
+- Create publication metadata (publication-request.json for FHIR IGs)
+- Build final artifacts (IG Publisher build, LaTeX compilation)
+- Create release branches and tags
+- Create GitHub releases with release notes
+- Deploy to publication platform (smart.who.int, arXiv, etc.)
+- Reset development branch to draft status for next cycle
+
+## Actors
+- Publication Manager (lead)
+- Programme Manager (release authorization)
+
+## Inputs
+- Approved and tested content
+- Version increment decision (major/minor/patch)
+- Release notes
+
+## Outputs
+- Published artifacts (IG, PDF, etc.)
+- GitHub release with tags
+- Publication URL
+- Updated version in development branch

--- a/skills/content-lifecycle/content-retire.md
+++ b/skills/content-lifecycle/content-retire.md
@@ -1,0 +1,27 @@
+# Content Retirement
+
+Deprecate and retire content that is no longer current or needed.
+
+## Responsibilities
+- Identify content for deprecation/retirement
+- Communicate deprecation timeline to users
+- Update content status metadata
+- Archive retired content
+- Redirect references to successor content
+- Remove from active publication platforms
+
+## Actors
+- Programme Manager (decision authority)
+- Publication Manager (execution)
+- Technical Officer (communication)
+
+## Inputs
+- Successor content (if replacement)
+- Deprecation decision
+- Impact assessment
+
+## Outputs
+- Deprecation notice
+- Archived content
+- Updated redirects
+- Retirement record

--- a/skills/content-lifecycle/content-review.md
+++ b/skills/content-lifecycle/content-review.md
@@ -1,0 +1,27 @@
+# Content Review
+
+Formal review and approval of validated content before publication.
+
+## Responsibilities
+- Review L2 content before L3 begins (phase gate)
+- Review L3 content before publication (phase gate)
+- Assess breaking vs. non-breaking changes
+- Ensure alignment with source guidelines
+- Approve draft publications for stakeholder circulation
+- Provide final publication release sign-off
+
+## Actors
+- Content Reviewer (lead, approval authority)
+- Technical Officer (first-pass review)
+- Clinical SME (clinical sign-off)
+- Programme Manager (governance oversight)
+
+## Inputs
+- Validated content artifacts
+- Validation reports
+- Change log / diff from previous version
+
+## Outputs
+- Review decision (approve / request-changes / reject)
+- Review comments and required modifications
+- Approval record (who, when, conditions)

--- a/skills/content-lifecycle/content-test.md
+++ b/skills/content-lifecycle/content-test.md
@@ -1,0 +1,29 @@
+# Content Testing
+
+End-to-end testing of content artifacts in realistic scenarios.
+
+## Responsibilities
+- Execute test plans and test scripts
+- Verify StructureMap extraction output (FHIR)
+- Verify CQL execution and measure calculations (FHIR)
+- Run Lean proof verification (formal math)
+- Validate LaTeX compilation and output (formal math)
+- Test cross-component integration
+- Run regression tests against previous versions
+- Document test results
+
+## Actors
+- QC Reviewer (lead)
+- FHIR Modeller (technical testing)
+- Business Analyst (scenario testing)
+
+## Inputs
+- Approved content artifacts
+- Test plans and test data
+- Expected outcomes / golden files
+
+## Outputs
+- Test results report
+- Coverage metrics
+- Regression comparison
+- Issue list (if failures)

--- a/skills/content-lifecycle/content-validate.md
+++ b/skills/content-lifecycle/content-validate.md
@@ -1,0 +1,27 @@
+# Content Validation
+
+Validate authored content against schemas, standards, and clinical accuracy.
+
+## Responsibilities
+- Run schema validation against defined constraints
+- Validate FHIR resources (if applicable)
+- Run SUSHI compilation (if applicable)
+- Execute IG Publisher QA checks (if applicable)
+- Verify Lean proofs compile (if applicable)
+- Check cross-component consistency
+- Validate terminology bindings
+
+## Actors
+- QC Reviewer (lead)
+- FHIR Modeller (technical validation)
+- Terminologist (terminology validation)
+- Clinical SME (clinical accuracy)
+
+## Inputs
+- Authored content artifacts
+- Validation rules and schemas
+- Reference standards
+
+## Outputs
+- Validation report (pass/fail per artifact)
+- Issue list with severity and remediation guidance

--- a/skills/content-lifecycle/package-manifest.json
+++ b/skills/content-lifecycle/package-manifest.json
@@ -1,0 +1,63 @@
+{
+  "name": "content-lifecycle",
+  "version": "0.1.0",
+  "description": "General content development lifecycle skills: plan, author, validate, review, test, publish, feedback, retire",
+  "skills": [
+    "content-plan",
+    "content-author",
+    "content-validate",
+    "content-review",
+    "content-test",
+    "content-publish",
+    "content-feedback",
+    "content-retire"
+  ],
+  "docker": {
+    "baseImage": "ubuntu:24.04",
+    "aptPackages": [
+      "curl",
+      "git",
+      "git-lfs",
+      "python3",
+      "python3-pip",
+      "python3-venv",
+      "nodejs",
+      "npm",
+      "jq",
+      "ca-certificates"
+    ],
+    "pipPackages": [
+      "jsonschema",
+      "pyyaml",
+      "requests"
+    ],
+    "npmPackages": [
+      "typescript",
+      "ts-node"
+    ],
+    "labels": {
+      "org.opencontainers.image.title": "folio-assistant-lifecycle",
+      "org.opencontainers.image.description": "Content development lifecycle management tools",
+      "org.opencontainers.image.source": "https://github.com/litlfred/folio-assistant"
+    }
+  },
+  "providesCapabilities": [
+    "git-push",
+    "python3",
+    "node-runtime"
+  ],
+  "lifecycleStages": [
+    "plan",
+    "author",
+    "validate",
+    "review",
+    "test",
+    "publish",
+    "feedback",
+    "retire"
+  ],
+  "schemas": [
+    "schemas/generated/SkillDefinition.schema.json",
+    "schemas/generated/Requirement.schema.json"
+  ]
+}

--- a/skills/remote-packages/claude-scientific-skills.json
+++ b/skills/remote-packages/claude-scientific-skills.json
@@ -1,0 +1,62 @@
+{
+  "name": "claude-scientific-skills",
+  "description": "Scientific skills for Claude — visualization, critical thinking, hypothesis generation. Maintained by K-Dense-AI.",
+  "repo": "https://github.com/K-Dense-AI/claude-scientific-skills",
+  "ref": "main",
+  "path": "/",
+  "maintainer": "K-Dense-AI",
+  "sync": {
+    "strategy": "shallow-clone",
+    "frequency": "weekly",
+    "autoUpdate": true
+  },
+  "wrapper": {
+    "description": "Light wrapper providing SkillPackageManifest compliance for external claude-scientific-skills.",
+    "docker": {
+      "baseImage": "ubuntu:24.04",
+      "aptPackages": [
+        "curl",
+        "git",
+        "python3",
+        "python3-pip",
+        "python3-venv",
+        "nodejs",
+        "npm",
+        "graphviz",
+        "ca-certificates"
+      ],
+      "pipPackages": [
+        "matplotlib",
+        "numpy",
+        "scipy",
+        "sympy",
+        "pandas",
+        "seaborn"
+      ],
+      "npmPackages": [
+        "typescript",
+        "ts-node"
+      ],
+      "labels": {
+        "org.opencontainers.image.title": "folio-assistant-scientific-skills",
+        "org.opencontainers.image.description": "Scientific skills for visualization, critical thinking, and hypothesis generation",
+        "org.opencontainers.image.source": "https://github.com/K-Dense-AI/claude-scientific-skills"
+      }
+    },
+    "providesCapabilities": [
+      "scientific-visualization",
+      "hypothesis-generation",
+      "critical-thinking"
+    ],
+    "skills": [
+      "scientific-visualization",
+      "scientific-critical-thinking",
+      "hypothesis-generation"
+    ],
+    "lifecycleStages": [
+      "author",
+      "validate",
+      "review"
+    ]
+  }
+}

--- a/skills/remote-packages/smarter-fhir.json
+++ b/skills/remote-packages/smarter-fhir.json
@@ -1,0 +1,53 @@
+{
+  "name": "smarter-fhir",
+  "description": "SMARTerFHIR — Enhanced SMART on FHIR client library for building clinical applications. Maintained by Topology Health.",
+  "repo": "https://github.com/TopologyHealth/SMARTerFHIR",
+  "ref": "main",
+  "path": "/",
+  "maintainer": "TopologyHealth",
+  "sync": {
+    "strategy": "shallow-clone",
+    "frequency": "weekly",
+    "autoUpdate": true
+  },
+  "wrapper": {
+    "description": "Light wrapper providing SkillPackageManifest compliance for the external SMARTerFHIR library.",
+    "docker": {
+      "baseImage": "ubuntu:24.04",
+      "aptPackages": [
+        "curl",
+        "git",
+        "nodejs",
+        "npm",
+        "ca-certificates"
+      ],
+      "npmPackages": [
+        "typescript",
+        "ts-node"
+      ],
+      "setupCommands": [
+        "cd /opt/smarter-fhir && npm install"
+      ],
+      "env": {
+        "SMARTER_FHIR_HOME": "/opt/smarter-fhir"
+      },
+      "labels": {
+        "org.opencontainers.image.title": "folio-assistant-smarter-fhir",
+        "org.opencontainers.image.description": "SMARTerFHIR integration for FHIR-based clinical applications",
+        "org.opencontainers.image.source": "https://github.com/TopologyHealth/SMARTerFHIR"
+      }
+    },
+    "providesCapabilities": [
+      "smart-on-fhir",
+      "fhir-client"
+    ],
+    "skills": [
+      "smart-launch",
+      "fhir-client-operations"
+    ],
+    "lifecycleStages": [
+      "author",
+      "test"
+    ]
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["schemas/**/*.ts", "skills/**/*.ts", "scripts/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Implements the cross-repository agent skills framework from #1, unifying skill management, role-based access control, and capability detection across the qou (formal math) and smart-base (WHO FHIR IG) projects.

### Core Schemas (all under `schemas/`)
- **TypeScript types** (`types.ts`) with Zod validation (`constraints.ts`) and builders (`builders.ts`)
- **9 core schema types**: ActorDefinition, CapabilityDefinition, SkillDefinition, Requirement, SkillRegistry, RoleAssignment, DockerRequirements, SkillPackageManifest, RemotePackageRef
- **18 per-skill input/output JSON Schemas** under `schemas/skills/<skill-id>/` — every skill with MCP, Python, Node, or script implementation has associated schemas linked via `schemaRef`

### Skill Packages with Docker Requirements
Each package declares its Docker deps in `package-manifest.json` (OCI-compliant):
- **authoring-math**: Lean 4, LaTeX (texlive-full), scientific Python (matplotlib, numpy, sympy)
- **authoring-who-smart-guidelines**: FHIR IG Publisher, SUSHI, OpenJDK 21, Ruby/Jekyll, PlantUML
- **content-lifecycle**: General lifecycle tools (Python, Node, jq)

### Remote Package Integration
- **TopologyHealth/SMARTerFHIR** — SMART on FHIR client library with Docker wrapper
- **K-Dense-AI/claude-scientific-skills** — Scientific visualization, critical thinking, hypothesis generation

### Content Development Lifecycle
8 lifecycle stages: plan → author → validate → review → test → publish → feedback → retire  
Each backed by a SkillDefinition + input/output schemas + markdown instructions

### Actors & Roles (16 definitions)
Role hierarchy: `viewer → reviewer → author → admin`  
WHO personas: Programme Manager, Business Analyst, Clinical SME, FHIR Modeller, Terminologist, QC Reviewer, Content Reviewer, Publication Manager, Technical Officer, Translator  
System actors: Lean MCP Server, IG Publisher Service

### Auto-Generation Scripts
- `generate-schemas.ts` — Zod → JSON Schema (20 schema files)
- `generate-docs.ts` — Comprehensive docs: SCHEMAS.md, SKILLS.md, ACTORS.md, CAPABILITIES.md, REQUIREMENTS.md, PACKAGES.md, LIFECYCLE.md + index.json catalog
- `generate-registry.ts` — Unified SkillRegistry from all sources
- `validate-skills.ts` — Validates all JSON files against their Zod schemas

### Dockerfile
Ubuntu 24.04 LTS base image merging all skill package dependencies.

## Test plan
- [ ] Run `npm install && npm run generate:all` to verify schema generation
- [ ] Run `npm run validate` to verify all JSON files pass Zod validation
- [ ] Run `docker build -t folio-assistant .` to verify Dockerfile builds
- [ ] Review generated docs in `schemas/generated/` for completeness
- [ ] Verify each skill in `.claude/skills/local/` has a `schemaRef` pointing to `schemas/skills/<id>/`
- [ ] Verify remote package wrappers have valid Docker requirements

https://claude.ai/code/session_01JbZUoSNVWFxsbwn7Mv4GAG