### PR TITLE
fix(pipeline): repair absorbed import paths, unify lean.ref resolver, add orphan §7c coverage

### DIFF
--- a/.claude/skills/local/prepare-merge.md
+++ b/.claude/skills/local/prepare-merge.md
@@ -1,0 +1,76 @@
+# Prepare-merge — get a feature branch ready to land
+
+Canonical, repo-agnostic skill for taking a `claude/*` (or any feature) branch
+to a **clean, conflict-free, green, pushed** state so it can be merged with no
+surprises. This is the **generic source of truth**; downstream repos (e.g. qou)
+vendor or sync it rather than hand-maintaining their own copy.
+
+**"Prepare-merge" ≠ "merge".** It makes the branch *mergeable* and stops. It
+does **not** push to the default branch and does **not** merge a PR. Both are
+outward-facing, hard-to-reverse actions — do them only on an explicit request.
+
+## The problem this solves
+
+"prepare-merge" / "make it mergeable" / "ship it" is a plain-English ask, not a
+built-in command. Without a codified recipe each agent re-derives the steps and
+may do them inconsistently or unsafely (force-push over a sibling, push straight
+to `main`, declare green while sitting on pre-existing failures). This skill is
+the one recipe.
+
+## Recipe
+
+1. **Clean + committed.** `git status --short` must be empty. Commit outstanding
+   work first (the container is ephemeral — uncommitted work is lost on resume).
+2. **Fetch the base + your branch** (retry on network error, backoff 2/4/8/16s):
+   `git fetch origin <base> <branch>`.
+3. **Integrate if the base moved.** Compare `git merge-base HEAD origin/<base>`
+   to `git rev-parse origin/<base>`:
+   - **Equal** → base hasn't moved; nothing to do (your branch is a clean
+     fast-forward).
+   - **Different** → rebase onto the base: `git rebase origin/<base>` (preferred
+     for a linear history) or merge it in. Resolve conflicts, then re-run the
+     green check. A rebase needs a force-push **with lease**:
+     `git push --force-with-lease` — never a bare `--force` (it clobbers sibling
+     pushes).
+4. **Prove it merges cleanly** (no assumptions):
+   - `git merge-base --is-ancestor origin/<base> HEAD` → success means a clean
+     fast-forward, zero conflict potential.
+   - Otherwise dry-run: `git merge-tree $(git merge-base HEAD origin/<base>)
+     origin/<base> HEAD` and confirm no `<<<<<<<` / "changed in both" markers.
+5. **Green check.** Run the project's tests/build (here: `bun test`, plus
+   `bun build <file> --target=bun` for type-checking touched files). Report
+   **honestly**: distinguish failures you caused from pre-existing ones (diff the
+   counts against a baseline run on the merge-base). Do not call a branch green
+   by silently inheriting red.
+6. **Push** the feature branch (retry/backoff as in step 2):
+   `git push -u origin <branch>`.
+7. **Stop here** unless a PR / merge was explicitly requested. If a PR *was*
+   requested, see below.
+
+## Opening the PR (only when asked)
+
+GitHub access here is via the **GitHub MCP server**, whose tools are
+**deferred** (lazy-loaded). At session start they appear as names only — you
+cannot call them until you load the schema:
+
+```
+ToolSearch  "select:mcp__github__create_pull_request"
+```
+
+Then call `mcp__github__create_pull_request` with `owner`, `repo`, `head`
+(the feature branch), `base`. This "load-then-call" round-trip is by design —
+not a failure — and is needed once per deferred tool per session. The same
+applies to every `mcp__github__*` tool (review, comment, merge, CI status).
+
+PR body convention: end with the Claude Code footer + session link (see the
+harness git instructions). Do not include the model identifier in the PR.
+
+## Guardrails
+
+- **Never push to the default branch** and **never merge a PR** without an
+  explicit ask. Prepare-merge leaves the decision to the human.
+- **`--force-with-lease`, never bare `--force`** when a rebase rewrote history.
+- **Honest green.** Pre-existing red is reported as pre-existing, with evidence;
+  your-change red blocks the "ready" claim.
+- **One branch.** Develop on the assigned `claude/*` branch; moving work to a
+  different branch needs explicit permission.

--- a/.claude/skills/local/prepare-merge.md
+++ b/.claude/skills/local/prepare-merge.md
@@ -34,9 +34,15 @@ the one recipe.
      pushes).
 4. **Prove it merges cleanly** (no assumptions):
    - `git merge-base --is-ancestor origin/<base> HEAD` → success means a clean
-     fast-forward, zero conflict potential.
-   - Otherwise dry-run: `git merge-tree $(git merge-base HEAD origin/<base>)
-     origin/<base> HEAD` and confirm no `<<<<<<<` / "changed in both" markers.
+     fast-forward: git fast-forwards without running a merge, so conflicts are
+     impossible. This alone is sufficient.
+   - Otherwise (base moved, not yet rebased) dry-run with the modern form and
+     trust its **exit code**: `git merge-tree --write-tree origin/<base> HEAD`
+     (exit 0 = clean; non-zero = conflicts; add `--name-only` to list the
+     conflicted paths). Do **not** grep the old three-arg output for
+     `<<<<<<<` / "changed in both" — that false-positives on files which
+     legitimately contain those literals (docs about merge conflicts, test
+     fixtures — this very skill tripped that check when it was first run).
 5. **Green check.** Run the project's tests/build (here: `bun test`, plus
    `bun build <file> --target=bun` for type-checking touched files). Report
    **honestly**: distinguish failures you caused from pre-existing ones (diff the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,3 +62,5 @@ a background subagent, not the foreground.
 
 - Migration plan + cross-repo coordination: `docs/folio-assistant-migration.md`.
 - Skills live under `skills/` (packages) and `.claude/skills/` (local + capabilities).
+- Shipping a branch — verify → confirm mergeable → push → (only if asked) open a
+  PR via the deferred GitHub MCP tools: `.claude/skills/local/prepare-merge.md`.

--- a/adapters/mcp-server/server.ts
+++ b/adapters/mcp-server/server.ts
@@ -241,7 +241,7 @@ import {
   leanPackageByName,
   parseLeanRef,
   type ParsedLeanRef,
-} from "../../folio-assistant/schemas/lean-packages.js";
+} from "../../schemas/lean-packages.js";
 
 /**
  * Parse a block's `lean.ref` URI; returns `undefined` on missing or

--- a/content/pipeline/bib-qa.ts
+++ b/content/pipeline/bib-qa.ts
@@ -353,13 +353,13 @@ async function checkUrl(
 
 // ── Verification status (added 2026-05-19; Verifier union 2026-05-31) ───
 //
-// The canonical schema lives in folio-assistant/schemas/bib-verification.ts.
+// The canonical schema lives in schemas/bib-verification.ts.
 // We re-declare the consumer-side shape here to avoid a content/pipeline →
 // folio-assistant import edge (the content pipeline must stay in the
 // content/ tree).  The shapes must stay in sync.
 
-import type { Verifier, VerificationStatus } from "../../folio-assistant/schemas/bib-verification";
-import { verifierLabel } from "../../folio-assistant/schemas/bib-verification";
+import type { Verifier, VerificationStatus } from "../../schemas/bib-verification";
+import { verifierLabel } from "../../schemas/bib-verification";
 
 interface VerificationEntry {
   id: string;

--- a/content/pipeline/conditional-class-banner-audit.ts
+++ b/content/pipeline/conditional-class-banner-audit.ts
@@ -29,7 +29,7 @@
 import { readdir, readFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { leanPackageByName } from "../../folio-assistant/schemas/lean-packages.ts";
+import { leanPackageByName } from "../../schemas/lean-packages.ts";
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(SCRIPT_DIR, "..", "..");

--- a/content/pipeline/conjectural-propagation-audit.ts
+++ b/content/pipeline/conjectural-propagation-audit.ts
@@ -22,7 +22,7 @@
 import { readdir, readFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { leanPackageByName } from "../../folio-assistant/schemas/lean-packages.ts";
+import { leanPackageByName } from "../../schemas/lean-packages.ts";
 
 // Resolve repo root from this script's location:
 // content/pipeline/conjectural-propagation-audit.ts → repo root.

--- a/content/pipeline/export-bibtex.ts
+++ b/content/pipeline/export-bibtex.ts
@@ -28,8 +28,8 @@ const outPath = outIdx >= 0 ? resolve(args[outIdx + 1]) : join(REPO_ROOT, "refer
 // `annotation = {...}` field that LaTeX / biblatex / pandoc can
 // display in the rendered bibliography.
 
-import type { Verifier } from "../../folio-assistant/schemas/bib-verification";
-import { verifierLabel } from "../../folio-assistant/schemas/bib-verification";
+import type { Verifier } from "../../schemas/bib-verification";
+import { verifierLabel } from "../../schemas/bib-verification";
 
 interface VerifEntry {
   id: string;

--- a/content/pipeline/export-json.ts
+++ b/content/pipeline/export-json.ts
@@ -31,7 +31,7 @@ import type { Data as CSLData } from "csl-json";
 import { references, referenceMap } from "../../schemas/references";
 import { mergeCitations } from "./citations";
 import { isWitnessed, leanFileHash } from "../../scripts/lean-witness";
-import { leanPackageByName, parseLeanRef } from "../../folio-assistant/schemas/lean-packages";
+import { leanPackageByName, parseLeanRef } from "../../schemas/lean-packages";
 
 const REPO_ROOT = resolve(import.meta.dir, "../..");
 const CONTENT_ROOT = join(REPO_ROOT, "content");

--- a/content/pipeline/migrate-lean-refs.ts
+++ b/content/pipeline/migrate-lean-refs.ts
@@ -4,7 +4,7 @@
  *                   → `lean: { ref: "qou:QOU.Foo", ... }`
  *
  * Mapping from paper directory to package prefix is derived from
- * `folio-assistant/schemas/lean-packages.ts` (LEAN_PACKAGES).
+ * `schemas/lean-packages.ts` (LEAN_PACKAGES).
  *
  * Transforms every `.ts` under `content/` that contains a `decl:` field
  * inside a `lean:` object.  The `file:` field is dropped (it was only
@@ -22,7 +22,7 @@
 
 import { readdirSync, readFileSync, statSync, writeFileSync } from "fs";
 import { join, relative } from "path";
-import { LEAN_PACKAGES } from "../../folio-assistant/schemas/lean-packages";
+import { LEAN_PACKAGES } from "../../schemas/lean-packages";
 
 const REPO_ROOT = join(import.meta.dir, "..", "..");
 const CONTENT_ROOT = join(REPO_ROOT, "content");

--- a/content/pipeline/proof-narrative-lean-equiv-sweep.ts
+++ b/content/pipeline/proof-narrative-lean-equiv-sweep.ts
@@ -26,7 +26,7 @@ import {
 import type {
   BlockQaReport,
   QaCriterionEntry,
-} from "../../folio-assistant/schemas/block-qa";
+} from "../../schemas/block-qa";
 
 const __filename = fileURLToPath(import.meta.url);
 const REPO_ROOT = resolve(dirname(__filename), "..", "..");

--- a/content/pipeline/q-usage-audit.ts
+++ b/content/pipeline/q-usage-audit.ts
@@ -23,22 +23,30 @@
  * @module content/pipeline/q-usage-audit
  */
 
-import { existsSync, readdirSync, readFileSync, statSync, writeFileSync, mkdirSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { createHash } from "node:crypto";
-import { dirname, join, resolve, basename, relative } from "node:path";
+import { dirname, join, resolve, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   Q_USAGE_AUTOMATED_CHECKERS,
   Q_USAGE_CRITERION_IDS,
   CHAPTER_EXPECTED_REGIMES,
+  chapterFromPath,
+  detectRegimes,
+  checkQUsagePositivityImplicit,
   type QRegime,
   type QUsageResult,
 } from "./qa-checkers-q-usage.ts";
+import { checkWallSide, checkBaseRingMinimal } from "./qa-checkers-voice.ts";
+// Single source of truth for block discovery + candidate-1→candidate-2
+// `lean.ref` resolution + library-tree enumeration. q-usage-audit MUST
+// NOT reimplement these (it used to carry a private copy — removed so the
+// resolution logic can never drift from qa-sweep / qa-utils).
 import {
-  LEAN_PACKAGES,
-  parseLeanRef,
-  leanPackageByName,
-} from "../../folio-assistant/schemas/lean-packages.ts";
+  walkBlocks as utilWalkBlocks,
+  resolveCanonicalLean,
+  listPackageLeanFiles,
+} from "./qa-utils.ts";
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(SCRIPT_DIR, "..", "..");
@@ -50,6 +58,7 @@ const args = process.argv.slice(2);
 const noWrite = args.includes("--no-write");
 const strict = args.includes("--strict");
 const jsonReport = args.includes("--json");
+const noOrphans = args.includes("--no-orphans");
 const chapterFilterIdx = args.indexOf("--chapter");
 const chapterFilter = chapterFilterIdx >= 0 ? args[chapterFilterIdx + 1] : undefined;
 
@@ -64,120 +73,28 @@ interface BlockTriple {
   lean?: string;
 }
 
-const PROVABLE_KINDS = new Set([
-  "definition",
-  "theorem",
-  "lemma",
-  "proposition",
-  "corollary",
-  "conjecture",
-  "remark",
-  "example",
-  "simulator",
-  "prose",
-  "diagram",
-  "equation",
-]);
-
+/**
+ * Discover every content block under PAPER_ROOT via the shared
+ * `qa-utils.walkBlocks` — the single source of truth for block discovery
+ * AND candidate-1 (sibling) → candidate-2 (library/Lake tree) `lean.ref`
+ * resolution. The owning chapter is read from the block's `.ts` path, NOT
+ * from the resolved Lean file's directory, so the regime profile stays
+ * content-based (CLAUDE.md §7c — never infer the regime from the
+ * lean-tree directory name).
+ */
 function walkBlocks(): BlockTriple[] {
   const out: BlockTriple[] = [];
-
-  // Per-Lake-package basename cache. Some blocks have been promoted
-  // from sibling .lean files into the Lake-buildable tree (per the
-  // cluster-migration pattern, e.g. lean/QOU/BraidKnot/...). When the
-  // sibling check fails, fall back to resolving the lean.ref URI via
-  // (a) the parsed module path, or (b) a basename match anywhere
-  // under the package's Lake root.
-  const lakeTreeBasenameCache = new Map<string, Set<string>>();
-  function lakeTreeContains(lakeRoot: string, base: string): boolean {
-    const abs = resolve(REPO_ROOT, lakeRoot);
-    let cached = lakeTreeBasenameCache.get(abs);
-    if (!cached) {
-      cached = new Set<string>();
-      try {
-        const stack: string[] = [abs];
-        while (stack.length) {
-          const dir = stack.pop()!;
-          for (const e of readdirSync(dir, { withFileTypes: true })) {
-            const full = join(dir, e.name);
-            if (e.isDirectory()) stack.push(full);
-            else if (e.isFile() && e.name.endsWith(".lean")) cached.add(e.name);
-          }
-        }
-      } catch { /* Lake root missing — empty cache */ }
-      lakeTreeBasenameCache.set(abs, cached);
-    }
-    return cached.has(base);
-  }
-  function resolveLakeTreePath(ref: string | undefined): string | undefined {
-    if (!ref) return undefined;
-    try {
-      const parsed = parseLeanRef(ref);
-      const pkg = leanPackageByName(parsed.package);
-      if (!pkg) return undefined;
-      // Try direct module-path resolution first.
-      const modulePath = parsed.module.replace(/\./g, "/");
-      const direct = resolve(REPO_ROOT, pkg.lakeRoot, `${modulePath}.lean`);
-      if (existsSync(direct)) return direct;
-      // Basename fallback under the Lake tree.
-      if (lakeTreeContains(pkg.lakeRoot, `${parsed.name}.lean`)) {
-        // Find the actual path via scan.
-        const stack: string[] = [resolve(REPO_ROOT, pkg.lakeRoot)];
-        while (stack.length) {
-          const dir = stack.pop()!;
-          for (const e of readdirSync(dir, { withFileTypes: true })) {
-            const full = join(dir, e.name);
-            if (e.isDirectory()) stack.push(full);
-            else if (e.isFile() && e.name === `${parsed.name}.lean`) return full;
-          }
-        }
-      }
-    } catch { /* parseLeanRef failed — fall through */ }
-    return undefined;
-  }
-
-  const chapters = readdirSync(PAPER_ROOT, { withFileTypes: true })
-    .filter((d) => d.isDirectory())
-    .map((d) => d.name);
-  for (const chapter of chapters) {
+  for (const b of utilWalkBlocks(PAPER_ROOT)) {
+    const chapter = chapterFromPath(b.ts) ?? "";
     if (chapterFilter && chapter !== chapterFilter) continue;
-    const chDir = join(PAPER_ROOT, chapter);
-    let files: string[];
-    try {
-      files = readdirSync(chDir);
-    } catch {
-      continue;
-    }
-    for (const f of files) {
-      if (!f.endsWith(".ts")) continue;
-      if (f === `${chapter}.ts`) continue; // chapter manifest, not a block
-      const tsPath = join(chDir, f);
-      const root = f.replace(/\.ts$/, "");
-      const mdPath = join(chDir, `${root}.md`);
-      const leanPath = join(chDir, `${root}.lean`);
-      const ts = readFileSync(tsPath, "utf-8");
-      const kindMatch = ts.match(
-        /export\s+default\s+(definition|theorem|lemma|proposition|corollary|conjecture|remark|example|simulator|prose|diagram|equation)\s*\(/,
-      );
-      if (!kindMatch) continue;
-      const kind = kindMatch[1];
-      const labelMatch = ts.match(/label:\s*["']([^"']+)["']/);
-      const label = labelMatch ? labelMatch[1] : root;
-      // Resolve .lean: (1) sibling, (2) Lake-tree mirror via lean.ref.
-      let leanResolved: string | undefined = existsSync(leanPath) ? leanPath : undefined;
-      if (!leanResolved) {
-        const refMatch = ts.match(/ref:\s*["']([^"']+)["']/);
-        leanResolved = resolveLakeTreePath(refMatch?.[1]);
-      }
-      out.push({
-        label,
-        kind,
-        chapter,
-        ts: tsPath,
-        md: existsSync(mdPath) ? mdPath : undefined,
-        lean: leanResolved,
-      });
-    }
+    out.push({
+      label: b.label,
+      kind: b.kind,
+      chapter,
+      ts: b.ts,
+      md: b.md,
+      lean: b.lean,
+    });
   }
   return out;
 }
@@ -409,10 +326,83 @@ function hasHumanDispensation(
   return false;
 }
 
+// ── Orphan library-tree coverage ────────────────────────────────
+//
+// Block-driven auditing only reaches Lean files referenced by some
+// block's `lean.ref`. Library-tree files that NO block references
+// (orphans) would otherwise go unswept — exactly how a gratuitous
+// `(q : ℝ)` can slip in unseen. We audit them with the CONTENT-BASED,
+// chapter-INDEPENDENT checkers only: an orphan has no owning content
+// block, hence no chapter, and CLAUDE.md §7c forbids inferring the
+// regime from the lean-tree directory name (the path heuristic
+// over-fires — `lean/QOU/BraidKnot/` legitimately holds archimedean
+// files like the QBeta ladder). So the chapter-relative checkers
+// (`*-in-categorical-chapter`, `fixed-q0-leak`, `narrative-chapter-
+// mismatch`) are NOT run on orphans; only same-file content signals are:
+//   - wall-side-correct          — mixed archimedean + generic-R in one file
+//   - wall-base-ring-minimal     — field/inverse restatable over ℤ[q,q⁻¹]
+//   - q-usage-positivity-implicit — Real.* on q without a positivity hyp
+// plus the detected regime vector (reported, never used to fail).
+
+/** Minimal shape shared by CheckerResult and QUsageResult. */
+type MiniResult = {
+  result: "pass" | "fail" | "warn" | "n/a";
+  hits: Array<{ file: string; line: number; text: string }>;
+};
+
+interface OrphanFinding {
+  file: string;
+  criterion: string;
+  result: "fail" | "warn";
+  regimes: string[];
+  evidence: string;
+}
+
+export function scanOrphanLeanFiles(coveredLean: Set<string>): {
+  scanned: number;
+  orphans: number;
+  findings: OrphanFinding[];
+} {
+  const all = listPackageLeanFiles(REPO_ROOT);
+  const findings: OrphanFinding[] = [];
+  let orphans = 0;
+  for (const file of all) {
+    if (coveredLean.has(resolve(file))) continue; // referenced by a block
+    orphans++;
+    const regimes = [
+      ...detectRegimes(undefined, undefined, file).regimes,
+    ].sort();
+    const checks: Array<{ id: string; r: MiniResult }> = [
+      { id: "wall-side-correct", r: checkWallSide(undefined, file) },
+      { id: "wall-base-ring-minimal", r: checkBaseRingMinimal(file) },
+      {
+        id: "q-usage-positivity-implicit",
+        r: checkQUsagePositivityImplicit(undefined, undefined, file),
+      },
+    ];
+    for (const { id, r } of checks) {
+      if (r.result === "fail" || r.result === "warn") {
+        findings.push({
+          file: relative(REPO_ROOT, file),
+          criterion: id,
+          result: r.result,
+          regimes,
+          evidence: r.hits
+            .slice(0, 3)
+            .map((h) => `${relative(REPO_ROOT, h.file)}:${h.line} — ${h.text}`)
+            .join(" | "),
+        });
+      }
+    }
+  }
+  return { scanned: all.length, orphans, findings };
+}
+
 function main(): void {
   const blocks = walkBlocks();
   const stats: Map<string, ChapterStat> = new Map();
   const findings: BlockFinding[] = [];
+  const coveredLean = new Set<string>();
   let touchedSidecars = 0;
   let dispensationsHonored = 0;
 
@@ -426,6 +416,7 @@ function main(): void {
       regime_dist: {},
     };
     stat.n_blocks++;
+    if (b.lean) coveredLean.add(resolve(b.lean));
     const currentHashes = {
       ts: hashFile(b.ts),
       md: b.md ? hashFile(b.md) : undefined,
@@ -476,6 +467,14 @@ function main(): void {
     if (!noWrite) touchedSidecars++;
   }
 
+  // Orphan library-tree coverage — Lean files reachable by no block's
+  // lean.ref. Skipped for a single-chapter run (--chapter) since the
+  // library tree is paper-wide, and on demand via --no-orphans.
+  const orphan =
+    noOrphans || chapterFilter
+      ? { scanned: 0, orphans: 0, findings: [] as OrphanFinding[] }
+      : scanOrphanLeanFiles(coveredLean);
+
   // Global witness
   const witnessPath = join(
     REPO_ROOT,
@@ -485,7 +484,9 @@ function main(): void {
   );
   const witness = {
     $schema: "q-usage-audit/v1",
-    description: "Per-block q-usage regime audit + chapter-mismatch sweep",
+    description:
+      "Per-block q-usage regime audit + chapter-mismatch sweep + orphan " +
+      "library-tree coverage (content-based, chapter-independent)",
     audited_at: NOW_ISO,
     script: SCRIPT_PATH,
     script_hash: SCRIPT_HASH,
@@ -493,6 +494,9 @@ function main(): void {
     n_chapters: stats.size,
     n_fails: findings.filter((f) => f.result === "fail").length,
     n_warns: findings.filter((f) => f.result === "warn").length,
+    lean_tree_scanned: orphan.scanned,
+    n_orphan_files: orphan.orphans,
+    n_orphan_findings: orphan.findings.length,
     by_chapter: Object.fromEntries(
       [...stats.entries()].sort().map(([k, v]) => [k, v]),
     ),
@@ -503,6 +507,9 @@ function main(): void {
       if (da !== db) return da - db;
       return (a.chapter + a.label).localeCompare(b.chapter + b.label);
     }),
+    orphan_findings: orphan.findings.sort((a, b) =>
+      a.file.localeCompare(b.file) || a.criterion.localeCompare(b.criterion),
+    ),
   };
   if (!noWrite) {
     mkdirSync(dirname(witnessPath), { recursive: true });
@@ -516,6 +523,11 @@ function main(): void {
     console.error(
       `  fails=${witness.n_fails}  warns=${witness.n_warns}  sidecars-touched=${touchedSidecars}  dispensations-honored=${dispensationsHonored}`,
     );
+    if (!noOrphans && !chapterFilter) {
+      console.error(
+        `  lean-tree-scanned=${orphan.scanned}  orphan-files=${orphan.orphans}  orphan-findings=${orphan.findings.length}`,
+      );
+    }
     console.error("");
     console.error("Chapter regime distribution (top tags only):");
     for (const stat of [...stats.values()].sort((a, b) => a.chapter.localeCompare(b.chapter))) {
@@ -537,13 +549,29 @@ function main(): void {
     if (witness.findings.length > 40) {
       console.error(`  …and ${witness.findings.length - 40} more (see witness JSON)`);
     }
+    if (orphan.findings.length > 0) {
+      console.error("");
+      console.error("Orphan library-tree findings (no owning block):");
+      for (const f of orphan.findings.slice(0, 40)) {
+        console.error(`  [${f.result.padEnd(4)}] ${f.criterion}  ${f.file}  [${f.regimes.join(",")}]`);
+        if (f.evidence) console.error(`            ${f.evidence.slice(0, 200)}`);
+      }
+      if (orphan.findings.length > 40) {
+        console.error(`  …and ${orphan.findings.length - 40} more (see witness JSON)`);
+      }
+    }
     if (!noWrite) {
       console.error("");
       console.error(`Witness written to ${relative(REPO_ROOT, witnessPath)}`);
     }
   }
 
-  if (strict && witness.n_fails > 0) process.exit(1);
+  // Orphan `fail`s are real §7c violations (mixed-substrate files); count
+  // them toward strict exit. Orphan `warn`s (base-ring advisories) do not.
+  const orphanFails = orphan.findings.filter((f) => f.result === "fail").length;
+  if (strict && witness.n_fails + orphanFails > 0) process.exit(1);
 }
 
-main();
+// Run as a CLI only when invoked directly; importing the module (e.g. in
+// tests) must not execute the audit or write a witness.
+if (import.meta.main) main();

--- a/content/pipeline/qa-criteria-registry.ts
+++ b/content/pipeline/qa-criteria-registry.ts
@@ -280,6 +280,14 @@ const WALL: QaCriterionDefinition[] = [
     // The automated checker scans .lean imports and the .md narrative
     // for an archimedean acknowledgement banner. The .ts manifest is
     // not read — kept out of depends_on to avoid spurious staleness.
+    //
+    // Coverage scope: the `.lean` read here is the block's *resolved*
+    // file — candidate-1 sibling OR candidate-2 library/Lake-tree module
+    // named by `lean.ref` (`qa-utils.resolveCanonicalLean`, the single
+    // resolver shared with qa-sweep + q-usage-audit). Library-tree
+    // declarations referenced by a block are therefore in scope. Files
+    // referenced by NO block (orphans) are swept separately, content-
+    // based + chapter-independent, by `q-usage-audit`'s orphan pass.
     depends_on: ["md", "lean"],
     automated: true,
   },
@@ -426,6 +434,13 @@ const Q_USAGE: QaCriterionDefinition[] = [
     // present on nearly every block so anchoring on md catches the
     // common case without forcing n/a on lean-less blocks
     // (#1640-Copilot @ qa-criteria-registry.ts:333).
+    //
+    // Coverage scope: the lean side is the block's *resolved* file —
+    // sibling OR library/Lake-tree module via `lean.ref`
+    // (`qa-utils.resolveCanonicalLean`). The chapter profile is derived
+    // from the owning block's path, NEVER the lean-tree directory, so a
+    // library decl is audited against its referencing chapter's regime
+    // (CLAUDE.md §7c — do not infer the regime from the lean-tree path).
     depends_on: ["md"],
     automated: true,
     source_file: "content/pipeline/qa-checkers-q-usage.ts",
@@ -1234,7 +1249,7 @@ const BIBLIOGRAPHY: QaCriterionDefinition[] = [
 //
 // Audits **script files** (not content blocks). Sidecar is
 // per-script `.script-qa.json`, schema in
-// `folio-assistant/schemas/script-qa.ts`. Driven by
+// `schemas/script-qa.ts`. Driven by
 // `content/pipeline/script-sweep.ts`.
 //
 // Planned criteria (one PR per checker):

--- a/content/pipeline/qa-merge-findings.ts
+++ b/content/pipeline/qa-merge-findings.ts
@@ -45,7 +45,7 @@ import type {
   BlockQaReport,
   QaCriterionEntry,
   QaReviewer,
-} from "../../folio-assistant/schemas/block-qa";
+} from "../../schemas/block-qa";
 
 interface FindingInput {
   block_md?: string;

--- a/content/pipeline/qa-utils.ts
+++ b/content/pipeline/qa-utils.ts
@@ -17,6 +17,7 @@ import { execFileSync } from "child_process";
 import {
   parseLeanRef,
   leanPackageByName,
+  LEAN_PACKAGES,
 } from "../../schemas/lean-packages";
 import { mkdirSync } from "fs";
 import { dirname } from "path";
@@ -206,7 +207,59 @@ export function computeCriterionScriptHashes(
   };
 }
 
-// ── Canonical lean.ref resolution ───────────────────────────────
+// ── Canonical lean.ref resolution (single source of truth) ──────
+//
+// This is THE resolver for `lean.ref` → on-disk Lean file. Every QA
+// consumer — `walkBlocks` (used by qa-sweep), `q-usage-audit`,
+// `qa-agent-write`, and orphan-coverage scans — routes through
+// `resolveCanonicalLean` so the candidate-1 (sibling) → candidate-2
+// (Lake/library tree) resolution can never drift between tools. Do not
+// reimplement this walk anywhere else; pass a `LakeTreeCache` for bulk
+// callers and reuse the same function.
+
+/**
+ * Per-package basename → first-path index for one Lake root, keyed by
+ * the absolute Lake-root path. Bulk callers (walking many blocks) build
+ * this once and reuse it so the library tree is scanned a single time
+ * rather than once per ref.
+ */
+export type LakeTreeCache = Map<string, Map<string, string>>;
+
+/** Walk one Lake root once, indexing `*.lean` basename → absolute path. */
+function buildLakeBasenameMap(absRoot: string): Map<string, string> {
+  const map = new Map<string, string>();
+  try {
+    const stack: string[] = [absRoot];
+    while (stack.length) {
+      const dir = stack.pop()!;
+      for (const e of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, e.name);
+        if (e.isDirectory()) stack.push(full);
+        // First occurrence wins for ambiguous basenames; the common
+        // case (one file per basename) is unambiguous.
+        else if (e.isFile() && e.name.endsWith(".lean") && !map.has(e.name))
+          map.set(e.name, full);
+      }
+    }
+  } catch {
+    /* Lake root missing — empty map */
+  }
+  return map;
+}
+
+/** Fetch (or lazily build + cache) the basename index for a Lake root. */
+function lakeBasenameMap(
+  absRoot: string,
+  cache?: LakeTreeCache,
+): Map<string, string> {
+  if (!cache) return buildLakeBasenameMap(absRoot);
+  let m = cache.get(absRoot);
+  if (!m) {
+    m = buildLakeBasenameMap(absRoot);
+    cache.set(absRoot, m);
+  }
+  return m;
+}
 
 /**
  * Resolve a content block's package-qualified `lean.ref` URI (e.g.
@@ -222,14 +275,15 @@ export function computeCriterionScriptHashes(
  * declaration rather than an uncompiled sibling stub: a content block's
  * `<root>.lean` may be a `True := by trivial` placeholder while the real
  * statement lives in the library module named by `lean.ref` (CLAUDE.md
- * §3b-cond — the sibling stub is not the integrity gate). `walkBlocks`
- * applies the same fallback (with a per-package basename cache) on the
- * read path; this standalone form serves single-block callers such as
- * `qa-agent-write`.
+ * §3b-cond — the sibling stub is not the integrity gate).
+ *
+ * Pass a shared `cache` when resolving many refs (e.g. a corpus sweep)
+ * so the Lake tree is scanned once; omit it for single-block callers.
  */
 export function resolveCanonicalLean(
   ref: string | undefined,
   repoRoot: string,
+  cache?: LakeTreeCache,
 ): string | undefined {
   if (!ref) return undefined;
   let parsed: ReturnType<typeof parseLeanRef>;
@@ -247,23 +301,37 @@ export function resolveCanonicalLean(
     `${parsed.module.replace(/\./g, "/")}.lean`,
   );
   if (existsSync(direct)) return direct;
-  // (b) Basename fallback under the Lake tree (uncached — single-use).
-  const target = `${parsed.name}.lean`;
+  // (b) Basename fallback under the Lake tree.
   const lakeRootAbs = resolve(repoRoot, pkg.lakeRoot);
-  const stack: string[] = [lakeRootAbs];
-  try {
-    while (stack.length) {
-      const dir = stack.pop()!;
-      for (const e of readdirSync(dir, { withFileTypes: true })) {
-        const full = join(dir, e.name);
-        if (e.isDirectory()) stack.push(full);
-        else if (e.isFile() && e.name === target) return full;
+  return lakeBasenameMap(lakeRootAbs, cache).get(`${parsed.name}.lean`);
+}
+
+/**
+ * Enumerate every `*.lean` file under every configured package's Lake
+ * tree (absolute paths). Single source for "what library-tree files
+ * exist", consumed by orphan-coverage scans that audit Lean files
+ * reachable by **no** block's `lean.ref`. Returns `[]` when no packages
+ * are configured (e.g. the framework repo with no content injected).
+ */
+export function listPackageLeanFiles(repoRoot: string): string[] {
+  const out: string[] = [];
+  for (const pkg of LEAN_PACKAGES) {
+    const absRoot = resolve(repoRoot, pkg.lakeRoot);
+    try {
+      const stack: string[] = [absRoot];
+      while (stack.length) {
+        const dir = stack.pop()!;
+        for (const e of readdirSync(dir, { withFileTypes: true })) {
+          const full = join(dir, e.name);
+          if (e.isDirectory()) stack.push(full);
+          else if (e.isFile() && e.name.endsWith(".lean")) out.push(full);
+        }
       }
+    } catch {
+      /* Lake root missing — skip this package */
     }
-  } catch {
-    /* Lake root missing */
   }
-  return undefined;
+  return out;
 }
 
 // ── Block discovery ─────────────────────────────────────────────
@@ -310,56 +378,16 @@ export function readBlockManifest(
  * file that is not a single-block manifest.
  */
 export function* walkBlocks(rootDir: string): Generator<BlockPaths> {
-  // Per-Lake-package basename cache, populated lazily.  When a block's
-  // sibling `<root>.lean` is missing but its `lean.ref` URI points at
-  // a file in the package's Lake tree (the cluster-migration pattern,
-  // e.g. lean/QOU/BraidKnot/MarkovAxiomsPrimitive.lean), fall back to
-  // resolving the Lake-tree path so qa-checkers that consume the
+  // When a block's sibling `<root>.lean` is missing but its `lean.ref`
+  // URI points at a file in the package's Lake tree (the cluster-
+  // migration pattern, e.g. lean/QOU/BraidKnot/MarkovAxiomsPrimitive.lean),
+  // fall back to the canonical resolver so qa-checkers that consume the
   // .lean source (wall-side, voice, q-usage, …) don't silently skip.
+  // `resolveCanonicalLean` is the single source of truth for that walk;
+  // a shared cache scans each Lake tree once across the whole block walk.
   // Resolve REPO_ROOT relative to qa-utils.ts (= content/pipeline/).
   const REPO_ROOT = resolve(import.meta.dir, "../..");
-  const lakeTreeBasenameToPath = new Map<string, Map<string, string>>();
-  function lakeTreePathFor(
-    lakeRoot: string,
-    base: string,
-  ): string | undefined {
-    const absRoot = resolve(REPO_ROOT, lakeRoot);
-    let cached = lakeTreeBasenameToPath.get(absRoot);
-    if (!cached) {
-      cached = new Map<string, string>();
-      try {
-        const stack: string[] = [absRoot];
-        while (stack.length) {
-          const dir = stack.pop()!;
-          for (const e of readdirSync(dir, { withFileTypes: true })) {
-            const full = join(dir, e.name);
-            if (e.isDirectory()) stack.push(full);
-            else if (e.isFile() && e.name.endsWith(".lean")) {
-              // First occurrence wins for ambiguous basenames; the
-              // common case (one file per basename) is unambiguous.
-              if (!cached.has(e.name)) cached.set(e.name, full);
-            }
-          }
-        }
-      } catch { /* Lake root missing — empty map */ }
-      lakeTreeBasenameToPath.set(absRoot, cached);
-    }
-    return cached.get(base);
-  }
-  function resolveLakeTreeLean(ref: string | undefined): string | undefined {
-    if (!ref) return undefined;
-    try {
-      const parsed = parseLeanRef(ref);
-      const pkg = leanPackageByName(parsed.package);
-      if (!pkg) return undefined;
-      // (a) Direct module-path resolution.
-      const modulePath = parsed.module.replace(/\./g, "/");
-      const direct = resolve(REPO_ROOT, pkg.lakeRoot, `${modulePath}.lean`);
-      if (existsSync(direct)) return direct;
-      // (b) Basename fallback under the Lake tree.
-      return lakeTreePathFor(pkg.lakeRoot, `${parsed.name}.lean`);
-    } catch { return undefined; }
-  }
+  const lakeCache: LakeTreeCache = new Map();
 
   function* recurse(d: string): Generator<BlockPaths> {
     if (!existsSync(d)) return;
@@ -385,7 +413,7 @@ export function* walkBlocks(rootDir: string): Generator<BlockPaths> {
           // via a regex over the raw file (mirrors q-usage-audit).
           const tsSrc = readFileSync(full, "utf-8");
           const refMatch = tsSrc.match(/ref:\s*["']([^"']+)["']/);
-          leanResolved = resolveLakeTreeLean(refMatch?.[1]);
+          leanResolved = resolveCanonicalLean(refMatch?.[1], REPO_ROOT, lakeCache);
         }
         yield {
           label: manifest.label,

--- a/scripts/tests/lean-ref-coverage.test.ts
+++ b/scripts/tests/lean-ref-coverage.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Regression tests for §7c Lean library-tree QA coverage.
+ *
+ * Locks in three properties so they cannot silently regress:
+ *
+ *   1. Candidate-1 (sibling) → candidate-2 (library/Lake tree) `lean.ref`
+ *      resolution via the SINGLE resolver `resolveCanonicalLean`, and that
+ *      the q-usage / wall-side checkers audit the *resolved* library file
+ *      (not just a chapter-dir sibling). This is the coverage the
+ *      `2026-06-25-lean-library-tree-7c-coverage-gap` audit feared was
+ *      missing — it is present and proven here.
+ *   2. Orphan library-tree coverage: Lean files referenced by no block are
+ *      audited with content-based, chapter-INDEPENDENT checkers only
+ *      (CLAUDE.md §7c — never infer the regime from the lean-tree path).
+ *   3. Hygiene guards: no imports reference the non-existent
+ *      `folio-assistant/schemas/...` path, and `q-usage-audit` carries no
+ *      private re-implementation of the resolver/walker (single source of
+ *      truth lives in `qa-utils`).
+ *
+ * Deliberately does NOT import `./helpers` (it pulls an optional
+ * `@unified-latex` dep absent in some envs); these tests are self-contained.
+ *
+ *     cd scripts/tests && bun test lean-ref-coverage.test.ts
+ */
+
+import { describe, test, expect } from "bun:test";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join, resolve, relative } from "path";
+
+import {
+  walkBlocks,
+  resolveCanonicalLean,
+  listPackageLeanFiles,
+} from "../../content/pipeline/qa-utils.ts";
+import { checkWallSide } from "../../content/pipeline/qa-checkers-voice.ts";
+import { checkQUsageArchimedeanInCategoricalChapter } from "../../content/pipeline/qa-checkers-q-usage.ts";
+import { scanOrphanLeanFiles } from "../../content/pipeline/q-usage-audit.ts";
+import { configureLeanPackages } from "../../schemas/lean-packages.ts";
+
+const REPO_ROOT = resolve(import.meta.dir, "..", "..");
+
+// ── Fixture helpers ─────────────────────────────────────────────
+
+/** Create a throwaway workspace with a `content/<paper>` tree + a `lean/` Lake tree. */
+function makeWorkspace(): { tmp: string; content: string; lake: string } {
+  const tmp = mkdtempSync(join(tmpdir(), "leancov-"));
+  const content = join(tmp, "content", "quantum-observable-universe");
+  const lake = join(tmp, "lean");
+  mkdirSync(content, { recursive: true });
+  mkdirSync(lake, { recursive: true });
+  // Register the qou package pointing at this workspace's Lake tree.
+  // lakeRoot is absolute, so resolve() ignores any repoRoot prefix.
+  configureLeanPackages([
+    { name: "qou", paperDir: "quantum-observable-universe", lakeRoot: lake, lib: "QOU" },
+  ]);
+  return { tmp, content, lake };
+}
+
+function writeLake(lake: string, modRelPath: string, body: string): string {
+  const abs = join(lake, modRelPath);
+  mkdirSync(join(abs, ".."), { recursive: true });
+  writeFileSync(abs, body, "utf-8");
+  return abs;
+}
+
+function writeBlock(
+  content: string,
+  chapter: string,
+  name: string,
+  opts: { ref?: string; sibling?: string; md?: string },
+): { ts: string } {
+  const dir = join(content, chapter);
+  mkdirSync(dir, { recursive: true });
+  const ts = join(dir, `${name}.ts`);
+  const leanClause = opts.ref ? `\n  lean: { ref: "${opts.ref}" },` : "";
+  writeFileSync(
+    ts,
+    `export default theorem({\n  label: "thm:${name}",${leanClause}\n});\n`,
+    "utf-8",
+  );
+  if (opts.md) writeFileSync(join(dir, `${name}.md`), opts.md, "utf-8");
+  if (opts.sibling) writeFileSync(join(dir, `${name}.lean`), opts.sibling, "utf-8");
+  return { ts };
+}
+
+// A gratuitously-archimedean algebraic lemma (the §7c smell): det=1 is
+// CommRing-universal, the [2]_q identity is over ℚ(q), yet typed over ℝ.
+const ARCHIMEDEAN_BODY = [
+  "import Mathlib",
+  "/-- det = 1 is CommRing-universal -/",
+  "theorem barEven_two (q : ℝ) : q + q = 2 * q := by ring",
+  "theorem det_one (q : ℝ) : True := by linarith [sq_nonneg q]",
+].join("\n");
+
+// A clean generic-R lemma — correctly stated over a type variable.
+const GENERIC_R_BODY = [
+  "import Mathlib",
+  "variable {R : Type*} [CommRing R]",
+  "theorem genId (q : R) : q = q := rfl",
+].join("\n");
+
+// A genuinely mixed file: BOTH generic-R AND archimedean in one module.
+const MIXED_BODY = [
+  "import Mathlib",
+  "variable {R : Type*} [CommRing R]",
+  "theorem gen (q : R) : q = q := rfl",
+  "theorem arch (q : ℝ) : 0 < q + 1 := by linarith [sq_nonneg q]",
+].join("\n");
+
+// ── 1. Candidate-2 resolution + audit of the resolved file ──────
+
+describe("lean.ref candidate-2 (library tree) resolution", () => {
+  test("sibling-less block resolves to the Lake-tree file and is audited", () => {
+    const { tmp, content, lake } = makeWorkspace();
+    try {
+      writeLake(lake, "QOU/BraidKnot/TauQuantumIntegerForm.lean", ARCHIMEDEAN_BODY);
+      const { ts } = writeBlock(content, "braids-and-knots", "tau-integer-form", {
+        ref: "qou:QOU.BraidKnot.TauQuantumIntegerForm",
+        md: "The bar-even identity holds over any commutative ring.\n",
+      });
+
+      const blocks = [...walkBlocks(join(tmp, "content"))];
+      const blk = blocks.find((b) => b.ts === ts);
+      expect(blk).toBeDefined();
+      // Resolved to the library tree — NOT a chapter-dir sibling (none exists).
+      expect(blk!.lean).toBeDefined();
+      expect(blk!.lean!.replace(/\\/g, "/")).toContain(
+        "/lean/QOU/BraidKnot/TauQuantumIntegerForm.lean",
+      );
+
+      // Both named checkers fail on the RESOLVED library content.
+      expect(checkWallSide(blk!.md, blk!.lean).result).toBe("fail");
+      const arch = checkQUsageArchimedeanInCategoricalChapter(
+        blk!.md,
+        blk!.ts,
+        blk!.lean,
+      );
+      expect(arch.result).toBe("fail");
+      // Chapter is content-based (from the block path), NOT the lean dir.
+      expect(arch.chapter).toBe("braids-and-knots");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("direct module-path resolution (candidate 2a)", () => {
+    const { tmp, lake } = makeWorkspace();
+    try {
+      const abs = writeLake(lake, "QOU/FluidDynamics/qBkm.lean", GENERIC_R_BODY);
+      const got = resolveCanonicalLean("qou:QOU.FluidDynamics.qBkm", REPO_ROOT);
+      expect(got).toBe(abs);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("sibling (candidate 1) wins over the library tree", () => {
+    const { tmp, content, lake } = makeWorkspace();
+    try {
+      writeLake(lake, "QOU/BraidKnot/Dup.lean", ARCHIMEDEAN_BODY);
+      const { ts } = writeBlock(content, "braids-and-knots", "dup", {
+        ref: "qou:QOU.BraidKnot.Dup",
+        sibling: GENERIC_R_BODY, // co-located sibling present
+      });
+      const blk = [...walkBlocks(join(tmp, "content"))].find((b) => b.ts === ts);
+      expect(blk!.lean!.replace(/\\/g, "/")).toContain("/braids-and-knots/dup.lean");
+      expect(blk!.lean!.replace(/\\/g, "/")).not.toContain("/lean/QOU/");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("unknown package / malformed ref resolves to undefined", () => {
+    makeWorkspace();
+    expect(resolveCanonicalLean("nope:QOU.X", REPO_ROOT)).toBeUndefined();
+    expect(resolveCanonicalLean("malformed-no-colon", REPO_ROOT)).toBeUndefined();
+    expect(resolveCanonicalLean(undefined, REPO_ROOT)).toBeUndefined();
+  });
+});
+
+// ── 2. Orphan library-tree coverage ─────────────────────────────
+
+describe("orphan library-tree coverage", () => {
+  test("an orphan mixed-substrate file is flagged; a referenced file is not scanned", () => {
+    const { tmp, lake } = makeWorkspace();
+    try {
+      const referenced = writeLake(lake, "QOU/Mathlib/Referenced.lean", GENERIC_R_BODY);
+      writeLake(lake, "QOU/BraidKnot/OrphanMixed.lean", MIXED_BODY);
+
+      // `referenced` stands in for a file some block's lean.ref resolves to.
+      const covered = new Set<string>([resolve(referenced)]);
+      const res = scanOrphanLeanFiles(covered);
+
+      expect(res.scanned).toBe(2);
+      expect(res.orphans).toBe(1); // only OrphanMixed
+      const wall = res.findings.filter((f) => f.criterion === "wall-side-correct");
+      expect(wall.length).toBe(1);
+      expect(wall[0].file.replace(/\\/g, "/")).toContain("OrphanMixed.lean");
+      // The referenced (clean, covered) file is never an orphan finding.
+      expect(res.findings.every((f) => !f.file.includes("Referenced"))).toBe(true);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("a clean generic-R orphan produces no findings (no path-based over-firing)", () => {
+    const { tmp, lake } = makeWorkspace();
+    try {
+      // Lives under BraidKnot/ — the catch-all dir the path heuristic
+      // over-fired on. Content is clean generic-R, so it must NOT flag.
+      writeLake(lake, "QOU/BraidKnot/CleanGeneric.lean", GENERIC_R_BODY);
+      const res = scanOrphanLeanFiles(new Set());
+      expect(res.orphans).toBe(1);
+      expect(res.findings.length).toBe(0);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("listPackageLeanFiles enumerates every .lean across the Lake tree", () => {
+    const { tmp, lake } = makeWorkspace();
+    try {
+      writeLake(lake, "QOU/A/One.lean", GENERIC_R_BODY);
+      writeLake(lake, "QOU/B/Two.lean", GENERIC_R_BODY);
+      const files = listPackageLeanFiles(REPO_ROOT).map((f) => f.replace(/\\/g, "/"));
+      expect(files.some((f) => f.endsWith("/QOU/A/One.lean"))).toBe(true);
+      expect(files.some((f) => f.endsWith("/QOU/B/Two.lean"))).toBe(true);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── 3. Hygiene / single-source-of-truth guards ──────────────────
+
+describe("import + SSOT hygiene guards", () => {
+  function tsFilesUnder(dir: string): string[] {
+    const out: string[] = [];
+    const abs = join(REPO_ROOT, dir);
+    const stack = [abs];
+    while (stack.length) {
+      const d = stack.pop()!;
+      let entries: string[];
+      try {
+        entries = readdirSync(d);
+      } catch {
+        continue;
+      }
+      for (const e of entries) {
+        if (e === "node_modules" || e === ".lake" || e.startsWith(".")) continue;
+        const full = join(d, e);
+        if (statSync(full).isDirectory()) stack.push(full);
+        else if (e.endsWith(".ts")) out.push(full);
+      }
+    }
+    return out;
+  }
+
+  test("no imports reference the non-existent folio-assistant/schemas path", () => {
+    const offenders: string[] = [];
+    for (const dir of ["content", "adapters", "schemas", "src", "scripts"]) {
+      for (const f of tsFilesUnder(dir)) {
+        const src = readFileSync(f, "utf-8");
+        for (const line of src.split("\n")) {
+          // Only flag actual import/export-from statements, not prose/comments.
+          if (
+            /^\s*(?:import|export)\b[^\n]*\bfrom\s+["'][^"']*folio-assistant\/schemas/.test(
+              line,
+            )
+          ) {
+            offenders.push(`${relative(REPO_ROOT, f)}: ${line.trim()}`);
+          }
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  test("q-usage-audit carries no private resolver/walker (single source of truth)", () => {
+    const src = readFileSync(
+      join(REPO_ROOT, "content/pipeline/q-usage-audit.ts"),
+      "utf-8",
+    );
+    expect(src).toContain('from "./qa-utils');
+    expect(src).not.toContain("function resolveLakeTreePath");
+    expect(src).not.toContain("function lakeTreeContains");
+  });
+});

--- a/src/qa-agent-write.ts
+++ b/src/qa-agent-write.ts
@@ -39,11 +39,11 @@ import {
   saveQaReport,
   readBlockManifest,
   resolveCanonicalLean,
-} from "../../content/pipeline/qa-utils";
+} from "../content/pipeline/qa-utils";
 import type {
   BlockQaReport,
   QaCriterionEntry,
-} from "../../schemas/block-qa";
+} from "../schemas/block-qa";
 
 const REPO_ROOT = resolve(import.meta.dir, "../..");
 


### PR DESCRIPTION
## Summary

Originated from a qou follow-up (audit `2026-06-25-lean-library-tree-7c-coverage-gap`, qou PR #2789) claiming the §7c QA checkers don't sweep the Lean **library tree**. Investigation shows that coverage **already exists** — both `wall-side-correct` and `q-usage-archimedean-in-categorical-chapter` audit the block's *resolved* Lean file (candidate-1 sibling → candidate-2 library/Lake tree via `lean.ref`). This PR makes that coverage **correct and maintainable**, and closes the one genuine hole (orphan library files).

## Correctness — absorbed-from-qou import artifacts
The `absorb platform infrastructure from qou` commit left imports pointing at a non-existent `folio-assistant/` subdir, leaving several pipeline scripts (incl. `q-usage-audit.ts`) **un-runnable** in this repo:
- Repoint 12 imports `../../folio-assistant/schemas/*` → `../../schemas/*` (10 files: lean-packages, block-qa, bib-verification).
- Fix two overshooting `../../` imports in `src/qa-agent-write.ts` (→ `../`).

## Single source of truth
- Collapse **3 duplicate** `lean.ref`→file resolvers into one cache-enabled `qa-utils.resolveCanonicalLean`; `walkBlocks` + `q-usage-audit` share it.
- `q-usage-audit` reuses `qa-utils.walkBlocks`; its private resolver/walker are removed.
- New single library-tree enumerator `qa-utils.listPackageLeanFiles`.

## Robustness — orphan coverage
`q-usage-audit` gains an orphan pass: library-tree files referenced by **no** block are swept with **content-based, chapter-independent** checkers only (`wall-side`, `wall-base-ring-minimal`, `q-usage-positivity-implicit`) — never path-based chapter inference (the directory heuristic over-fires per §7c). Reported in the witness as `orphan_findings`; orphan fails count toward `--strict`. `main()` is guarded by `import.meta.main` so the module is importable for tests.

## Tests
`scripts/tests/lean-ref-coverage.test.ts` (9 cases): candidate-1→2 resolution + audit of the resolved file, sibling precedence, orphan detection vs a clean generic-R file, plus import-hygiene + SSOT guards so the absorption breakage cannot recur. Full suite: **73 pass** (was 64); the 5 fail / 3 err are pre-existing and unrelated (`qa-checkers-python` logic case + missing `@unified-latex` dep).

## Notes
No checker **logic** changed → no `script_hash` bump or sidecar invalidation; block-level results are byte-identical. Registry scope notes added (the registry is not hashed into any `script_hash`/`deps_hash`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUnKeZE2YcdjGmTEcKA2Ng

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUnKeZE2YcdjGmTEcKA2Ng)_