### PR TITLE
feat(sage): expose SageMath as a lazily-loaded MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "sage": {
+      "command": "scripts/sage-mcp.sh",
+      "args": [],
+      "env": {
+        "SAGE_DOCKER_IMAGE": "sagemath/sagemath:latest"
+      }
+    }
+  }
+}

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -42,11 +42,41 @@ services:
       - MCP_PORT=${MCP_INTERNAL_PORT:-8080}
     expose:
       - "${MCP_INTERNAL_PORT:-8080}"
+    # Shared scratch workspace for exchanging computation inputs/outputs with
+    # opt-in compute services (e.g. sage). Mounted at /shared (NOT /workspace,
+    # which is the app's own dir in the image).
+    volumes:
+      - sage_workspace:/shared
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:${MCP_INTERNAL_PORT:-8080}/health"]
       interval: 30s
       timeout: 5s
       retries: 3
+
+  # ── SageMath (algebra / number theory compute) — lazy, opt-in ────
+  # NOT started by a plain `docker compose up`. The ~2 GB sagemath/sagemath
+  # image is pulled only when the `sage` profile is first activated, e.g.:
+  #
+  #   docker compose --profile sage up -d sage          # persistent service
+  #
+  # or spawn the Sage MCP server (stdio) on demand, sharing the workspace:
+  #
+  #   docker compose --profile sage run --rm -i sage \
+  #     python3 /repo/folio-assistant/src/sage-mcp-server.py --stdio
+  #
+  # Inside this container `sage` is native, so the MCP server uses it directly
+  # (no nested Docker). Files written under /shared are visible to
+  # folio-assistant; the repo is mounted read-only at /repo.
+  sage:
+    image: ${SAGE_DOCKER_IMAGE:-sagemath/sagemath:latest}
+    container_name: sage
+    profiles: ["sage"]
+    restart: unless-stopped
+    working_dir: /shared
+    command: ["sleep", "infinity"]
+    volumes:
+      - sage_workspace:/shared
+      - ../:/repo:ro
 
   # ── Auth Gateway (dual OAuth + role-based sessions) ──────────────
   auth-gateway:
@@ -84,3 +114,6 @@ services:
 volumes:
   caddy_data:
   caddy_config:
+  # Shared scratch workspace between folio-assistant and opt-in compute
+  # services (sage). Empty until the `sage` profile is used.
+  sage_workspace:

--- a/docs/sage-mcp.md
+++ b/docs/sage-mcp.md
@@ -1,0 +1,70 @@
+# Sage as an MCP server (lazily loaded)
+
+[SageMath](https://www.sagemath.org/) is exposed as a Model Context Protocol
+server so agents can call algebra / number-theory tools (Iwahori–Hecke trace,
+Faddeev quantum dilogarithm, nuclear β-decay scaffolding, and arbitrary
+`sage_eval`).
+
+Sage is a **~2 GB compiled distribution** — there is no pip wheel, and it is
+often missing from apt/conda. To keep it "available easily" without forcing that
+download on anyone who never uses it, the backend is resolved **lazily**:
+nothing is installed or pulled at startup or during the MCP handshake. The
+backend is chosen — and the Docker image pulled if needed — only on the **first
+actual tool call**.
+
+Backend resolution order (first hit wins):
+
+1. `$SAGE_CMD` — explicit command (e.g. `sage`, `/opt/sage/sage`)
+2. `sage` on `PATH` — a native install
+3. **Docker** — runs `sagemath/sagemath` (image pulled on demand)
+
+Env knobs: `SAGE_DOCKER_IMAGE` (default `sagemath/sagemath:latest`),
+`SAGE_NO_DOCKER=1` (disable the Docker fallback), `SAGE_CMD` (force a command).
+
+Server source: [`src/sage-mcp-server.py`](../src/sage-mcp-server.py) — a
+dependency-free JSON-RPC 2.0 stdio server (system Python 3, no `mcp` package).
+
+## Mode 1 — local / dev (Claude Code)
+
+Already wired. The project [`.mcp.json`](../.mcp.json) registers the `sage`
+server via `scripts/sage-mcp.sh`. Registration costs nothing; on the first Sage
+tool call the script uses a native `sage` if present, otherwise pulls and runs
+the Docker image (mounting the current dir at `/work`).
+
+Check the backend without triggering any download:
+
+```sh
+python3 src/sage-mcp-server.py --status
+```
+
+Pre-warm the Docker image ahead of time (optional, so the first call isn't slow):
+
+```sh
+./scripts/setup-sage.sh --pull
+```
+
+## Mode 2 — deployed stack (docker compose)
+
+`deploy/docker-compose.yml` defines a `sage` service behind a Compose
+**profile**, sharing a `sage_workspace` volume (mounted at `/shared`) with
+`folio-assistant`. Because it's profile-gated, a plain `docker compose up` never
+starts or pulls it — it activates only on demand:
+
+```sh
+# Persistent Sage service (pulls the image the first time this runs):
+docker compose --profile sage up -d sage
+
+# Or spawn the Sage MCP server (stdio) on demand inside the service,
+# where `sage` is native (no nested Docker) and the repo is at /repo:
+docker compose --profile sage run --rm -i sage \
+  python3 /repo/folio-assistant/src/sage-mcp-server.py --stdio
+```
+
+Files written under `/shared` are visible to `folio-assistant`; the repo is
+mounted read-only at `/repo`.
+
+> Note on topology: folio-assistant's deployed stack is a *web* topology
+> (Caddy → auth-gateway → folio-assistant), not one container per compute tool.
+> Most compute tools (LaTeX, Lean, Python) are baked into the monolithic
+> `folio-assistant` image; Sage is kept out of it (size) and supplied as this
+> opt-in, lazily-pulled sidecar instead.

--- a/scripts/sage-mcp.sh
+++ b/scripts/sage-mcp.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Launch the SageMath MCP server (stdio transport).
+#
+# Registered in the project .mcp.json as the "sage" server. This wrapper just
+# locates a Python 3 and execs src/sage-mcp-server.py — all backend selection
+# (native `sage` vs Docker) and the lazy ~2 GB image pull happen inside that
+# script, and ONLY on the first actual Sage tool call. Registering this server
+# costs nothing; if you never call a Sage tool, nothing is downloaded.
+#
+# Override the image with $SAGE_DOCKER_IMAGE; disable the Docker fallback with
+# SAGE_NO_DOCKER=1; force a command with $SAGE_CMD.
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/src/sage-mcp-server.py"
+
+PY="$(command -v python3 || command -v python || true)"
+if [[ -z "$PY" ]]; then
+  echo "sage-mcp: no python3/python on PATH" >&2
+  exit 1
+fi
+
+exec "$PY" "$SCRIPT" --stdio

--- a/scripts/setup-sage.sh
+++ b/scripts/setup-sage.sh
@@ -1,26 +1,43 @@
 #!/bin/bash
-# Setup SageMath for QOU witness computations.
+# Setup SageMath for QOU computations.
 #
 # Copy-paste from repo root:
 #
-#   ./scripts/setup-sage.sh
+#   ./scripts/setup-sage.sh           # detect / install a native Sage
+#   ./scripts/setup-sage.sh --pull    # pre-warm the Docker image (~2 GB)
 #
-# Then run all witness computations:
+# YOU MAY NOT NEED THIS. The Sage MCP server (src/sage-mcp-server.py, registered
+# in .mcp.json) resolves its backend LAZILY: if `sage` is on PATH it uses it,
+# otherwise it pulls and runs the `sagemath/sagemath` Docker image — but only on
+# the FIRST actual tool call. If you never invoke a Sage tool, nothing downloads.
+# Run this script only to install a native Sage, or `--pull` to download the
+# Docker image ahead of time so the first call isn't slow.
 #
-#   ./scripts/run-sage-witnesses.sh
-#
-# NOTE: SageMath requires Python <= 3.12. If your system Python is 3.13+,
+# NOTE: native SageMath requires Python <= 3.12. If your system Python is 3.13+,
 # this script creates a dedicated conda environment with Python 3.12.
 
 set -e
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 ENV_NAME="qou-sage"
+SAGE_IMAGE="${SAGE_DOCKER_IMAGE:-sagemath/sagemath:latest}"
 
 echo "═══════════════════════════════════════════════════════════"
-echo "SageMath setup for QOU witness computations"
+echo "SageMath setup"
 echo "═══════════════════════════════════════════════════════════"
 echo
+
+# ── --pull: pre-warm the Docker image (optional) ─────────────────
+if [[ "${1:-}" == "--pull" ]]; then
+    if ! command -v docker &>/dev/null; then
+        echo "✗ docker not found — cannot pre-pull. Install Docker or a native Sage."
+        exit 1
+    fi
+    echo "▸ Pre-pulling Sage Docker image '$SAGE_IMAGE' (~2 GB, one time)…"
+    docker pull "$SAGE_IMAGE"
+    echo "✓ Image ready. The Sage MCP server will use it without further downloads."
+    exit 0
+fi
 
 # ── Check if sage is already available ───────────────────────────
 if command -v sage &>/dev/null; then

--- a/src/sage-mcp-server.py
+++ b/src/sage-mcp-server.py
@@ -2,98 +2,232 @@
 """
 SageMath MCP server for algebraic computations.
 
+A real, dependency-free Model Context Protocol server (JSON-RPC 2.0 over
+stdio — no `mcp` pip package required, just the system Python 3).
+
 Provides tools for:
 - Iwahori--Hecke algebra computations (IwahoriHeckeAlgebra)
-- Braid group operations
-- Jones polynomial evaluation
 - Markov trace (exact, symbolic over Q(q))
 - Quantum dilogarithm (Faddeev) evaluation
-- Nuclear braid word construction and reduction
+- Nuclear beta-decay Q-value scaffolding
+- Arbitrary Sage evaluation (sage_eval)
 
-Requires: SageMath installed (sage executable on PATH)
+── Lazy backend resolution ──────────────────────────────────────────
+SageMath is a ~2 GB compiled distribution (PARI, Singular, GAP, FLINT,
+NTL, Maxima, …) — there is no pip wheel, and it is frequently absent from
+apt/conda. To make it "available easily as MCP" without forcing a 2 GB
+download on users who never call a Sage tool, the backend is resolved
+*lazily*: nothing is installed or pulled at startup or during the MCP
+handshake (initialize / tools/list). The backend is chosen, and the
+Docker image pulled if needed, only on the FIRST `tools/call`.
 
-MCP transport: stdio
+Resolution order (first hit wins):
+  1. $SAGE_CMD            — explicit command, e.g. "sage" or "/opt/sage/sage"
+  2. `sage` on PATH       — a native install
+  3. Docker               — runs `sagemath/sagemath` (image pulled on demand)
+
+Override the Docker image via $SAGE_DOCKER_IMAGE (default
+"sagemath/sagemath:latest"). Disable the Docker fallback with
+SAGE_NO_DOCKER=1.
+
+MCP transport: stdio (newline-delimited JSON-RPC 2.0).
 
 Usage:
-    sage -python folio-assistant/src/sage-mcp-server.py --stdio
+    python3 src/sage-mcp-server.py --stdio     # MCP server (default)
+    python3 src/sage-mcp-server.py --status    # report backend, no download
+
+Registered for Claude Code via the project .mcp.json ("sage" server).
 """
 
 import json
-import sys
+import os
+import shutil
 import subprocess
+import sys
 from pathlib import Path
+
+PROTOCOL_VERSION = "2024-11-05"
+SERVER_INFO = {"name": "sage-mcp", "version": "0.2.0"}
+
+SAGE_IMAGE = os.environ.get("SAGE_DOCKER_IMAGE", "sagemath/sagemath:latest")
+SAGE_NO_DOCKER = os.environ.get("SAGE_NO_DOCKER", "") not in ("", "0", "false")
+
+
+def eprint(*args: object) -> None:
+    """Diagnostics MUST go to stderr — stdout is the MCP protocol channel."""
+    print(*args, file=sys.stderr, flush=True)
+
+
+# ── Lazy backend resolution ──────────────────────────────────────
+
+# Resolved once, on first use. None = not yet resolved.
+#   {"kind": "native", "cmd": [...]} | {"kind": "docker", "image": str}
+_backend: dict | None = None
+
+
+def _docker_ok() -> bool:
+    """Is a usable Docker daemon present? (cheap — no pull)."""
+    if SAGE_NO_DOCKER or not shutil.which("docker"):
+        return False
+    try:
+        r = subprocess.run(["docker", "info"], capture_output=True, timeout=15)
+        return r.returncode == 0
+    except Exception:
+        return False
+
+
+def _image_present(image: str) -> bool:
+    try:
+        r = subprocess.run(["docker", "image", "inspect", image],
+                           capture_output=True, timeout=15)
+        return r.returncode == 0
+    except Exception:
+        return False
+
+
+def _ensure_image(image: str) -> bool:
+    """Pull the Sage image if absent. Progress streams to stderr. One-time ~2 GB."""
+    if _image_present(image):
+        return True
+    eprint(f"[sage-mcp] Sage image '{image}' not present — pulling (~2 GB, one time)…")
+    try:
+        # Stream pull progress to stderr so it never corrupts the stdout MCP channel.
+        r = subprocess.run(["docker", "pull", image], stdout=sys.stderr, stderr=sys.stderr)
+        ok = r.returncode == 0
+        eprint(f"[sage-mcp] pull {'succeeded' if ok else 'FAILED'}")
+        return ok
+    except Exception as e:  # pragma: no cover
+        eprint(f"[sage-mcp] pull error: {e}")
+        return False
+
+
+def resolve_backend(allow_download: bool = True) -> dict:
+    """
+    Pick (and cache) the Sage backend. With allow_download=False, report
+    what *would* be used without pulling anything (for --status / probes).
+    Returns {"kind": "native"|"docker"|"none", ...}.
+    """
+    global _backend
+    if _backend is not None:
+        return _backend
+
+    env_cmd = os.environ.get("SAGE_CMD")
+    if env_cmd and shutil.which(env_cmd.split()[0]):
+        _backend = {"kind": "native", "cmd": env_cmd.split()}
+        return _backend
+
+    if shutil.which("sage"):
+        _backend = {"kind": "native", "cmd": ["sage"]}
+        return _backend
+
+    if _docker_ok():
+        if allow_download:
+            if not _ensure_image(SAGE_IMAGE):
+                return {"kind": "none", "reason": f"docker pull of {SAGE_IMAGE} failed"}
+            _backend = {"kind": "docker", "image": SAGE_IMAGE}
+            return _backend
+        # Probe mode: report docker availability without pulling.
+        return {"kind": "docker", "image": SAGE_IMAGE, "pulled": _image_present(SAGE_IMAGE)}
+
+    return {
+        "kind": "none",
+        "reason": "no `sage` on PATH and no usable Docker daemon "
+                  "(SAGE_NO_DOCKER set, or docker not installed/running)",
+    }
 
 
 def sage_eval(code: str, timeout: int = 300) -> dict:
-    """Execute Sage code and return the result."""
-    try:
-        result = subprocess.run(
-            ['sage', '-c', code],
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-        )
+    """Execute Sage code via the resolved backend and return stdout/stderr/returncode."""
+    backend = resolve_backend(allow_download=True)
+
+    if backend["kind"] == "native":
+        cmd = [*backend["cmd"], "-c", code]
+    elif backend["kind"] == "docker":
+        # Mount cwd at /work so Sage code can read/write repo files.
+        cwd = os.getcwd()
+        cmd = [
+            "docker", "run", "--rm", "-i",
+            "-v", f"{cwd}:/work", "-w", "/work",
+            backend["image"], "sage", "-c", code,
+        ]
+    else:
         return {
-            'stdout': result.stdout,
-            'stderr': result.stderr,
-            'returncode': result.returncode,
+            "error": "SageMath is not available.",
+            "detail": backend.get("reason", ""),
+            "hint": "Install Sage (`./scripts/setup-sage.sh`) or run a Docker "
+                    "daemon so the sagemath/sagemath image can be pulled on demand.",
         }
-    except FileNotFoundError:
-        return {'error': 'sage not found on PATH. Install: conda install -c conda-forge sage'}
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        return {
+            "backend": backend["kind"],
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+            "returncode": result.returncode,
+        }
     except subprocess.TimeoutExpired:
-        return {'error': f'Sage computation timed out after {timeout}s'}
+        return {"error": f"Sage computation timed out after {timeout}s"}
+    except Exception as e:  # pragma: no cover
+        return {"error": f"Sage execution failed: {e}"}
 
 
 # ── MCP Tool definitions ────────────────────────────────────────
 
 TOOLS = [
     {
-        'name': 'sage_hecke_trace',
-        'description': 'Compute the Markov trace of a nuclear braid word in the Iwahori--Hecke algebra H_A(q). Returns exact symbolic result over Q(q).',
-        'inputSchema': {
-            'type': 'object',
-            'properties': {
-                'p': {'type': 'integer', 'description': 'Number of protons'},
-                'n': {'type': 'integer', 'description': 'Number of neutrons'},
-                'q_numerical': {'type': 'number', 'description': 'Numerical q value (default 1.110)', 'default': 1.110},
+        "name": "sage_status",
+        "description": "Report the resolved Sage backend (native / docker / none) "
+                       "WITHOUT triggering any download. Use to check availability first.",
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "sage_hecke_trace",
+        "description": "Compute the Markov trace of a nuclear braid word in the Iwahori--Hecke algebra H_A(q). Returns exact symbolic result over Q(q).",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "p": {"type": "integer", "description": "Number of protons"},
+                "n": {"type": "integer", "description": "Number of neutrons"},
+                "q_numerical": {"type": "number", "description": "Numerical q value (default 1.110)", "default": 1.110},
             },
-            'required': ['p', 'n'],
+            "required": ["p", "n"],
         },
     },
     {
-        'name': 'sage_faddeev_dilog',
-        'description': 'Evaluate the Faddeev quantum dilogarithm Φ_b(z) at given spectral coordinates. Uses the integral representation for analytic continuation.',
-        'inputSchema': {
-            'type': 'object',
-            'properties': {
-                'z_values': {'type': 'array', 'items': {'type': 'number'}, 'description': 'Spectral coordinates to evaluate'},
-                'q': {'type': 'number', 'description': 'Substrate parameter', 'default': 1.110},
+        "name": "sage_faddeev_dilog",
+        "description": "Evaluate the Faddeev quantum dilogarithm Φ_b(z) at given spectral coordinates. Uses the integral representation for analytic continuation.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "z_values": {"type": "array", "items": {"type": "number"}, "description": "Spectral coordinates to evaluate"},
+                "q": {"type": "number", "description": "Substrate parameter", "default": 1.110},
             },
-            'required': ['z_values'],
+            "required": ["z_values"],
         },
     },
     {
-        'name': 'sage_nuclear_Q',
-        'description': 'Compute the beta-decay Q-value for N(p,n) → N(p+1,n-1) using the full descended-to-point mass formula with quantum dilogarithm.',
-        'inputSchema': {
-            'type': 'object',
-            'properties': {
-                'p': {'type': 'integer', 'description': 'Number of protons'},
-                'n': {'type': 'integer', 'description': 'Number of neutrons'},
+        "name": "sage_nuclear_Q",
+        "description": "Compute the beta-decay Q-value for N(p,n) → N(p+1,n-1) using the full descended-to-point mass formula with quantum dilogarithm.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "p": {"type": "integer", "description": "Number of protons"},
+                "n": {"type": "integer", "description": "Number of neutrons"},
             },
-            'required': ['p', 'n'],
+            "required": ["p", "n"],
         },
     },
     {
-        'name': 'sage_eval',
-        'description': 'Execute arbitrary Sage code and return the result. For custom algebraic computations.',
-        'inputSchema': {
-            'type': 'object',
-            'properties': {
-                'code': {'type': 'string', 'description': 'Sage code to execute'},
-                'timeout': {'type': 'integer', 'description': 'Timeout in seconds', 'default': 300},
+        "name": "sage_eval",
+        "description": "Execute arbitrary Sage code and return the result. For custom algebraic computations.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "code": {"type": "string", "description": "Sage code to execute"},
+                "timeout": {"type": "integer", "description": "Timeout in seconds", "default": 300},
             },
-            'required': ['code'],
+            "required": ["code"],
         },
     },
 ]
@@ -165,23 +299,26 @@ for z in z_values:
 
 
 def handle_tool_call(tool_name: str, arguments: dict) -> str:
-    """Handle an MCP tool call."""
-    if tool_name == 'sage_hecke_trace':
-        p = arguments['p']
-        n = arguments['n']
+    """Handle an MCP tool call. Returns a JSON string for the text content."""
+    if tool_name == "sage_status":
+        return json.dumps(resolve_backend(allow_download=False), indent=2)
+
+    if tool_name == "sage_hecke_trace":
+        p = arguments["p"]
+        n = arguments["n"]
         A = p + n
         code = HECKE_TRACE_TEMPLATE.format(A=A, p=p, n=n)
         return json.dumps(sage_eval(code))
 
-    elif tool_name == 'sage_faddeev_dilog':
-        z_values = arguments['z_values']
-        q_val = arguments.get('q', 1.110)
+    elif tool_name == "sage_faddeev_dilog":
+        z_values = arguments["z_values"]
+        q_val = arguments.get("q", 1.110)
         code = FADDEEV_TEMPLATE.format(q=q_val, z_values=z_values)
         return json.dumps(sage_eval(code))
 
-    elif tool_name == 'sage_nuclear_Q':
-        p = arguments['p']
-        n = arguments['n']
+    elif tool_name == "sage_nuclear_Q":
+        p = arguments["p"]
+        n = arguments["n"]
         # Compose the full computation
         code = f"""
 # Full Q computation for N({p},{n}) → N({p+1},{n-1})
@@ -197,35 +334,116 @@ except Exception as e:
 """
         return json.dumps(sage_eval(code))
 
-    elif tool_name == 'sage_eval':
-        code = arguments['code']
-        timeout = arguments.get('timeout', 300)
+    elif tool_name == "sage_eval":
+        code = arguments["code"]
+        timeout = arguments.get("timeout", 300)
         return json.dumps(sage_eval(code, timeout))
 
     else:
-        return json.dumps({'error': f'Unknown tool: {tool_name}'})
+        return json.dumps({"error": f"Unknown tool: {tool_name}"})
 
 
-# ── MCP stdio transport ─────────────────────────────────────────
+# ── MCP stdio transport (JSON-RPC 2.0, newline-delimited) ────────
 
-def main():
-    """MCP server over stdio."""
-    # For now, just verify sage is available and print tools
-    result = sage_eval('print("SageMath ready:", version())')
-
-    if 'error' in result:
-        print(json.dumps({
-            'status': 'error',
-            'message': result['error'],
-            'install': 'conda install -c conda-forge sage',
-        }))
-    else:
-        print(json.dumps({
-            'status': 'ready',
-            'sage_version': result['stdout'].strip(),
-            'tools': [t['name'] for t in TOOLS],
-        }))
+def _result(req_id: object, result: object) -> dict:
+    return {"jsonrpc": "2.0", "id": req_id, "result": result}
 
 
-if __name__ == '__main__':
+def _error(req_id: object, code: int, message: str) -> dict:
+    return {"jsonrpc": "2.0", "id": req_id, "error": {"code": code, "message": message}}
+
+
+def handle_message(msg: dict) -> dict | None:
+    """Dispatch a single JSON-RPC message. Returns a response, or None for notifications."""
+    method = msg.get("method")
+    req_id = msg.get("id")
+    params = msg.get("params") or {}
+
+    # Notifications (no id) get no response.
+    is_notification = "id" not in msg
+
+    if method == "initialize":
+        return _result(req_id, {
+            "protocolVersion": PROTOCOL_VERSION,
+            "capabilities": {"tools": {}},
+            "serverInfo": SERVER_INFO,
+        })
+
+    if method in ("notifications/initialized", "initialized"):
+        return None
+
+    if method == "ping":
+        return _result(req_id, {})
+
+    if method == "tools/list":
+        return _result(req_id, {"tools": TOOLS})
+
+    if method == "tools/call":
+        name = params.get("name", "")
+        arguments = params.get("arguments") or {}
+        try:
+            text = handle_tool_call(name, arguments)
+            payload = json.loads(text)
+            is_err = isinstance(payload, dict) and "error" in payload
+            return _result(req_id, {
+                "content": [{"type": "text", "text": text}],
+                "isError": is_err,
+            })
+        except Exception as e:  # pragma: no cover
+            return _result(req_id, {
+                "content": [{"type": "text", "text": json.dumps({"error": str(e)})}],
+                "isError": True,
+            })
+
+    if method in ("shutdown",):
+        return _result(req_id, {})
+
+    if is_notification:
+        return None
+    return _error(req_id, -32601, f"Method not found: {method}")
+
+
+def serve_stdio() -> None:
+    """Run the MCP server over newline-delimited JSON-RPC on stdin/stdout."""
+    eprint(f"[sage-mcp] ready (stdio). Backend resolves lazily on first tool call. "
+           f"docker image={SAGE_IMAGE}")
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        response = handle_message(msg)
+        if response is not None:
+            sys.stdout.write(json.dumps(response) + "\n")
+            sys.stdout.flush()
+        if msg.get("method") == "shutdown":
+            break
+
+
+def print_status() -> None:
+    """Report the backend that WOULD be used, without downloading anything."""
+    backend = resolve_backend(allow_download=False)
+    print(json.dumps({
+        "server": SERVER_INFO,
+        "backend": backend,
+        "docker_image": SAGE_IMAGE,
+        "tools": [t["name"] for t in TOOLS],
+        "note": "The Sage Docker image (~2 GB) is pulled only on the first "
+                "tools/call, never at startup.",
+    }, indent=2))
+
+
+def main() -> None:
+    args = sys.argv[1:]
+    if "--status" in args or "--check" in args:
+        print_status()
+        return
+    # Default to stdio MCP transport.
+    serve_stdio()
+
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## What & why

Makes SageMath **"available easily as MCP"** without forcing its ~2 GB download on anyone who never uses it. Sage has no pip wheel and is usually absent from apt/conda, so the only practical packaging here is the official `sagemath/sagemath` Docker image — and it's wired to load **lazily**: nothing is installed or pulled at startup or during the MCP handshake; the backend is chosen (and the image pulled if needed) **only on the first actual tool call**.

## Changes

- **`src/sage-mcp-server.py`** — was a status-only stub that never spoke the protocol; now a real, dependency-free JSON-RPC 2.0 **stdio MCP server** (`initialize` / `tools/list` / `tools/call` / `ping` / `shutdown`, system Python 3, no `mcp` package). Backend resolves lazily: `$SAGE_CMD` → native `sage` → Docker. Adds a `sage_status` tool that reports the backend **without** downloading, and routes all diagnostics to stderr so the stdout protocol channel stays clean.
- **`.mcp.json`** + **`scripts/sage-mcp.sh`** — register the `sage` server for Claude Code. Registration is free; the 2 GB pull happens only when a Sage tool is invoked.
- **`deploy/docker-compose.yml`** — adds a profile-gated `sage` service sharing a `sage_workspace` volume (mounted at `/shared`) with `folio-assistant`. A plain `docker compose up` never pulls it; only `--profile sage` activates it.
- **`scripts/setup-sage.sh`** — documents the lazy/Docker reality; adds `--pull` to pre-warm the image.
- **`docs/sage-mcp.md`** — documents both modes (local stdio + compose sidecar) and the backend knobs.

## Backend resolution

`$SAGE_CMD` → native `sage` on PATH → Docker (`sagemath/sagemath:latest`, pulled on demand). Env knobs: `SAGE_DOCKER_IMAGE`, `SAGE_NO_DOCKER`, `SAGE_CMD`.

## Testing

- MCP handshake, `tools/list` (5 tools), `sage_status` (confirms **no** download on a status check), and graceful degradation of `sage_eval` when no backend is reachable — all verified via the wrapper and direct invocation.
- `docker compose config` parses cleanly with the new service + volume.
- ⚠️ This sandbox has no reachable Docker daemon, so an end-to-end Sage **computation** couldn't be exercised here; the code is written for environments where Docker (or a native `sage`) is available and degrades with a clear hint otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASwqatKnwCiGmgp5EA8SfJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01ASwqatKnwCiGmgp5EA8SfJ)_