### PR TITLE
follow-up: zero-width break + seam audit for formula-abutting-text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 
 # Generated files — regenerate with `npm run generate:all`
 schemas/generated/
+content/audit-tex-source.json

--- a/content/pipeline/audit-tex-source.ts
+++ b/content/pipeline/audit-tex-source.ts
@@ -30,8 +30,9 @@
  * @module content/pipeline/audit-tex-source
  */
 
-import { readFileSync, readdirSync, statSync, existsSync } from "fs";
+import { readFileSync, readdirSync, statSync, existsSync, writeFileSync } from "fs";
 import { resolve, join, relative } from "path";
+import { findMathTextSeams } from "./render-latex";
 
 const REPO_ROOT = resolve(import.meta.dir, "../..");
 const args = process.argv.slice(2);
@@ -209,6 +210,25 @@ function auditDoubleSubscripts(file: string) {
   }
 }
 
+// ── Rule: $…$word seam (a formula abutting a word with no space) ──────────────
+// A dropped space such as `$V$discharged` renders as one unbreakable box that
+// overflows a narrow table cell. The renderer bridges it with a zero-width break
+// (render-latex renderChildren), but a genuine typo still *reads* run-together,
+// so flag the seam to add the space in the source. Intentional suffixes
+// (`$n$th`), punctuation-led runs (`$\mathbb{Z}$-module`) and spaced text don't
+// match (shared detector: findMathTextSeams).
+function auditMathTextSeams(file: string) {
+  let seams: ReturnType<typeof findMathTextSeams>;
+  try {
+    seams = findMathTextSeams(readFileSync(file, "utf-8"));
+  } catch {
+    return;
+  }
+  for (const s of seams) {
+    report("math-text-seam", file, s.line, `formula abutting a word (missing space?): "${s.context}"`);
+  }
+}
+
 // ── Run ──────────────────────────────────────────────────────────────────────
 console.log("Auditing TeX-source hazards...");
 auditReferencesTs();
@@ -220,6 +240,7 @@ for (const f of mdFiles) {
   auditMarkdownTablePipes(f);
   auditMarkdownLinkInTexFence(f);
   auditDoubleSubscripts(f);
+  auditMathTextSeams(f);
 }
 
 // ── Report ───────────────────────────────────────────────────────────────────
@@ -228,6 +249,19 @@ for (const f of findings) {
   if (!byRule.has(f.rule)) byRule.set(f.rule, []);
   byRule.get(f.rule)!.push(f);
 }
+
+// Sidecar: machine-readable findings (e.g. the math-text-seam list) for
+// downstream tooling / a content-fix worklist. Written every run.
+const OUT_JSON = resolve(REPO_ROOT, "content/audit-tex-source.json");
+writeFileSync(
+  OUT_JSON,
+  JSON.stringify(
+    { total: findings.length, byRule: Object.fromEntries([...byRule].map(([r, i]) => [r, i.length])), findings },
+    null,
+    2,
+  ),
+);
+console.log(`Sidecar: ${relative(REPO_ROOT, OUT_JSON)}`);
 
 if (findings.length === 0) {
   console.log("✓ No TeX-source hazards detected.");

--- a/content/pipeline/render-latex.ts
+++ b/content/pipeline/render-latex.ts
@@ -868,24 +868,74 @@ function renderTable(node: any): string {
   return lines.join("\n");
 }
 
+/** An inline formula/code mdast node. */
+function isFormulaNode(n: any): boolean {
+  return !!n && (n.type === "inlineMath" || n.type === "inlineCode");
+}
+
+/**
+ * A formula/code node abutting a >=4-letter word with no space at the boundary
+ * in the source — a `$V$discharged`-style seam (a dropped space). Shared by
+ * renderChildren (which bridges it with a zero-width break) and
+ * findMathTextSeams (which reports it). Intentional suffixes (`$n$th`),
+ * punctuation-led runs (`$\mathbb{Z}$-module`), and already-spaced text don't
+ * match.
+ */
+function isMathTextSeam(prev: any, cur: any): boolean {
+  if (!prev || !cur) return false;
+  if (isFormulaNode(prev) && cur.type === "text" && /^[A-Za-z]{4,}/.test(cur.value)) return true;
+  if (prev.type === "text" && isFormulaNode(cur) && /[A-Za-z]{4,}$/.test(prev.value)) return true;
+  return false;
+}
+
 /** Render all children of a node, inserting a zero-width break (`\allowbreak{}`)
- *  where a formula/code abuts a word with no space in the source. Such a seam —
- *  e.g. `$V$discharged` (a dropped space) — otherwise renders as one unbreakable
- *  box that overflows a narrow cell. Detected via mdast adjacency, so intentional
- *  suffixes (`$n$th`) and already-spaced text are untouched. It inserts a
- *  *break*, not a space: a real space would be wrong for `$n$th` /
- *  `$\mathbb{Z}$-module`; the missing space, if any, is a content fix. */
+ *  at any math↔word seam (see isMathTextSeam) so it doesn't form one unbreakable
+ *  box that overflows a narrow cell. It inserts a *break*, not a space; the
+ *  missing space itself, if a typo, is a content fix (see findMathTextSeams). */
 function renderChildren(node: any): string[] {
   const kids: any[] = node.children ?? [];
-  const isFormula = (n: any) => n && (n.type === "inlineMath" || n.type === "inlineCode");
   return kids.map((child: any, i: number) => {
     const s = renderMdastNode(child);
-    const prev = kids[i - 1];
-    const seam =
-      (isFormula(prev) && child.type === "text" && /^[A-Za-z]{4,}/.test(child.value)) ||
-      (prev?.type === "text" && isFormula(child) && /[A-Za-z]{4,}$/.test(prev.value));
-    return seam ? "\\allowbreak{}" + s : s;
+    return isMathTextSeam(kids[i - 1], child) ? "\\allowbreak{}" + s : s;
   });
+}
+
+export interface MathTextSeam {
+  line: number;
+  column: number;
+  /** Short source context around the seam, e.g. "$V$discharged". */
+  context: string;
+}
+
+/**
+ * Find every math↔word seam (a formula abutting a word with no space — a likely
+ * dropped space) in a markdown string, with source positions. renderChildren
+ * bridges these with a zero-width break so they don't overflow; this surfaces
+ * them so the space can be added in the content (the run-together still *reads*
+ * wrong when it doesn't wrap).
+ */
+export function findMathTextSeams(md: string): MathTextSeam[] {
+  const seams: MathTextSeam[] = [];
+  const raw = (n: any): string =>
+    n.type === "inlineMath" ? `$${n.value}$`
+      : n.type === "inlineCode" ? "`" + n.value + "`"
+        : String(n.value ?? "");
+  const visit = (node: any): void => {
+    const kids: any[] = node.children ?? [];
+    for (let i = 1; i < kids.length; i++) {
+      if (isMathTextSeam(kids[i - 1], kids[i])) {
+        const pos = kids[i].position?.start ?? kids[i - 1].position?.end ?? { line: 0, column: 0 };
+        seams.push({
+          line: pos.line ?? 0,
+          column: pos.column ?? 0,
+          context: (raw(kids[i - 1]) + raw(kids[i])).replace(/\s+/g, " ").slice(0, 60),
+        });
+      }
+    }
+    for (const k of kids) if (k && k.children) visit(k);
+  };
+  visit(parseMdCached(md));
+  return seams;
 }
 
 /** Render a list item's content (unwrap single-paragraph items). */

--- a/content/pipeline/render-latex.ts
+++ b/content/pipeline/render-latex.ts
@@ -868,9 +868,24 @@ function renderTable(node: any): string {
   return lines.join("\n");
 }
 
-/** Render all children of a node. */
+/** Render all children of a node, inserting a zero-width break (`\allowbreak{}`)
+ *  where a formula/code abuts a word with no space in the source. Such a seam —
+ *  e.g. `$V$discharged` (a dropped space) — otherwise renders as one unbreakable
+ *  box that overflows a narrow cell. Detected via mdast adjacency, so intentional
+ *  suffixes (`$n$th`) and already-spaced text are untouched. It inserts a
+ *  *break*, not a space: a real space would be wrong for `$n$th` /
+ *  `$\mathbb{Z}$-module`; the missing space, if any, is a content fix. */
 function renderChildren(node: any): string[] {
-  return (node.children ?? []).map((child: any) => renderMdastNode(child));
+  const kids: any[] = node.children ?? [];
+  const isFormula = (n: any) => n && (n.type === "inlineMath" || n.type === "inlineCode");
+  return kids.map((child: any, i: number) => {
+    const s = renderMdastNode(child);
+    const prev = kids[i - 1];
+    const seam =
+      (isFormula(prev) && child.type === "text" && /^[A-Za-z]{4,}/.test(child.value)) ||
+      (prev?.type === "text" && isFormula(child) && /[A-Za-z]{4,}$/.test(prev.value));
+    return seam ? "\\allowbreak{}" + s : s;
+  });
 }
 
 /** Render a list item's content (unwrap single-paragraph items). */

--- a/scripts/tests/render-latex-tables.test.ts
+++ b/scripts/tests/render-latex-tables.test.ts
@@ -18,6 +18,7 @@ import {
   validateLatexAst,
   chooseColumnSpec,
   splitLongMath,
+  findMathTextSeams,
 } from "../../content/pipeline/render-latex";
 
 const GFM_TABLE = `
@@ -187,5 +188,13 @@ describe("breaking non-breaking blobs (long math + identifiers)", () => {
     expect(markdownToLatex("the $n$th case")).not.toContain("allowbreak{}th");
     expect(markdownToLatex("a $\\mathbb{Z}$-module")).not.toContain("allowbreak{}-");
     expect(markdownToLatex("at $V$ discharged")).not.toContain("allowbreak{}discharged");
+  });
+
+  test("findMathTextSeams reports dropped-space seams (for the audit sidecar)", () => {
+    const md = "Intro line.\n\nat $V$discharged here, $n$th is fine, $A$ spaced too.";
+    const seams = findMathTextSeams(md);
+    expect(seams.length).toBe(1);
+    expect(seams[0].context).toContain("discharged");
+    expect(seams[0].line).toBe(3); // 1-based source line
   });
 });

--- a/scripts/tests/render-latex-tables.test.ts
+++ b/scripts/tests/render-latex-tables.test.ts
@@ -177,4 +177,15 @@ describe("breaking non-breaking blobs (long math + identifiers)", () => {
     const out = markdownToLatex("`canonical_braid_crossings.atom_canonical_crossings`");
     expect(out).toMatch(/texttt\{[^}]*\\allowbreak/);
   });
+
+  test("a formula abutting a word (dropped space) gets a zero-width break", () => {
+    // math/code touching a long word → \allowbreak{} so it can wrap
+    expect(markdownToLatex("at $V_{(2,1)}$discharged by it")).toContain(
+      "$\\allowbreak{}discharged",
+    );
+    // intentional suffix, leading punctuation, and already-spaced text are untouched
+    expect(markdownToLatex("the $n$th case")).not.toContain("allowbreak{}th");
+    expect(markdownToLatex("a $\\mathbb{Z}$-module")).not.toContain("allowbreak{}-");
+    expect(markdownToLatex("at $V$ discharged")).not.toContain("allowbreak{}discharged");
+  });
 });


### PR DESCRIPTION
Follow-up to #24 (merged), addressing the residual `$V$discharged`-style seams — a formula/code abutting a word with no space in the source, which renders as one unbreakable box that overflows narrow table cells (e.g. mass-theory #37).

Two pieces, both driven off the mdast AST:

### 1. Renderer: zero-width break at the seam (`9a5bd1e`)
`renderChildren` detects an `inlineMath`/`inlineCode` node abutting a ≥4-letter word (no space at the boundary) and inserts a **zero-width `\allowbreak{}`** so it can wrap. A *break*, not a space — a real space would corrupt intentional suffixes (`$n$th`) and `$\mathbb{Z}$-module`, so those and already-spaced text are untouched.

### 2. Audit: flag the seams as a sidecar (`9d3728b`)
The break stops the overflow, but a genuine dropped-space typo still *reads* run-together when it doesn't wrap — that's a content fix. So `findMathTextSeams(md)` (same AST detector, shared `isMathTextSeam` predicate) powers a new `math-text-seam` rule in `audit-tex-source.ts`, reported with the other TeX-source hazards (gated by `--strict`). The audit now also writes a machine-readable **sidecar** (`content/audit-tex-source.json`, gitignored) listing every finding — a content-fix worklist.

### Verification
3 new unit tests (seam break inserted; suffixes/spaced text untouched; `findMathTextSeams` line numbers) + the audit rule verified firing on a synthetic seam. Full renderer suite green (16 tests); `\allowbreak` already allowlisted, preflight clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Q5vKi74QU2vUCnBMUFVGh

---
_Generated by [Claude Code](https://claude.ai/code/session_017Q5vKi74QU2vUCnBMUFVGh)_