### PR TITLE
fix(qa-checkers): domain-phrase exemption + wall-side reads authorNotes

### DIFF
--- a/content/pipeline/qa-checkers-voice.ts
+++ b/content/pipeline/qa-checkers-voice.ts
@@ -234,8 +234,11 @@ const MATH_IDIOM_EXEMPT =
 // Domain-terminology exemption: fixed scientific noun-phrases in which a
 // flagged adverb is bound into a standard term of art, not editorializing.
 // e.g. "naturally occurring elements/isotopes" (natural vs. synthetic) —
-// removing the adverb would break the terminology.
-const DOMAIN_PHRASE_EXEMPT = /\bnaturally\s+occurring\b/i;
+// removing the adverb would break the terminology. Applied by STRIPPING the
+// phrase from a scratch copy of the line before the editorializing test, so
+// it never masks a genuine hit elsewhere on the same line (global flag →
+// every occurrence removed; used only in `.replace`, never stateful `.test`).
+const DOMAIN_PHRASE_EXEMPT = /\bnaturally\s+occurring\b/gi;
 
 export function checkEditorializing(mdPath: string): CheckerResult {
   // Skip lines that are clearly in fenced code (Lean / TeX snippets).
@@ -248,14 +251,15 @@ export function checkEditorializing(mdPath: string): CheckerResult {
       return;
     }
     if (inFence) return;
-    if (!EDITORIALIZING_RE.test(l)) return;
+    // Strip fixed scientific noun-phrases ("naturally occurring") from a
+    // scratch copy first, so an adverb bound inside one is not flagged
+    // WITHOUT masking other editorializing terms elsewhere on the line.
+    const scan = l.replace(DOMAIN_PHRASE_EXEMPT, "");
+    if (!EDITORIALIZING_RE.test(scan)) return;
     // Math-idiom exemption: if the editorial adverb is in a math
     // construction (e.g. "naturally an algebra", "non-simply-laced",
     // "contribute trivially"), it's canonical math language.
-    if (MATH_IDIOM_EXEMPT.test(l)) return;
-    // Domain-terminology exemption: fixed scientific noun-phrases
-    // ("naturally occurring elements") are standard terms, not opinion.
-    if (DOMAIN_PHRASE_EXEMPT.test(l)) return;
+    if (MATH_IDIOM_EXEMPT.test(scan)) return;
     hits.push({ file: mdPath, line: i + 1, text: l.trim().slice(0, 200) });
   });
   return { result: hits.length > 0 ? "fail" : "pass", hits };
@@ -354,20 +358,30 @@ const ALGEBRAIC_LEAN_RE = /\b(CommRing|Field|GroupWithZero|\{R : Type\*\}|\(R :=
 function readAuthorNotesText(tsPath: string | undefined): string {
   if (!tsPath || !existsSync(tsPath)) return "";
   const src = readFileSync(tsPath, "utf-8");
-  const m = src.match(/authorNotes\s*:\s*\[/);
+  const m = src.match(/\bauthorNotes\s*:\s*\[/);
   if (!m || m.index === undefined) return "";
   let depth = 0;
   let out = "";
+  // Active string delimiter ('"' | "'" | "`") or null when outside a string.
+  // Bracket depth is only tracked OUTSIDE string literals, so a `]` inside a
+  // note body (markdown links `[t](u)`, footnotes `[1]`, refterms) does not
+  // prematurely terminate the array extraction.
+  let quote: string | null = null;
   for (let i = m.index + m[0].length - 1; i < src.length; i++) {
     const ch = src[i];
-    if (ch === "[") depth++;
-    else if (ch === "]") {
-      depth--;
-      out += ch;
-      if (depth === 0) break;
+    out += ch;
+    if (quote) {
+      if (ch === quote && src[i - 1] !== "\\") quote = null;
       continue;
     }
-    out += ch;
+    if (ch === '"' || ch === "'" || ch === "`") {
+      quote = ch;
+    } else if (ch === "[") {
+      depth++;
+    } else if (ch === "]") {
+      depth--;
+      if (depth === 0) break;
+    }
   }
   return out;
 }
@@ -416,9 +430,12 @@ export function checkWallSide(
     // Archimedean is fine if the specialisation is acknowledged — either
     // in the .md narrative OR in the .ts `authorNotes` (per CLAUDE.md §4d,
     // §7c banners migrate out of prose into authorNotes).
-    const ack = (md + "\n" + readAuthorNotesText(tsPath)).toLowerCase();
+    // Keep original casing and use a case-insensitive regex: lowercasing
+    // `ack` would turn `\mathbb{R}` into `\mathbb{r}`, which the (uppercase-R)
+    // alternative cannot then match — a latent false-fail source.
+    const ack = md + "\n" + readAuthorNotesText(tsPath);
     const acknowledged =
-      /archimedean|over\s+\\?mathbb\{R\}|over\s+ℝ|specialise|specialize|numerical evaluation|codata|experimental|§7c|base.?ring/.test(
+      /archimedean|over\s+\$?\\?mathbb\{R\}|over\s+ℝ|specialise|specialize|numerical evaluation|codata|experimental|§7c|base.?ring/i.test(
         ack,
       );
     if (!acknowledged) {

--- a/content/pipeline/qa-checkers-voice.ts
+++ b/content/pipeline/qa-checkers-voice.ts
@@ -231,6 +231,12 @@ const EDITORIALIZING_RE =
 const MATH_IDIOM_EXEMPT =
   /(?:naturally|trivially|easily|cleanly|simply|nicely|just)\s+(?:an?|the)\s+\S+|(?:decomposes|attaches|factors|contributes?|contribute|extends|embeds|maps|acts|commutes|generates|bar-classify|generate)\s+(?:naturally|trivially|easily|cleanly|nicely|simply)\b|(?:naturally|trivially|easily|cleanly|nicely|simply)\s+\$|(?:non|un|tri|semi|quasi|bi|sub|super|hyper|inter|intra|pre|post)-(?:simply|naturally|trivially|easily|cleanly|nicely)|(?:simply|naturally|trivially|easily|cleanly|nicely)-(?:laced|connected|graded|ordered)/i;
 
+// Domain-terminology exemption: fixed scientific noun-phrases in which a
+// flagged adverb is bound into a standard term of art, not editorializing.
+// e.g. "naturally occurring elements/isotopes" (natural vs. synthetic) —
+// removing the adverb would break the terminology.
+const DOMAIN_PHRASE_EXEMPT = /\bnaturally\s+occurring\b/i;
+
 export function checkEditorializing(mdPath: string): CheckerResult {
   // Skip lines that are clearly in fenced code (Lean / TeX snippets).
   const lines = readLines(mdPath);
@@ -247,6 +253,9 @@ export function checkEditorializing(mdPath: string): CheckerResult {
     // construction (e.g. "naturally an algebra", "non-simply-laced",
     // "contribute trivially"), it's canonical math language.
     if (MATH_IDIOM_EXEMPT.test(l)) return;
+    // Domain-terminology exemption: fixed scientific noun-phrases
+    // ("naturally occurring elements") are standard terms, not opinion.
+    if (DOMAIN_PHRASE_EXEMPT.test(l)) return;
     hits.push({ file: mdPath, line: i + 1, text: l.trim().slice(0, 200) });
   });
   return { result: hits.length > 0 ? "fail" : "pass", hits };
@@ -335,9 +344,38 @@ const ALGEBRAIC_LEAN_RE = /\b(CommRing|Field|GroupWithZero|\{R : Type\*\}|\(R :=
  * archimedean markers without the .md acknowledging archimedean
  * specialisation) get flagged.
  */
+/**
+ * Extract the text of a block's `authorNotes` array literal from its
+ * `.ts` manifest (best-effort, bracket-depth aware). Per CLAUDE.md §4d,
+ * §7c archimedean-specialisation acknowledgements migrate OUT of prose
+ * INTO `authorNotes`, so the wall-side acknowledgement check must read
+ * them too — otherwise a correctly-migrated note reads as a false fail.
+ */
+function readAuthorNotesText(tsPath: string | undefined): string {
+  if (!tsPath || !existsSync(tsPath)) return "";
+  const src = readFileSync(tsPath, "utf-8");
+  const m = src.match(/authorNotes\s*:\s*\[/);
+  if (!m || m.index === undefined) return "";
+  let depth = 0;
+  let out = "";
+  for (let i = m.index + m[0].length - 1; i < src.length; i++) {
+    const ch = src[i];
+    if (ch === "[") depth++;
+    else if (ch === "]") {
+      depth--;
+      out += ch;
+      if (depth === 0) break;
+      continue;
+    }
+    out += ch;
+  }
+  return out;
+}
+
 export function checkWallSide(
   mdPath: string | undefined,
   leanPath: string | undefined,
+  tsPath?: string | undefined,
 ): CheckerResult {
   if (!leanPath || !existsSync(leanPath)) {
     return { result: "pass", hits: [] };
@@ -371,22 +409,27 @@ export function checkWallSide(
     });
   }
 
-  if (isArchimedean && mdPath && existsSync(mdPath)) {
-    const md = readFileSync(mdPath, "utf-8");
-    // Archimedean is fine if the .md acknowledges the specialisation.
-    // Without acknowledgement we flag for review.
+  const mdReadable = mdPath && existsSync(mdPath);
+  const tsReadable = tsPath && existsSync(tsPath);
+  if (isArchimedean && (mdReadable || tsReadable)) {
+    const md = mdReadable ? readFileSync(mdPath!, "utf-8") : "";
+    // Archimedean is fine if the specialisation is acknowledged — either
+    // in the .md narrative OR in the .ts `authorNotes` (per CLAUDE.md §4d,
+    // §7c banners migrate out of prose into authorNotes).
+    const ack = (md + "\n" + readAuthorNotesText(tsPath)).toLowerCase();
     const acknowledged =
-      /archimedean|over\s+\\?mathbb\{R\}|over\s+ℝ|specialise|specialize|numerical evaluation|codata|experimental/.test(
-        md.toLowerCase(),
+      /archimedean|over\s+\\?mathbb\{R\}|over\s+ℝ|specialise|specialize|numerical evaluation|codata|experimental|§7c|base.?ring/.test(
+        ack,
       );
     if (!acknowledged) {
       hits.push({
         file: leanPath,
         line: 1,
         text:
-          "Lean file uses archimedean constructs but .md narrative does " +
-          "not acknowledge archimedean specialisation. Add a §7c-style " +
-          "banner or move the archimedean evaluation to a sibling block.",
+          "Lean file uses archimedean constructs but neither the .md " +
+          "narrative nor the .ts authorNotes acknowledge archimedean " +
+          "specialisation. Add a §7c-style note (in authorNotes, per §4d) " +
+          "or move the archimedean evaluation to a sibling block.",
       });
     }
   }
@@ -912,7 +955,7 @@ export const AUTOMATED_CHECKERS: Record<
       : { result: "pass", hits: [] },
   "framework-canonical": (p) =>
     p.md ? checkFrameworkCanonical(p.md) : { result: "pass", hits: [] },
-  "wall-side-correct": (p) => checkWallSide(p.md, p.lean),
+  "wall-side-correct": (p) => checkWallSide(p.md, p.lean, p.ts),
   "wall-base-ring-minimal": (p) => checkBaseRingMinimal(p.lean),
   // Extended checkers for the non-voice integration axes
   // (proof, canonical, compute, detangler, bibliography). The

--- a/content/pipeline/qa-criteria-registry.ts
+++ b/content/pipeline/qa-criteria-registry.ts
@@ -277,9 +277,11 @@ const WALL: QaCriterionDefinition[] = [
       "explicitly. Each block belongs in either the algebraic substrate " +
       "or the archimedean specialisation, never both.",
     default_severity: "critical",
-    // The automated checker scans .lean imports and the .md narrative
-    // for an archimedean acknowledgement banner. The .ts manifest is
-    // not read — kept out of depends_on to avoid spurious staleness.
+    // The automated checker scans the .lean body for archimedean markers
+    // and looks for an archimedean-specialisation acknowledgement in EITHER
+    // the .md narrative OR the .ts `authorNotes` (per CLAUDE.md §4d, §7c
+    // banners migrate out of prose into authorNotes) — so `ts` is a genuine
+    // input and belongs in depends_on for correct staleness tracking.
     //
     // Coverage scope: the `.lean` read here is the block's *resolved*
     // file — candidate-1 sibling OR candidate-2 library/Lake-tree module
@@ -288,7 +290,7 @@ const WALL: QaCriterionDefinition[] = [
     // declarations referenced by a block are therefore in scope. Files
     // referenced by NO block (orphans) are swept separately, content-
     // based + chapter-independent, by `q-usage-audit`'s orphan pass.
-    depends_on: ["md", "lean"],
+    depends_on: ["md", "lean", "ts"],
     automated: true,
   },
   {

--- a/scripts/tests/qa-checkers-voice.test.ts
+++ b/scripts/tests/qa-checkers-voice.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Unit tests for the voice/wall QA checkers' false-positive fixes
+ * (litlfred/folio-assistant #41):
+ *
+ *   1. `checkEditorializing` — the "naturally occurring" domain-phrase
+ *      exemption must be a STRIP (not a whole-line skip), so a genuine
+ *      editorializing term elsewhere on the same line is still caught.
+ *   2. `checkWallSide` — the §7c archimedean acknowledgement may live in
+ *      the `.ts` `authorNotes` (per CLAUDE.md §4d), not only the `.md`;
+ *      a `]` inside a note body must not truncate extraction; and the
+ *      `\mathbb{R}` acknowledgement must match regardless of case.
+ *
+ * Run via `bun test`.
+ */
+import { describe, test, expect } from "bun:test";
+import { writeFileSync, mkdtempSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  checkEditorializing,
+  checkWallSide,
+} from "../../content/pipeline/qa-checkers-voice.ts";
+
+const DIR = mkdtempSync(join(tmpdir(), "qa-voice-"));
+let seq = 0;
+function tmp(name: string, contents: string): string {
+  const p = join(DIR, `${seq++}-${name}`);
+  writeFileSync(p, contents);
+  return p;
+}
+const ed = (line: string) =>
+  checkEditorializing(tmp("t.md", line)).result;
+
+describe("checkEditorializing — domain-phrase exemption is a strip, not a mask", () => {
+  test("'naturally occurring' alone passes (domain term, not opinion)", () => {
+    expect(ed("These are naturally occurring elements.")).toBe("pass");
+  });
+  test("editorializing elsewhere on a 'naturally occurring' line still FAILS", () => {
+    // The strip must not hide the second hit — regression for #41 comment.
+    expect(
+      ed("naturally occurring elements are, surprisingly, abundant"),
+    ).toBe("fail");
+  });
+  test("'simply is' still fails (genuine intensifier)", () => {
+    expect(ed("the universe simply is the structure")).toBe("fail");
+  });
+  test("'naturally beautiful' still fails (exemption is narrow)", () => {
+    expect(ed("a naturally beautiful result")).toBe("fail");
+  });
+});
+
+describe("checkWallSide — §7c acknowledgement via .ts authorNotes", () => {
+  const archLean = () =>
+    tmp("a.lean", "noncomputable def f : Real := Real.pi\n");
+  const plainMd = () => tmp("a.md", "The map f is defined.");
+
+  test("§7c note in authorNotes → pass (no .md acknowledgement)", () => {
+    const ts = tmp(
+      "ack.ts",
+      `export const b = { authorNotes: [{ kind: "note", body: "archimedean specialisation over R (§7c)." }] };`,
+    );
+    expect(checkWallSide(plainMd(), archLean(), ts).result).toBe("pass");
+  });
+
+  test("no acknowledgement anywhere → fail (checker not neutered)", () => {
+    const ts = tmp("noack.ts", `export const b = { title: "f", uses: [] };`);
+    expect(checkWallSide(plainMd(), archLean(), ts).result).toBe("fail");
+  });
+
+  test("']' inside a note body does not truncate extraction of a later §7c note", () => {
+    const ts = tmp(
+      "brackets.ts",
+      `export const b = { authorNotes: [{ kind: "note", body: "see [ref](x) and footnote [1]; archimedean specialisation over R." }] };`,
+    );
+    expect(checkWallSide(plainMd(), archLean(), ts).result).toBe("pass");
+  });
+
+  test("'over \\\\mathbb{R}' acknowledgement in .md matches case-insensitively", () => {
+    const md = tmp("mr.md", "Defined over $\\mathbb{R}$ here.");
+    const ts = tmp("bare.ts", `export const b = { title: "f" };`);
+    expect(checkWallSide(md, archLean(), ts).result).toBe("pass");
+  });
+
+  test("algebraic .lean (generic R) is unaffected → pass", () => {
+    const lean = tmp("g.lean", "def f {R : Type*} [CommRing R] (x : R) := x\n");
+    const ts = tmp("bare2.ts", `export const b = { title: "f" };`);
+    expect(checkWallSide(plainMd(), lean, ts).result).toBe("pass");
+  });
+});


### PR DESCRIPTION
## What

Fixes two QA-checker false-positive classes surfaced by the qou exposition-drain sidecar refresh (litlfred/qou **#3327** / **#3330**). Both were content-correct blocks the checkers wrongly flagged.

### 1. `voice-editorializing` — domain-phrase exemption

The checker flagged the word **"naturally"** inside **"naturally occurring elements/isotopes"** (`amc-method.md:8`, `:136`) — the standard scientific term for natural vs. synthetic elements, not editorializing. Added a narrow `DOMAIN_PHRASE_EXEMPT` (`/\bnaturally\s+occurring\b/i`) alongside the existing math-idiom exemption.

**Narrowness verified** — genuine hits still fail:
| input | result |
|---|---|
| `naturally occurring elements` | pass ✓ (exempt) |
| `the universe simply is …` | fail ✓ |
| `a naturally beautiful result` | fail ✓ |
| `surprisingly, X holds` | fail ✓ |

### 2. `wall-side-correct` — read the §7c acknowledgement from `authorNotes`

`checkWallSide` scanned only the `.md` for the archimedean-specialisation acknowledgement. But per **CLAUDE.md §4d**, §7c banners migrate *out of prose into `.ts` `authorNotes`* (banner-in-prose is a one-voice Category H violation). So a correctly-migrated note (e.g. `torsion-knot-flow`, whose `.lean` puts `intrinsicAngularMomentum` over `ℝ` via `Real.pi`) read as a false **fail**.

- `checkWallSide` now takes `tsPath` and scans the block's `authorNotes` array text (bracket-depth-aware extractor) in addition to the `.md`.
- Acknowledgement regex extended with `§7c` / `base ring`.
- Registry `wall-side-correct.depends_on` gains **`ts`** so the verdict re-runs when `authorNotes` change (the stale "ts not read" comment is corrected).

**Not neutered** — an archimedean `.lean` with no acknowledgement in *either* `.md` or `authorNotes` still **fails** (verified).

## Verification

Against qou content: `amc-method` `voice-editorializing` → **pass**; `torsion-knot-flow` `wall-side-correct` → **pass**; 6/6 regression cases correct (unit-tested both checkers directly). Only `content/pipeline/qa-checkers-voice.ts` + `qa-criteria-registry.ts` touched.

Follow-up in qou: re-sweep the drain backlog so these two false-positive classes clear across all batches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019ieTGMnRzVKhHkCyaVeTSn)_