### PR TITLE
qa-sweep: REPLACE prior script entry instead of appending

### DIFF
--- a/.beans/folio-assistant-oja4--qa-sweep-replace-script-entries-not-append.md
+++ b/.beans/folio-assistant-oja4--qa-sweep-replace-script-entries-not-append.md
@@ -1,0 +1,10 @@
+---
+# folio-assistant-oja4
+title: 'qa-sweep: replace script entries, not append'
+status: in-progress
+type: task
+priority: normal
+created_at: 2026-07-04T14:23:04Z
+updated_at: 2026-07-04T14:23:50Z
+---
+

--- a/content/pipeline/qa-sweep.ts
+++ b/content/pipeline/qa-sweep.ts
@@ -31,8 +31,11 @@
  *   - For each automated criterion:
  *       - If a fresh entry exists (field_hash matches current),
  *         skip — no need to re-audit.
- *       - Otherwise, run the checker and append a new reviewer
- *         entry with reviewer.kind="script", reviewer.id="qa-sweep".
+ *       - Otherwise, run the checker and write a reviewer entry with
+ *         reviewer.kind="script", reviewer.id="qa-sweep". A script
+ *         re-run is a REFRESH: the fresh entry REPLACES the prior
+ *         script entry (agent/human entries are preserved) so the
+ *         criterion array does not grow unboundedly across sweeps.
  *   - Non-automated criteria (scholarly-default, ai-slop, fit-...)
  *     are reported as `needs-agent` in the summary but NOT written
  *     to the sidecar — the watcher dispatches an agent to fill those.
@@ -66,6 +69,7 @@ import {
   loadQaReport,
   saveQaReport,
   entryIsFresh,
+  preserveNonScriptEntries,
   computeCriterionScriptHashes,
   saveQaScriptSidecar,
   type CriterionScriptHashes,
@@ -267,6 +271,15 @@ function run(): void {
       // relaxed in the registry) must NOT short-circuit the sweep;
       // it has to be re-evaluated against the actual checker.
       const existing = report.criteria[criterionId] ?? [];
+      // A script re-run is a REFRESH, not a new opinion: it must REPLACE the
+      // prior script entry rather than append. Only agent-kind reviewers
+      // append (their multi-reviewer audit trail is meaningful); human
+      // adjudications are always kept. Dropping stale script entries here
+      // keeps sidecars from growing unboundedly on every sweep. NOTE: the
+      // freshness gate below still scans the FULL `existing` array (including
+      // the old script entry) so an unchanged block still short-circuits as
+      // `fresh-skip`.
+      const nonScriptExisting = preserveNonScriptEntries(existing);
       const scriptHashes = scriptHashesByCriterion[criterionId];
       const freshExisting = existing.find((e) =>
         entryIsFresh(e, currentHashes, def.depends_on, scriptHashes),
@@ -323,7 +336,7 @@ function run(): void {
           reviewed_sha: headSha,
           notes: "block has no .md sibling",
         };
-        report.criteria[criterionId] = [...existing, naEntry];
+        report.criteria[criterionId] = [...nonScriptExisting, naEntry];
         sweepResult.details.push({
           criterion: criterionId,
           outcome: "n/a-no-md",
@@ -339,7 +352,7 @@ function run(): void {
           reviewed_sha: headSha,
           notes: "block has no .lean sibling",
         };
-        report.criteria[criterionId] = [...existing, naEntry];
+        report.criteria[criterionId] = [...nonScriptExisting, naEntry];
         sweepResult.details.push({
           criterion: criterionId,
           outcome: "n/a-no-lean",
@@ -386,8 +399,9 @@ function run(): void {
         }
       }
 
-      // Append the new entry (multiple reviewer entries co-exist).
-      report.criteria[criterionId] = [...existing, entry];
+      // Write the fresh script entry, REPLACING the prior script entry
+      // (agent + human entries are preserved via `nonScriptExisting`).
+      report.criteria[criterionId] = [...nonScriptExisting, entry];
 
       sweepResult.details.push({
         criterion: criterionId,

--- a/content/pipeline/qa-utils.ts
+++ b/content/pipeline/qa-utils.ts
@@ -524,7 +524,13 @@ export function entryIsFresh(
 export function preserveNonScriptEntries(
   existing: QaCriterionEntry[],
 ): QaCriterionEntry[] {
-  return existing.filter((e) => e.reviewer.kind !== "script");
+  // Optional chaining guards against malformed / legacy / hand-edited
+  // sidecar entries (a null entry, or one missing its `reviewer`): the
+  // `.qa.json` files are external JSON that `loadQaReport` does not
+  // shape-validate. Such an entry is NOT a recognizable script entry, so
+  // it is PRESERVED rather than dropped — dropping a malformed `human`
+  // entry would violate the "human always preserved" invariant above.
+  return existing.filter((e) => e?.reviewer?.kind !== "script");
 }
 
 /**

--- a/content/pipeline/qa-utils.ts
+++ b/content/pipeline/qa-utils.ts
@@ -506,6 +506,28 @@ export function entryIsFresh(
 }
 
 /**
+ * Entries a script sweep must NOT drop when it re-runs a criterion.
+ *
+ * A script re-run is a REFRESH, not a new opinion: it must REPLACE the
+ * prior `kind: "script"` entry rather than append a duplicate. So when
+ * a sweep writes a fresh script entry it keeps only the non-script
+ * entries — `kind: "agent"` (the multi-reviewer audit trail across
+ * agent passes is meaningful and co-exists) and `kind: "human"` (final
+ * authority; never dropped) — and appends the one fresh script entry.
+ *
+ * Filtering the stale script entry here is what keeps `<block>.qa.json`
+ * criterion arrays from growing unboundedly on every sweep. This mirrors
+ * the invalidation contract in the `integration-audit` skill ("Pure
+ * script: delete every `kind:"script"` reviewer entry; sweep re-runs" /
+ * "Human: always preserved").
+ */
+export function preserveNonScriptEntries(
+  existing: QaCriterionEntry[],
+): QaCriterionEntry[] {
+  return existing.filter((e) => e.reviewer.kind !== "script");
+}
+
+/**
  * Per-criterion freshness summary for one block.
  *
  * - `fresh-entries`: reviewer entries whose field_hash matches.

--- a/scripts/tests/qa-sweep-merge.test.ts
+++ b/scripts/tests/qa-sweep-merge.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Regression tests for the qa-sweep script-entry REPLACE behaviour.
+ *
+ * A `qa-sweep` re-run is a REFRESH of the deterministic (`kind: "script"`)
+ * verdict — NOT a new opinion. It must therefore REPLACE the prior script
+ * entry for a criterion rather than append a duplicate, so `<block>.qa.json`
+ * criterion arrays do not grow unboundedly on every sweep. Agent-kind
+ * entries (the multi-reviewer audit trail) and human-kind entries (final
+ * authority) are always preserved.
+ *
+ * The write step qa-sweep performs at each of its three sidecar-write sites
+ * is `report.criteria[c] = [...preserveNonScriptEntries(existing), entry]`.
+ * `sweepWrite` below reproduces exactly that step, so running it twice on the
+ * same criterion array models "two consecutive sweeps of one unchanged block".
+ *
+ * Covers the acceptance criteria in the task requirements:
+ *   §5.1 — array length stable across two consecutive sweeps (no growth)
+ *   §5.2 — a pre-existing human entry is retained
+ *   §5.3 — a pre-existing agent entry is retained (agents still append)
+ *   §5.4 — [script_stale, agent] → [agent, script_fresh] (one script, agent kept)
+ *
+ * Run via the standard `bun test` harness:
+ *
+ *     ./scripts/tests/run-tests.sh
+ *     # or
+ *     cd scripts/tests && bun test qa-sweep-merge.test.ts
+ */
+import { describe, test, expect } from "bun:test";
+import { preserveNonScriptEntries } from "../../content/pipeline/qa-utils.ts";
+import type {
+  QaCriterionEntry,
+  QaReviewerKind,
+} from "../../schemas/block-qa.ts";
+
+// ── fixture builders ─────────────────────────────────────────────
+
+function entry(
+  kind: QaReviewerKind,
+  opts: { result?: QaCriterionEntry["result"]; tag?: string } = {},
+): QaCriterionEntry {
+  return {
+    field_hash: { md: opts.tag ?? "aaaaaaaaaaaa" },
+    result: opts.result ?? "pass",
+    reviewer: {
+      kind,
+      id:
+        kind === "script"
+          ? "content/pipeline/qa-checkers-voice.ts"
+          : kind === "agent"
+            ? "claude:one-voice-integration-watcher"
+            : "litlfred",
+      version: "v1",
+    },
+    reviewed_at: "2026-07-04T00:00:00.000Z",
+    reviewed_sha: "0".repeat(40),
+  };
+}
+
+/**
+ * Reproduce the exact write step qa-sweep performs: drop the prior
+ * script entry, append the fresh script entry. Returns the new array.
+ */
+function sweepWrite(
+  existing: QaCriterionEntry[],
+  fresh: QaCriterionEntry,
+): QaCriterionEntry[] {
+  return [...preserveNonScriptEntries(existing), fresh];
+}
+
+// ── preserveNonScriptEntries — unit ──────────────────────────────
+
+describe("preserveNonScriptEntries", () => {
+  test("drops every script entry, keeps agent + human", () => {
+    const kept = preserveNonScriptEntries([
+      entry("script"),
+      entry("agent"),
+      entry("script"),
+      entry("human"),
+    ]);
+    expect(kept.map((e) => e.reviewer.kind)).toEqual(["agent", "human"]);
+  });
+
+  test("empty array stays empty", () => {
+    expect(preserveNonScriptEntries([])).toEqual([]);
+  });
+
+  test("does not mutate its input", () => {
+    const input = [entry("script"), entry("agent")];
+    const before = input.length;
+    preserveNonScriptEntries(input);
+    expect(input.length).toBe(before);
+  });
+});
+
+// ── the REPLACE-not-append invariant (task §5) ───────────────────
+
+describe("qa-sweep script-entry REPLACE (task §5)", () => {
+  test("§5.1 — array length is stable across two consecutive sweeps", () => {
+    // Sweep run 1 on a fresh (empty) criterion array.
+    const run1 = sweepWrite([], entry("script", { tag: "sha_run1" }));
+    // Sweep run 2 on the SAME (unchanged) block re-runs the checker and
+    // writes a fresh script entry (fresh reviewed_at / field_hash).
+    const run2 = sweepWrite(run1, entry("script", { tag: "sha_run2" }));
+
+    expect(run1.length).toBe(1);
+    // No growth: run 2 must not add a second script entry.
+    expect(run2.length).toBe(run1.length);
+    expect(run2.filter((e) => e.reviewer.kind === "script").length).toBe(1);
+  });
+
+  test("§5.2 — a pre-existing human entry is retained after a sweep", () => {
+    const start = [entry("human", { result: "fail" }), entry("script")];
+    const after = sweepWrite(start, entry("script", { tag: "fresh" }));
+    expect(after.filter((e) => e.reviewer.kind === "human").length).toBe(1);
+    expect(after.filter((e) => e.reviewer.kind === "script").length).toBe(1);
+  });
+
+  test("§5.3 — a pre-existing agent entry is retained (agents still append)", () => {
+    const start = [entry("agent")];
+    const after = sweepWrite(start, entry("script", { tag: "fresh" }));
+    expect(after.map((e) => e.reviewer.kind)).toEqual(["agent", "script"]);
+  });
+
+  test("§5.4 — [script_stale, agent] → [agent, script_fresh]", () => {
+    const start = [
+      entry("script", { tag: "stale" }),
+      entry("agent"),
+    ];
+    const after = sweepWrite(start, entry("script", { tag: "fresh" }));
+    expect(after.map((e) => e.reviewer.kind)).toEqual(["agent", "script"]);
+    // exactly one script entry, and it is the fresh one
+    const scripts = after.filter((e) => e.reviewer.kind === "script");
+    expect(scripts.length).toBe(1);
+    expect(scripts[0].field_hash.md).toBe("fresh");
+  });
+
+  test("multiple agent entries all survive a script sweep", () => {
+    const start = [entry("agent"), entry("agent"), entry("script")];
+    const after = sweepWrite(start, entry("script", { tag: "fresh" }));
+    expect(after.filter((e) => e.reviewer.kind === "agent").length).toBe(2);
+    expect(after.filter((e) => e.reviewer.kind === "script").length).toBe(1);
+    // Repeated sweeps never grow the agent count or the script count.
+    const after2 = sweepWrite(after, entry("script", { tag: "fresher" }));
+    expect(after2.length).toBe(after.length);
+  });
+});

--- a/scripts/tests/qa-sweep-merge.test.ts
+++ b/scripts/tests/qa-sweep-merge.test.ts
@@ -90,6 +90,27 @@ describe("preserveNonScriptEntries", () => {
     preserveNonScriptEntries(input);
     expect(input.length).toBe(before);
   });
+
+  test("does not throw on malformed / legacy sidecar entries; preserves them", () => {
+    // Sidecars are external JSON that loadQaReport does not shape-validate,
+    // so a hand-edited / legacy entry may be null or lack a `reviewer`.
+    // preserveNonScriptEntries must not crash, and (being unable to prove
+    // such an entry is a script entry) must PRESERVE it rather than drop it
+    // — dropping a malformed human entry would break "human always preserved".
+    const malformed = [
+      null,
+      undefined,
+      {} as unknown, // no reviewer
+      { reviewer: {} } as unknown, // reviewer without kind
+      entry("script"),
+      entry("human"),
+    ] as unknown as QaCriterionEntry[];
+    const kept = preserveNonScriptEntries(malformed);
+    // the one well-formed script entry is dropped; everything else kept
+    expect(kept.length).toBe(malformed.length - 1);
+    expect(kept).toContain(malformed[5]); // human preserved
+    expect(kept).not.toContain(malformed[4]); // script dropped
+  });
 });
 
 // ── the REPLACE-not-append invariant (task §5) ───────────────────


### PR DESCRIPTION
## Problem

`qa-sweep` wrote every automated (`kind: "script"`) criterion result by **appending** to the criterion's entry array (`report.criteria[id] = [...existing, entry]`, 3 sites). Because each `entry` carries a fresh `field_hash` / `reviewed_at` / `reviewed_sha`, a re-sweep of an unchanged-verdict block **added a duplicate script entry** rather than refreshing the prior one, so criterion arrays grew **unboundedly** with every sweep.

Origin: discovered while refreshing the `qou` `<block>.qa.json` sidecars after a content edit. On one block (`braids-and-knots/hecke-normal-form.qa.json`) a single re-sweep grew total criterion entries 60 → 105; across 167 sidecars this produced a **+162k-line** diff of pure duplicated history.

## Fix

A **script re-run is a REFRESH, not a new opinion**, so the fresh script entry must **REPLACE** the prior script entry:

- New pure helper `preserveNonScriptEntries(existing)` in `content/pipeline/qa-utils.ts` — drops every `kind: "script"` entry, keeps `kind: "agent"` (multi-reviewer audit trail co-exists) and `kind: "human"` (final authority, never dropped).
- `qa-sweep.ts` computes `nonScriptExisting = preserveNonScriptEntries(existing)` once and uses it at all **three** write sites (the two `n/a` markers + the checker result).
- The freshness gate (`existing.find(entryIsFresh…)`) still scans the **full** `existing` array, so an unchanged block still short-circuits as `fresh-skip`.

This matches the invalidation contract in `.claude/skills/local/integration-audit.md` ("Pure script: delete every `kind:"script"` reviewer entry; sweep re-runs" / "Human: always preserved").

### Self-healing de-bloat
Because `nonScriptExisting` drops **all** prior script entries, any sidecar that already accumulated `[script_v1, script_v2, …]` collapses to a single fresh script entry the next time that criterion runs — no migration script needed. A corpus-wide sweep (or nightly `qa-sweep.yml`) will produce a one-time de-bloat diff.

## Tests

`scripts/tests/qa-sweep-merge.test.ts` (new) covers the acceptance criteria against the shared helper:

- **§5.1** array length stable across two consecutive sweeps (no growth)
- **§5.2** pre-existing `human` entry retained
- **§5.3** pre-existing `agent` entry retained (agents still append)
- **§5.4** `[script_stale, agent]` → `[agent, script_fresh]` (one script entry, agent preserved)

The test targets the extracted helper rather than a subprocess sweep, so it writes **no** `script-sidecars/*.json` into the repo tree.

## Verification

- `bun test scripts/tests/qa-sweep-merge.test.ts` → **8 pass / 0 fail**.
- `tsc --noEmit` → **no type errors** in the changed files.
- Full suite: the 29 unrelated failures are environmental in this standalone clone (missing qou-wired `folio-assistant/schemas/constraints.ts` symlink, `proof-objects.json`, generated `chapters/*.tex`); none reference qa/sweep/utils, and they reproduce on `main`.
- `eslint .` could not run in this standalone clone (no `eslint.config.*` / no local eslint binary — the `eslint .` script depends on wiring not present here); the changed files follow the surrounding style and type-check clean.

## Out of scope (not bundled)
- The qou-side bulk sidecar refresh (167 blocks) — separate qou task.
- Refreshing the 28 **agent** criteria (drained by `/integration-backlog`).
- Any change to `qa-checkers-*.ts` verdict logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9jVvC6oPG5vVKUvuXpWK2

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9jVvC6oPG5vVKUvuXpWK2)_