### PR TITLE
chore: adopt beans work-plan + add content-type-aware /prepare-merge

### DIFF
--- a/.beans.yml
+++ b/.beans.yml
@@ -1,0 +1,6 @@
+beans:
+    path: .beans
+    prefix: folio-assistant-
+    id_length: 4
+    default_status: todo
+    default_type: task

--- a/.beans/folio-assistant-8ywm--add-content-type-aware-prepare-merge-command.md
+++ b/.beans/folio-assistant-8ywm--add-content-type-aware-prepare-merge-command.md
@@ -1,0 +1,10 @@
+---
+# folio-assistant-8ywm
+title: Add content-type-aware /prepare-merge command
+status: in-progress
+type: task
+priority: normal
+created_at: 2026-06-29T19:20:42Z
+updated_at: 2026-06-29T19:21:06Z
+---
+

--- a/.beans/folio-assistant-rd58--expose-mechanical-pipeline-cores-as-mcp-tools-2733.md
+++ b/.beans/folio-assistant-rd58--expose-mechanical-pipeline-cores-as-mcp-tools-2733.md
@@ -1,0 +1,9 @@
+---
+# folio-assistant-rd58
+title: Expose mechanical pipeline cores as MCP tools (#27/#33)
+status: todo
+type: task
+created_at: 2026-06-29T19:20:42Z
+updated_at: 2026-06-29T19:20:42Z
+---
+

--- a/.beans/folio-assistant-sxkc--use-beans-internally-for-folio-assistant-work-plan.md
+++ b/.beans/folio-assistant-sxkc--use-beans-internally-for-folio-assistant-work-plan.md
@@ -1,0 +1,9 @@
+---
+# folio-assistant-sxkc
+title: Use beans internally for folio-assistant work-plan
+status: todo
+type: task
+created_at: 2026-06-29T19:20:42Z
+updated_at: 2026-06-29T19:20:42Z
+---
+

--- a/.claude/commands/prepare-merge.md
+++ b/.claude/commands/prepare-merge.md
@@ -1,0 +1,67 @@
+---
+description: Get the current branch to a clean, conflict-free, green, pushed state — generic recipe + content-type-specific checks.
+argument-hint: "[base branch]  (default: the repo's default branch)"
+allowed-tools: Bash(git*), Bash(bun*), Bash(beans*)
+---
+
+# /prepare-merge — make this branch mergeable
+
+A **generalized** branch-shipping recipe that ends with content-type-specific
+verification. "Prepare-merge" ≠ "merge": it makes the branch *mergeable* and
+stops — it does **not** push to the default branch and does **not** open or
+merge a PR (those are explicit, separate asks). Full discipline:
+`.claude/skills/local/prepare-merge.md`.
+
+Base branch: `$ARGUMENTS` if given, else the repo default (auto-detect:
+`git remote show origin | sed -n 's/.*HEAD branch: //p'`, fallback `main`).
+
+## Generic recipe (always)
+
+1. **Clean + committed** — `git status --short` empty (the container is
+   ephemeral; commit first).
+2. **Fetch** the base + branch (retry on network error): `git fetch origin <base>`.
+3. **Integrate if base moved** — compare `git merge-base HEAD origin/<base>` to
+   `git rev-parse origin/<base>`; if different, rebase (`git rebase origin/<base>`,
+   force-push **with lease**) or merge it in. Resolve conflicts.
+4. **Prove it merges cleanly** — `git merge-base --is-ancestor origin/<base> HEAD`
+   (clean fast-forward) or `git merge-tree --write-tree origin/<base> HEAD` (trust
+   the exit code).
+5. **Green check** — run the gates below; do not declare green while sitting on
+   pre-existing failures.
+6. **Push** the feature branch: `git push -u origin <branch>` (with lease after a
+   rebase). Stop here unless explicitly asked to open/merge a PR.
+
+## Content-type-specific verification (the generalization point)
+
+After the generic gates, run the checks for **this folio's content type** (read
+`contentType` from `folio.config.json`; default to the platform's own checks).
+Prefer the MCP tools (structured findings) when connected; otherwise the scripts.
+
+**Always (platform):**
+- `bun test` and `eslint .` green.
+- `bun run scripts/gen-schema-docs.ts` and `bun run scripts/gen-skill-docs.ts`
+  produce no uncommitted diff (generated docs in sync).
+
+**`contentType: paper` (Lean + LaTeX):**
+- `content_validate` — schema + constraints + AST clean.
+- `qa_sweep` — no critical findings (dry-run).
+- `proof_status` — no regression in sorry/coverage for changed blocks.
+- `latex_preflight` — no new unknown macros / overfull boxes.
+- `lean_build` / `lean_check` — build green (or unchanged) for touched packages.
+
+**`contentType: who-smart-dak` (L2):**
+- BPMN/DMN well-formedness; data-dictionary + value-set validation
+  (`content_validate` + terminology checks).
+
+**`contentType: who-smart-ig` (L3 FHIR):**
+- `fhir-validation` (SUSHI compile + validator) and `quality-control` (IG QA)
+  clean.
+
+**Other / unknown content type:** run the generic gates only, and report which
+content-specific checks were skipped (don't claim coverage you didn't run).
+
+## On success
+
+Report: base, integration action (none / rebased / merged), the gates run with
+their results, and that the branch is pushed + mergeable. Update the work-plan
+(`beans update <id> --status ...`). Do **not** merge.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,8 +62,11 @@ a background subagent, not the foreground.
 
 - Migration plan + cross-repo coordination: `docs/folio-assistant-migration.md`.
 - Skills live under `skills/` (packages) and `.claude/skills/` (local + capabilities).
-- Shipping a branch — verify → confirm mergeable → push → (only if asked) open a
-  PR via the deferred GitHub MCP tools: `.claude/skills/local/prepare-merge.md`.
+- Shipping a branch — `/prepare-merge [base]` runs the generic recipe plus this
+  folio's **content-type-specific** gates (paper → content_validate / qa_sweep /
+  proof_status / latex_preflight / lean_build; WHO IG → fhir-validation / QC),
+  then pushes. It does not merge. Command: `.claude/commands/prepare-merge.md`;
+  full discipline: `.claude/skills/local/prepare-merge.md`.
 - Watching a sibling PR — `/watch <pr|branch>` subscribes to a PR's CI / review /
   comment activity and follows through until it's merged or closed:
   `.claude/commands/watch.md`.


### PR DESCRIPTION
Adopts the project's own conventions: the **beans** work-plan and a generalized **`/prepare-merge`** command with content-type-specific actions.

## beans work-plan
- Initializes the `.beans/` store (committed) — `AGENTS.md` mandates beans as the single todo mechanism, but the repo had no store. Seeded with the active work items (mechanical-tools epic, /prepare-merge, beans adoption).
- `scripts/install-beans.sh` already provisions the CLI; `go install` works in this environment.

## `/prepare-merge` command
`.claude/commands/prepare-merge.md` — a **generalized** branch-shipping recipe (clean → fetch → integrate → prove-mergeable → green → push; never merges) that ends with **content-type-specific verification** read from `folio.config.json`:

| contentType | content-specific gates |
|-------------|------------------------|
| `paper` | `content_validate`, `qa_sweep`, `proof_status`, `latex_preflight`, `lean_build`/`check` |
| `who-smart-dak` | BPMN/DMN well-formedness, data-dictionary + value-set validation |
| `who-smart-ig` | `fhir-validation` (SUSHI + validator), `quality-control` (IG QA) |
| platform / other | generic gates + `bun test`, `eslint`, generated-docs-in-sync; skipped checks reported |

Backed by the existing `.claude/skills/local/prepare-merge.md` discipline; `AGENTS.md` now points "shipping a branch" at it.

## Dogfooded
Ran the platform gates for this PR: generated docs in sync (no diff), `qa-tools` test 6/6 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tkxsr1akjLwNKzFwegoust)_