### PR TITLE
feat(tools): wrap remaining read-only audits (closing sweep, #33)

### DIFF
--- a/.beans/folio-assistant-kktt--closing-sweep-audit-stragglers-close-33.md
+++ b/.beans/folio-assistant-kktt--closing-sweep-audit-stragglers-close-33.md
@@ -1,0 +1,10 @@
+---
+# folio-assistant-kktt
+title: 'Closing sweep: audit stragglers + close #33'
+status: in-progress
+type: task
+created_at: 2026-06-29T22:02:10Z
+updated_at: 2026-06-29T22:02:10Z
+---
+
+Wrap remaining read-only audits; document write/generate scripts left.

--- a/adapters/paper/tools/audit.ts
+++ b/adapters/paper/tools/audit.ts
@@ -21,7 +21,7 @@
 
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { runPipeline, asToolText } from "./_pipeline.js";
+import { runPipeline, asToolText, autoPaper } from "./_pipeline.js";
 
 /** Uniform read-only audits: no required args (optionally `--json`). */
 const AUDITS: { tool: string; script: string; json?: boolean; desc: string }[] = [
@@ -45,6 +45,14 @@ const AUDITS: { tool: string; script: string; json?: boolean; desc: string }[] =
     desc: "Validate computed/derived-value consistency across the corpus. Read-only." },
   { tool: "glossary_candidates", script: "glossary-candidates",
     desc: "Propose glossary candidate terms from the corpus. Read-only." },
+  { tool: "wiring_audit", script: "audit-wiring",
+    desc: "Audit script/hook wiring (no dangling references). Read-only." },
+  { tool: "conjectural_propagation", script: "conjectural-propagation-audit",
+    desc: "Audit propagation of conjectural status through dependent results. Read-only." },
+  { tool: "trivial_skeleton_audit", script: "trivial-skeleton-audit",
+    desc: "Flag trivial/placeholder proof skeletons. Read-only (prints to stdout)." },
+  { tool: "tex_validate", script: "validate-tex", json: true,
+    desc: "Structural validation of rendered .tex (no compile). Read-only." },
 ];
 
 export function registerAuditTools(server: McpServer): void {
@@ -63,5 +71,28 @@ export function registerAuditTools(server: McpServer): void {
       mode: z.enum(["list", "stale"]).default("list").describe("list | stale (both read-only)"),
     },
     async ({ mode }) => asToolText("lean_compile_audit", runPipeline("lean-compile-audit", [`--${mode}`])),
+  );
+
+  // proof ↔ narrative equivalence sweep (read-only via --dry-run --json).
+  server.tool(
+    "proof_narrative_equiv",
+    "Audit that each block's narrative proof matches its Lean counterpart " +
+      "(read-only: runs as a dry-run, JSON findings).",
+    {},
+    async () => asToolText("proof_narrative_equiv", runPipeline("proof-narrative-lean-equiv-sweep", ["--dry-run", "--json"])),
+  );
+
+  // status-section audit (per paper).
+  server.tool(
+    "status_sections_audit",
+    "Audit the per-block status sections for the paper (read-only).",
+    {
+      paper: z.string().optional().describe("Paper name (auto-detected if only one)"),
+    },
+    async ({ paper }) => {
+      const p = autoPaper(paper);
+      const args = p ? ["--paper", p] : [];
+      return asToolText("status_sections_audit", runPipeline("audit-status-sections", args));
+    },
   );
 }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -53,7 +53,7 @@ only when the matching adapter is active):
 | `qa_sweep` / `proof_status` / `latex_preflight` / `bib_qa` / `glossary_check` / `content_export` | Mechanical QA / publication / transform checks → structured findings (paper adapter) |
 | `bib_validate` / `references_validate` / `bib_export` | Bibliography QA + BibTeX export (paper adapter) |
 | `codemod` / `prune_deps` / `migrate_lean_refs` | Content transforms — dry-run by default, `apply=true` to write (paper adapter) |
-| `latex_overfull` / `tex_source_audit` / `dangling_remarks` / `conditional_class_audit` / `section_title_audit` / `wall_violations` / `defterm_validate` / `value_validate` / `qa_staleness` / `glossary_candidates` / `lean_compile_audit` | Read-only content/Lean audits → structured findings (paper adapter) |
+| `latex_overfull` / `tex_source_audit` / `tex_validate` / `dangling_remarks` / `conditional_class_audit` / `section_title_audit` / `status_sections_audit` / `wall_violations` / `defterm_validate` / `value_validate` / `qa_staleness` / `glossary_candidates` / `wiring_audit` / `conjectural_propagation` / `trivial_skeleton_audit` / `lean_compile_audit` / `proof_narrative_equiv` | Read-only content/Lean audits → structured findings (paper adapter) |
 | `paper_preferences` | Per-folio rendering preferences |
 
 ## 4. Run your first skill

--- a/scripts/tests/audit-tools.test.ts
+++ b/scripts/tests/audit-tools.test.ts
@@ -13,6 +13,8 @@ describe("registerAuditTools", () => {
     "latex_overfull", "qa_staleness", "tex_source_audit", "dangling_remarks",
     "conditional_class_audit", "section_title_audit", "wall_violations",
     "defterm_validate", "value_validate", "glossary_candidates", "lean_compile_audit",
+    "wiring_audit", "conjectural_propagation", "trivial_skeleton_audit",
+    "tex_validate", "proof_narrative_equiv", "status_sections_audit",
   ];
 
   test("registers all audit tools with handlers + descriptions", () => {


### PR DESCRIPTION
Closing sweep for #33 — adds the last read-only audit cores, completing the mechanical-tool surface.

## New audit tools (`tools/audit.ts`)
`wiring_audit`, `conjectural_propagation`, `trivial_skeleton_audit`, `tex_validate` (`validate-tex --json`, no compile), `proof_narrative_equiv` (`--dry-run --json`), `status_sections_audit` (`--paper`).

All read-only. The audit module now exposes **17 tools**; the test covers all of them (suite: **102 assertions, green**).

## Mechanical-tool surface — complete
Across #32 / #35 / #36 / this PR, the deterministic `content/pipeline` cores are now MCP tools:
- **QA/publication:** `qa_sweep`, `proof_status`, `latex_preflight`, `bib_qa`, `glossary_check`, `content_export`
- **Bibliography:** `bib_validate`, `references_validate`, `bib_export`
- **Transforms (apply-gated):** `codemod`, `prune_deps`, `migrate_lean_refs`
- **Read-only audits (17):** the audit module

**Intentionally left as scripts (not wrapped):** `build` / `generate-main-tex` / `generate-index` (overlap the existing `content_build`), and one-time migrations (`migrate-cites`, `migrate-bib-verifier`, `apply-glossary-curation`) — run directly when needed. Judgment-heavy skills stay as prose.

## Shipped via `/prepare-merge` gates
Generated docs in sync, tool suite green, module imports clean.

Closes #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tkxsr1akjLwNKzFwegoust)_