### PR TITLE
chore(beans): mark completed work-plan items + add summaries

### DIFF
--- a/.beans/folio-assistant-8ywm--add-content-type-aware-prepare-merge-command.md
+++ b/.beans/folio-assistant-8ywm--add-content-type-aware-prepare-merge-command.md
@@ -1,10 +1,12 @@
 ---
 # folio-assistant-8ywm
 title: Add content-type-aware /prepare-merge command
-status: in-progress
+status: completed
 type: task
 priority: normal
 created_at: 2026-06-29T19:20:42Z
-updated_at: 2026-06-29T19:21:06Z
+updated_at: 2026-06-30T01:09:13Z
 ---
 
+## Summary of Changes
+Added /prepare-merge command (.claude/commands/prepare-merge.md): generic recipe + content-type-specific gates. Merged in PR #34.

--- a/.beans/folio-assistant-kktt--closing-sweep-audit-stragglers-close-33.md
+++ b/.beans/folio-assistant-kktt--closing-sweep-audit-stragglers-close-33.md
@@ -1,10 +1,14 @@
 ---
 # folio-assistant-kktt
 title: 'Closing sweep: audit stragglers + close #33'
-status: in-progress
+status: completed
 type: task
+priority: normal
 created_at: 2026-06-29T22:02:10Z
-updated_at: 2026-06-29T22:02:10Z
+updated_at: 2026-06-30T01:09:13Z
 ---
 
 Wrap remaining read-only audits; document write/generate scripts left.
+
+## Summary of Changes
+Wrapped remaining read-only audits (wiring/conjectural/trivial-skeleton/tex-validate/proof-narrative/status-sections); closed #33. Merged in PR #37.

--- a/.beans/folio-assistant-o3ew--batch-3-audit-group-mcp-tools-toolsauditts.md
+++ b/.beans/folio-assistant-o3ew--batch-3-audit-group-mcp-tools-toolsauditts.md
@@ -1,9 +1,12 @@
 ---
 # folio-assistant-o3ew
 title: 'Batch 3: audit-group MCP tools (tools/audit.ts)'
-status: todo
+status: completed
 type: task
+priority: normal
 created_at: 2026-06-29T19:34:01Z
-updated_at: 2026-06-29T19:34:01Z
+updated_at: 2026-06-30T01:09:13Z
 ---
 
+## Summary of Changes
+tools/audit.ts read-only audit tools shipped in PR #36 (extended in #37).

--- a/.beans/folio-assistant-rd58--expose-mechanical-pipeline-cores-as-mcp-tools-2733.md
+++ b/.beans/folio-assistant-rd58--expose-mechanical-pipeline-cores-as-mcp-tools-2733.md
@@ -1,11 +1,14 @@
 ---
 # folio-assistant-rd58
 title: Expose mechanical pipeline cores as MCP tools (#27/#33)
-status: in-progress
+status: completed
 type: task
 priority: normal
 created_at: 2026-06-29T19:20:42Z
-updated_at: 2026-06-29T19:29:04Z
+updated_at: 2026-06-30T01:09:13Z
 ---
 
 Batch 2 (bib + transform tools) done; remaining scripts tracked in #33.
+
+## Summary of Changes
+Mechanical content/pipeline cores exposed as MCP tools across PRs #32 (qa/proof/latex/bib/glossary/export), #35 (bib + transform), #36/#37 (read-only audits). Pattern in adapters/paper/tools/_pipeline.ts; hermetic tests.

--- a/.beans/folio-assistant-sxkc--use-beans-internally-for-folio-assistant-work-plan.md
+++ b/.beans/folio-assistant-sxkc--use-beans-internally-for-folio-assistant-work-plan.md
@@ -1,9 +1,12 @@
 ---
 # folio-assistant-sxkc
 title: Use beans internally for folio-assistant work-plan
-status: todo
+status: completed
 type: task
+priority: normal
 created_at: 2026-06-29T19:20:42Z
-updated_at: 2026-06-29T19:20:42Z
+updated_at: 2026-06-30T01:09:13Z
 ---
 
+## Summary of Changes
+Initialized the .beans/ work-plan store and adopted beans for work tracking. Merged in PR #34.


### PR DESCRIPTION
Reconciles the `.beans/` store on `main`. The five work items whose PRs already merged are marked **completed** with `## Summary of Changes` sections (their status updates didn't all ride along in the feature-branch merges):

- `folio-assistant-8ywm` — /prepare-merge command (#34)
- `folio-assistant-sxkc` — adopt beans (#34)
- `folio-assistant-rd58` — mechanical cores as MCP tools (#32/#35/#36/#37)
- `folio-assistant-o3ew` — audit tools batch (#36)
- `folio-assistant-kktt` — closing sweep / closed #33 (#37)

No code changes — `.beans/` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tkxsr1akjLwNKzFwegoust)_