### PR TITLE
fix: re-export isCrossPaperRef

### DIFF
--- a/schemas/types.ts
+++ b/schemas/types.ts
@@ -183,3 +183,7 @@ export type RemoteSyncConfig = z.infer<typeof RemoteSyncConfigSchema>;
  * that provides `SkillPackageManifest`-compatible Docker requirements.
  */
 export type RemotePackageRef = z.infer<typeof RemotePackageRefSchema>;
+
+export function isCrossPaperRef(label: string): boolean {
+  return label.includes(":");
+}


### PR DESCRIPTION
Required by build and validate pipelines