### PR TITLE
feat(tools): expose mechanical QA/publication/transform cores as MCP tools

### DIFF
--- a/adapters/paper/index.ts
+++ b/adapters/paper/index.ts
@@ -13,6 +13,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import { registerRenderTools } from "./tools/render.js";
 import { registerValidateTools } from "./tools/validate.js";
 import { registerLeanTools } from "./tools/lean.js";
+import { registerQaTools } from "./tools/qa.js";
 import { registerDepsTools } from "../../src/tools/check-deps.js";
 import { registerPreferenceTools } from "../../src/tools/preferences.js";
 import { registerPreviewTools } from "../../src/tools/preview.js";
@@ -1025,6 +1026,7 @@ End every response with suggested follow-ups:
     registerRenderTools(server);
     registerValidateTools(server);
     registerLeanTools(server);
+    registerQaTools(server);
 
     // Generic tools
     registerDepsTools(server);

--- a/adapters/paper/tools/_pipeline.ts
+++ b/adapters/paper/tools/_pipeline.ts
@@ -1,0 +1,132 @@
+/**
+ * Shared helper for the mechanical "QA / publication / transform" MCP tools.
+ *
+ * These tools expose the deterministic cores that live as scripts under
+ * `content/pipeline/*` — the LLM calls them to get structured findings, then
+ * applies judgment (the skill bodies) on top. Each tool wraps one pipeline
+ * script through {@link runPipeline}, which spawns `bun run` on the script from
+ * the repo root and captures structured output, degrading gracefully when the
+ * script or a toolchain is missing.
+ *
+ * @module adapters/paper/tools/_pipeline
+ */
+
+import { spawnSync } from "child_process";
+import { existsSync, readdirSync } from "fs";
+import { join } from "path";
+import { get } from "../paths.js";
+
+export interface PipelineResult {
+  ok: boolean;
+  /** Script id (without `.ts`). */
+  script: string;
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  /** Parsed JSON when `--json` was requested and stdout parsed cleanly. */
+  json?: unknown;
+  /** Wrapper-level error (missing script / `bun` not found / spawn failure). */
+  error?: string;
+}
+
+/** Absolute path to a `content/pipeline/<script>.ts` file. */
+export function pipelineScriptPath(script: string): string {
+  const name = script.endsWith(".ts") ? script : `${script}.ts`;
+  return join(get.REPO_ROOT(), "content", "pipeline", name);
+}
+
+/**
+ * Best-effort JSON extraction: many scripts print a human banner before the
+ * JSON, so parse from the first `{`/`[`. Returns undefined if nothing parses.
+ */
+export function tryParseJson(s: string): unknown | undefined {
+  const t = s.trim();
+  if (!t) return undefined;
+  const candidates = ["{", "["]
+    .map((c) => t.indexOf(c))
+    .filter((i) => i >= 0);
+  if (candidates.length === 0) return undefined;
+  const start = Math.min(...candidates);
+  try {
+    return JSON.parse(t.slice(start));
+  } catch {
+    return undefined;
+  }
+}
+
+/** Run a pipeline script and capture a structured result. Never throws. */
+export function runPipeline(
+  script: string,
+  args: string[] = [],
+  opts: { timeoutMs?: number } = {},
+): PipelineResult {
+  const path = pipelineScriptPath(script);
+  if (!existsSync(path)) {
+    return {
+      ok: false,
+      script,
+      exitCode: null,
+      stdout: "",
+      stderr: "",
+      error: `pipeline script not found: content/pipeline/${script}.ts`,
+    };
+  }
+  const res = spawnSync("bun", ["run", path, ...args], {
+    cwd: get.REPO_ROOT(),
+    encoding: "utf-8",
+    timeout: opts.timeoutMs ?? 120_000,
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  if (res.error) {
+    return {
+      ok: false,
+      script,
+      exitCode: res.status ?? null,
+      stdout: res.stdout ?? "",
+      stderr: res.stderr ?? "",
+      error: res.error.message,
+    };
+  }
+  const stdout = res.stdout ?? "";
+  return {
+    ok: res.status === 0,
+    script,
+    exitCode: res.status,
+    stdout,
+    stderr: res.stderr ?? "",
+    json: args.includes("--json") ? tryParseJson(stdout) : undefined,
+  };
+}
+
+const MAX = 12_000;
+
+/** Format a PipelineResult as an MCP text tool result. */
+export function asToolText(title: string, r: PipelineResult) {
+  let text: string;
+  if (r.error) {
+    text = `# ${title}\n\n⚠️ ${r.error}`;
+  } else {
+    const body =
+      r.json !== undefined
+        ? "```json\n" + JSON.stringify(r.json, null, 2).slice(0, MAX) + "\n```"
+        : (r.stdout || r.stderr || "(no output)").slice(0, MAX);
+    text = `# ${title} (${r.ok ? "ok" : `exit ${r.exitCode}`})\n\n${body}`;
+  }
+  return { content: [{ type: "text" as const, text }] };
+}
+
+/** Resolve the single paper under content/ if not given (else undefined). */
+export function autoPaper(paper?: string): string | undefined {
+  if (paper) return paper;
+  const dir = join(get.REPO_ROOT(), "content");
+  if (!existsSync(dir)) return undefined;
+  const papers = readdirSync(dir, { withFileTypes: true })
+    .filter(
+      (d) =>
+        d.isDirectory() &&
+        !d.name.startsWith(".") &&
+        !["pipeline", "schema", "node_modules"].includes(d.name),
+    )
+    .map((d) => d.name);
+  return papers.length === 1 ? papers[0] : undefined;
+}

--- a/adapters/paper/tools/qa.ts
+++ b/adapters/paper/tools/qa.ts
@@ -1,0 +1,135 @@
+/**
+ * Mechanical QA / publication / transform tools for the paper adapter.
+ *
+ * Each tool exposes the deterministic core of a content-pipeline script as an
+ * MCP tool that returns structured findings. The judgment layer (what to fix)
+ * stays in the skill bodies (`folio-core` / `folio-paper-adapter`); these tools
+ * just run the check and report. All are read-only by default.
+ *
+ * Tools:
+ *   qa_sweep        — run the QA criteria sweep → findings (sidecar) [dry-run by default]
+ *   proof_status    — proof-formalization coverage dashboard (sorry counts, per-block status)
+ *   latex_preflight — flag unknown macros / overfull boxes in the LaTeX source
+ *   bib_qa          — bibliography metadata QA (+ optional URL resolution)
+ *   glossary_check  — verify the generated glossary index is up to date
+ *   content_export  — export content to viewer JSON (transform)
+ *
+ * @module adapters/paper/tools/qa
+ */
+
+import { z } from "zod";
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { get } from "../paths.js";
+import { runPipeline, asToolText, autoPaper, tryParseJson } from "./_pipeline.js";
+
+const paperArg = (p?: string) => (p ? `content/${p}` : undefined);
+
+export function registerQaTools(server: McpServer): void {
+  // ── qa_sweep ─────────────────────────────────────────────────
+  server.tool(
+    "qa_sweep",
+    "Run the content QA criteria sweep and return structured findings. " +
+      "Read-only by default (dry-run); set apply=true to write sidecar updates.",
+    {
+      paper: z.string().optional().describe("Paper name (auto-detected if only one)"),
+      only: z.string().optional().describe("Comma-separated criteria ids to run (default: all)"),
+      apply: z.boolean().default(false).describe("Write sidecar updates (default: dry-run, read-only)"),
+    },
+    async ({ paper, only, apply }) => {
+      const args: string[] = [];
+      const pp = paperArg(autoPaper(paper));
+      if (pp) args.push(pp);
+      args.push("--json");
+      if (!apply) args.push("--dry-run");
+      if (only) args.push("--only", only);
+      return asToolText("qa_sweep", runPipeline("qa-sweep", args));
+    },
+  );
+
+  // ── proof_status ─────────────────────────────────────────────
+  server.tool(
+    "proof_status",
+    "Proof-formalization coverage dashboard: per-block status, sorry counts, " +
+      "and axis breakdown (read-only).",
+    {
+      paper: z.string().optional().describe("Paper name (auto-detected if only one)"),
+    },
+    async ({ paper }) => {
+      const args: string[] = [];
+      const pp = paperArg(autoPaper(paper));
+      if (pp) args.push(pp);
+      args.push("--json");
+      return asToolText("proof_status", runPipeline("proof-axis-dashboard", args));
+    },
+  );
+
+  // ── latex_preflight ──────────────────────────────────────────
+  server.tool(
+    "latex_preflight",
+    "Preflight the rendered LaTeX source for unknown macros and overfull boxes " +
+      "before a full build (read-only; never fails the call).",
+    {},
+    async () => asToolText("latex_preflight", runPipeline("latex-preflight", ["--json", "--warn"])),
+  );
+
+  // ── bib_qa ───────────────────────────────────────────────────
+  server.tool(
+    "bib_qa",
+    "Bibliography QA: metadata completeness checks, and optionally verify that " +
+      "citation URLs resolve (HTTP). Read-only.",
+    {
+      checkUrls: z.boolean().default(false).describe("Also verify URLs resolve (network)"),
+    },
+    async ({ checkUrls }) => {
+      const out = join(get.REPO_ROOT(), "build", "bib-qa.json");
+      const args = ["--out", out];
+      if (checkUrls) args.push("--check-urls");
+      const r = runPipeline("bib-qa", args);
+      // bib-qa writes its report to --out; surface it if present.
+      if (!r.error && existsSync(out)) {
+        const parsed = tryParseJson(readFileSync(out, "utf-8"));
+        if (parsed !== undefined) r.json = parsed;
+      }
+      return asToolText("bib_qa", r);
+    },
+  );
+
+  // ── glossary_check ───────────────────────────────────────────
+  server.tool(
+    "glossary_check",
+    "Check that the generated glossary index is up to date (read-only gate; " +
+      "exits non-zero if regeneration is needed).",
+    {
+      paper: z.string().optional().describe("Paper name (auto-detected if only one)"),
+    },
+    async ({ paper }) => {
+      const pp = paperArg(autoPaper(paper));
+      if (!pp) {
+        return asToolText("glossary_check", {
+          ok: false, script: "build-glossary", exitCode: null, stdout: "", stderr: "",
+          error: "specify a paper (could not auto-detect a single paper under content/)",
+        });
+      }
+      return asToolText("glossary_check", runPipeline("build-glossary", [pp, "--check"]));
+    },
+  );
+
+  // ── content_export ───────────────────────────────────────────
+  server.tool(
+    "content_export",
+    "Export content objects to viewer JSON (transform step for publication).",
+    {
+      paper: z.string().optional().describe("Paper name (auto-detected if only one)"),
+      out: z.string().optional().describe("Output directory (default: build/viewer)"),
+    },
+    async ({ paper, out }) => {
+      const p = autoPaper(paper);
+      const args: string[] = [];
+      if (p) args.push("--paper", p);
+      if (out) args.push("--out", out);
+      return asToolText("content_export", runPipeline("export-json", args));
+    },
+  );
+}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,6 +50,7 @@ only when the matching adapter is active):
 | `paper_render_pdf` / `paper_render_html` / `paper_preview` | Render a paper (paper adapter) |
 | `formula_render` | Render a single formula to an image |
 | `lean_setup` / `lean_build` / `lean_check` / `lean_status` | Lean formalization lifecycle (paper adapter) |
+| `qa_sweep` / `proof_status` / `latex_preflight` / `bib_qa` / `glossary_check` / `content_export` | Mechanical QA / publication / transform checks → structured findings (paper adapter) |
 | `paper_preferences` | Per-folio rendering preferences |
 
 ## 4. Run your first skill

--- a/scripts/tests/qa-tools.test.ts
+++ b/scripts/tests/qa-tools.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for the mechanical QA/publication MCP tools and their pipeline helper.
+ *
+ * These are hermetic: they exercise the wrapper's structural behaviour
+ * (script-path resolution, JSON extraction, graceful errors) and verify the
+ * tools register with the expected names/handlers — without spawning the real
+ * pipeline (which needs a content/<paper> fixture).
+ */
+import { test, expect, describe } from "bun:test";
+import {
+  pipelineScriptPath,
+  tryParseJson,
+  runPipeline,
+  asToolText,
+} from "../../adapters/paper/tools/_pipeline.ts";
+import { registerQaTools } from "../../adapters/paper/tools/qa.ts";
+
+describe("_pipeline helper", () => {
+  test("pipelineScriptPath resolves under content/pipeline with .ts", () => {
+    const p = pipelineScriptPath("qa-sweep");
+    expect(p.endsWith("/content/pipeline/qa-sweep.ts")).toBe(true);
+    expect(pipelineScriptPath("x.ts").endsWith("/content/pipeline/x.ts")).toBe(true);
+  });
+
+  test("tryParseJson extracts JSON after a banner, else undefined", () => {
+    expect(tryParseJson('banner\n{"a":1}')).toEqual({ a: 1 });
+    expect(tryParseJson("[1,2,3]")).toEqual([1, 2, 3]);
+    expect(tryParseJson("no json here")).toBeUndefined();
+    expect(tryParseJson("")).toBeUndefined();
+  });
+
+  test("runPipeline returns a structured error for a missing script (never throws)", () => {
+    const r = runPipeline("definitely-not-a-real-script-xyz", ["--json"]);
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain("not found");
+    expect(r.json).toBeUndefined();
+  });
+
+  test("asToolText renders error and JSON results as MCP text content", () => {
+    const errRes = asToolText("t", {
+      ok: false, script: "s", exitCode: null, stdout: "", stderr: "", error: "boom",
+    });
+    expect(errRes.content[0].type).toBe("text");
+    expect(errRes.content[0].text).toContain("boom");
+
+    const jsonRes = asToolText("t", {
+      ok: true, script: "s", exitCode: 0, stdout: "", stderr: "", json: { findings: [] },
+    });
+    expect(jsonRes.content[0].text).toContain("```json");
+    expect(jsonRes.content[0].text).toContain("findings");
+  });
+});
+
+describe("registerQaTools", () => {
+  test("registers the expected mechanical tools with handlers", () => {
+    const registered: Record<string, { desc: string; schema: unknown; handler: Function }> = {};
+    const stub = {
+      tool(name: string, desc: string, schema: unknown, handler: Function) {
+        registered[name] = { desc, schema, handler };
+      },
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerQaTools(stub as any);
+
+    for (const name of [
+      "qa_sweep",
+      "proof_status",
+      "latex_preflight",
+      "bib_qa",
+      "glossary_check",
+      "content_export",
+    ]) {
+      expect(registered[name]).toBeDefined();
+      expect(typeof registered[name].handler).toBe("function");
+      expect(registered[name].desc.length).toBeGreaterThan(10);
+    }
+  });
+
+  test("glossary_check returns a graceful message when no paper resolves", async () => {
+    const registered: Record<string, Function> = {};
+    const stub = { tool(name: string, _d: string, _s: unknown, h: Function) { registered[name] = h; } };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerQaTools(stub as any);
+    // In this repo there is no content/<paper>, so auto-detect yields nothing.
+    const res = await registered["glossary_check"]({});
+    expect(res.content[0].type).toBe("text");
+    expect(res.content[0].text.toLowerCase()).toContain("paper");
+  });
+});


### PR DESCRIPTION
Implements the **skill→tool pattern** from #27: the deterministic cores of the `content/pipeline/*` scripts become MCP tools that return **structured findings**, while the judgment layer (what to fix) stays in the skill bodies. Covers your "mechanical aspects of publication / QA / review" and "rendering / transforming" ask.

## New tools (paper adapter, read-only by default)

| Tool | Wraps | Returns |
|------|-------|---------|
| `qa_sweep` | `qa-sweep.ts` | QA criteria findings (dry-run unless `apply=true`) |
| `proof_status` | `proof-axis-dashboard.ts` | proof-formalization coverage, sorry counts, per-block status |
| `latex_preflight` | `latex-preflight.ts` | unknown macros / overfull boxes before a full build |
| `bib_qa` | `bib-qa.ts` | bibliography metadata QA (+ optional URL resolution) |
| `glossary_check` | `build-glossary.ts --check` | glossary index freshness gate |
| `content_export` | `export-json.ts` | content → viewer JSON (transform) |

## The pattern (reusable for the rest)
`adapters/paper/tools/_pipeline.ts` is a shared runner: it `spawn`s `bun run content/pipeline/<script>.ts` from the repo root, captures stdout/stderr/exit, extracts JSON (`--json`), and **degrades gracefully** (missing script / missing toolchain / no content) without ever throwing. Adding the next tool is ~10 lines.

## Tests
`scripts/tests/qa-tools.test.ts` (hermetic — no real pipeline spawn): helper behaviour (path resolution, JSON extraction, missing-script error), tool registration (all 6 names + handlers), and the graceful no-paper path. **6 pass.**

## Scope / honesty
This is the **pattern + first batch** (the 6 highest-value mechanical cores), not all ~57 pipeline scripts. The remaining wrap-candidates (e.g. `latex-overfull-report`, `audit-tex-source`, `find-dangling-remarks`, `conditional-class-banner-audit`, `q-usage-audit`, `validate-references`, `conjectural-propagation-*`) follow the same `_pipeline` pattern — I'll open a tracking issue enumerating them. Judgment-heavy skills (`content-review`, `devils-advocate`, `scientific-accuracy`, …) intentionally stay as skill prose, not tools.

## Test plan
- [x] `bun test scripts/tests/qa-tools.test.ts` → 6 pass.
- [x] `qa.ts` / `_pipeline.ts` import cleanly; wired via `registerQaTools`.
- [ ] End-to-end against a real `content/<paper>` fixture (needs a paper repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tkxsr1akjLwNKzFwegoust)_