### PR TITLE
fix(qa): wall-side mixed-signal split ignores arithmetic tactics

### DIFF
--- a/content/pipeline/qa-checkers-voice.ts
+++ b/content/pipeline/qa-checkers-voice.ts
@@ -352,12 +352,15 @@ const ALGEBRAIC_LEAN_RE = /\b(CommRing|Field|GroupWithZero|\{R : Type\*\}|\(R :=
  *
  * The remaining tokens are IDENTICAL to `ARCHIMEDEAN_LEAN_RE` (no
  * broadening), so the split's coverage is unchanged. NB the `\b(…)\b`
- * framing is inherited verbatim, and its known limitation is inherited too:
- * the punctuation-leading alternatives (`\(ℝ\)`, `: ℝ`, `: Real`) cannot
- * actually match in JS (`\b` is ASCII-word-based and cannot sit before `(`
- * or `:`), so the EFFECTIVE markers are `Real.<fn>` and `LinearOrderedField`
- * — exactly the effective set `ARCHIMEDEAN_LEAN_RE` already uses. Broadening
- * ℝ detection to catch `(x : ℝ)` / `→ ℝ` forms is a deliberately SEPARATE
+ * framing is inherited verbatim, along with its known limitation: the
+ * punctuation-leading alternatives (`\(ℝ\)`, `: ℝ`, `: Real`) match only in
+ * uncommon spacings and MISS the common spaced Lean forms (`x : ℝ`,
+ * `(x : ℝ)`, `: ℝ :=`). (`\b` is ASCII-`\w`-based: the leading `\b` needs a
+ * word char immediately before `(`/`:`, and the trailing `\b` needs a word
+ * char immediately after ℝ — a space on either side breaks the match.) So
+ * the reliably-matched markers are `Real.<fn>` and `LinearOrderedField` —
+ * the same effective set `ARCHIMEDEAN_LEAN_RE` already uses. Broadening ℝ
+ * detection to catch `(x : ℝ)` / `→ ℝ` forms is a deliberately SEPARATE
  * follow-up: corpus-wide it newly flags 12 genuine ℝ+generic-R mixes the
  * heuristic currently misses, which belongs in its own change.
  *

--- a/content/pipeline/qa-checkers-voice.ts
+++ b/content/pipeline/qa-checkers-voice.ts
@@ -338,20 +338,33 @@ const ARCHIMEDEAN_LEAN_RE =
 const ALGEBRAIC_LEAN_RE = /\b(CommRing|Field|GroupWithZero|\{R : Type\*\}|\(R := |variable \{R\b)/;
 
 /**
- * Archimedean real-field TYPE markers — `ARCHIMEDEAN_LEAN_RE` MINUS the
- * four arithmetic tactics (`norm_num` / `linarith` / `positivity` /
- * `nlinarith`). Those tactics discharge goals over ANY ordered field (or
- * ℕ/ℤ numeric literals) and are NOT by themselves evidence of an ℝ
- * specialisation, so they must not drive the mixed-signal split: a generic
- * `[Field R]` file that merely closes a literal identity with `norm_num`
- * is purely algebraic, not a file "mixing ℝ with generic-R" (the
- * `bring-residue-resolvent` false-positive).
+ * Archimedean-side TYPE markers used for the mixed-signal split — this is
+ * `ARCHIMEDEAN_LEAN_RE` with the four arithmetic tactics (`norm_num` /
+ * `linarith` / `positivity` / `nlinarith`) removed. Those tactics discharge
+ * goals over ANY ordered field (or ℕ/ℤ numeric literals) and are NOT by
+ * themselves evidence of an archimedean specialisation, so they must not
+ * drive the "split this file" flag: a generic `[Field R]` file that merely
+ * closes a literal identity with `norm_num` is purely algebraic, not a file
+ * "mixing ℝ with generic-R" (the `bring-residue-resolvent` false-positive).
+ * (`LinearOrderedField` is an ordered-field structure, not ℝ-specific; it is
+ * kept for parity with `ARCHIMEDEAN_LEAN_RE` as the archimedean-ordering
+ * side of the §7c wall.)
  *
- * Token set is otherwise IDENTICAL to `ARCHIMEDEAN_LEAN_RE` (no broadening),
- * so the split's coverage of genuine ℝ+generic-R files is unchanged. The
- * acknowledgement check below keeps the full `ARCHIMEDEAN_LEAN_RE` signal
- * (tactics included), so ℝ-typed blocks whose ℝ is caught only via a soft
- * tactic still owe an acknowledgement — no acknowledgement coverage is lost.
+ * The remaining tokens are IDENTICAL to `ARCHIMEDEAN_LEAN_RE` (no
+ * broadening), so the split's coverage is unchanged. NB the `\b(…)\b`
+ * framing is inherited verbatim, and its known limitation is inherited too:
+ * the punctuation-leading alternatives (`\(ℝ\)`, `: ℝ`, `: Real`) cannot
+ * actually match in JS (`\b` is ASCII-word-based and cannot sit before `(`
+ * or `:`), so the EFFECTIVE markers are `Real.<fn>` and `LinearOrderedField`
+ * — exactly the effective set `ARCHIMEDEAN_LEAN_RE` already uses. Broadening
+ * ℝ detection to catch `(x : ℝ)` / `→ ℝ` forms is a deliberately SEPARATE
+ * follow-up: corpus-wide it newly flags 12 genuine ℝ+generic-R mixes the
+ * heuristic currently misses, which belongs in its own change.
+ *
+ * The acknowledgement check below keeps the full `ARCHIMEDEAN_LEAN_RE`
+ * signal (tactics included), so ℝ-typed blocks whose ℝ is caught only via a
+ * soft tactic still owe an acknowledgement — no acknowledgement coverage is
+ * lost.
  */
 const ARCHIMEDEAN_TYPE_RE =
   /\b(Real\.sqrt|Real\.rpow|Real\.log|Real\.exp|Real\.cos|Real\.sin|Real\.pi|\(ℝ\)|: ℝ\b|: Real\b|LinearOrderedField)\b/;
@@ -441,9 +454,9 @@ export function checkWallSide(
       file: leanPath,
       line: 1,
       text:
-        "Lean file contains both archimedean (ℝ / Real.* / linarith) AND " +
-        "generic-R (CommRing / {R : Type*}) markers — split into two files " +
-        "per CLAUDE.md §7c.",
+        "Lean file mixes a real-field type (Real.* / LinearOrderedField) " +
+        "with generic-R (CommRing / {R : Type*}) markers — split into two " +
+        "files per CLAUDE.md §7c.",
     });
   }
 

--- a/content/pipeline/qa-checkers-voice.ts
+++ b/content/pipeline/qa-checkers-voice.ts
@@ -338,6 +338,25 @@ const ARCHIMEDEAN_LEAN_RE =
 const ALGEBRAIC_LEAN_RE = /\b(CommRing|Field|GroupWithZero|\{R : Type\*\}|\(R := |variable \{R\b)/;
 
 /**
+ * Archimedean real-field TYPE markers — `ARCHIMEDEAN_LEAN_RE` MINUS the
+ * four arithmetic tactics (`norm_num` / `linarith` / `positivity` /
+ * `nlinarith`). Those tactics discharge goals over ANY ordered field (or
+ * ℕ/ℤ numeric literals) and are NOT by themselves evidence of an ℝ
+ * specialisation, so they must not drive the mixed-signal split: a generic
+ * `[Field R]` file that merely closes a literal identity with `norm_num`
+ * is purely algebraic, not a file "mixing ℝ with generic-R" (the
+ * `bring-residue-resolvent` false-positive).
+ *
+ * Token set is otherwise IDENTICAL to `ARCHIMEDEAN_LEAN_RE` (no broadening),
+ * so the split's coverage of genuine ℝ+generic-R files is unchanged. The
+ * acknowledgement check below keeps the full `ARCHIMEDEAN_LEAN_RE` signal
+ * (tactics included), so ℝ-typed blocks whose ℝ is caught only via a soft
+ * tactic still owe an acknowledgement — no acknowledgement coverage is lost.
+ */
+const ARCHIMEDEAN_TYPE_RE =
+  /\b(Real\.sqrt|Real\.rpow|Real\.log|Real\.exp|Real\.cos|Real\.sin|Real\.pi|\(ℝ\)|: ℝ\b|: Real\b|LinearOrderedField)\b/;
+
+/**
  * Block is wall-correct iff:
  *   - it has no .lean, OR
  *   - .lean is purely algebraic (no archimedean markers), OR
@@ -412,7 +431,12 @@ export function checkWallSide(
   const isAlgebraic = ALGEBRAIC_LEAN_RE.test(stripped);
   const hits: CheckerHit[] = [];
 
-  if (isArchimedean && isAlgebraic) {
+  // Mixed-signal split keys on a genuine ℝ / Real TYPE, not on arithmetic
+  // tactics: only a real-field type coexisting with generic-R markers is a
+  // "split this file" placement. A soft tactic (norm_num / linarith / …)
+  // over a generic `[Field R]` file is the legitimate algebraic pattern,
+  // not a wall violation (the bring-residue-resolvent false-positive).
+  if (ARCHIMEDEAN_TYPE_RE.test(stripped) && isAlgebraic) {
     hits.push({
       file: leanPath,
       line: 1,

--- a/scripts/tests/qa-checkers-voice.test.ts
+++ b/scripts/tests/qa-checkers-voice.test.ts
@@ -86,4 +86,35 @@ describe("checkWallSide — §7c acknowledgement via .ts authorNotes", () => {
     const ts = tmp("bare2.ts", `export const b = { title: "f" };`);
     expect(checkWallSide(plainMd(), lean, ts).result).toBe("pass");
   });
+
+  test("generic [Field R] closing a literal with norm_num is NOT a mixed-signal fail (bring-residue pattern)", () => {
+    // No ℝ / Real TYPE anywhere — only `[Field R]` + `norm_num`. The
+    // arithmetic tactics (`norm_num` / `linarith` / `positivity` /
+    // `nlinarith`) discharge goals over any ordered field / ℕ / ℤ and are
+    // NOT evidence of an ℝ specialisation, so they must not drive the
+    // mixed-signal split. Under the old heuristic `norm_num` alongside
+    // `[Field R]` tripped "split into two files"; the block is purely
+    // algebraic and, with its acknowledgement, must pass.
+    const lean = tmp(
+      "field.lean",
+      "def r {R : Type*} [Field R] (n : ℕ) (q : R) : R := 1 / (1 - q ^ n)\nexample : ((-3 : ℚ)) * (1 / 4) = -3 / 4 := by norm_num\n",
+    );
+    const mdAck = tmp(
+      "fieldack.md",
+      "The resolvent specialises to the substrate q-character.",
+    );
+    const ts = tmp("field.ts", `export const b = { title: "r" };`);
+    expect(checkWallSide(mdAck, lean, ts).result).toBe("pass");
+  });
+
+  test("genuine ℝ-TYPE marker (Real.*) alongside generic-R is still flagged as mixed", () => {
+    // A real-field type (here `Real.pi`) coexisting with generic-R markers
+    // IS a real mixed placement — the split flag must survive.
+    const lean = tmp(
+      "mix.lean",
+      "variable {R : Type*} [CommRing R]\nnoncomputable def t : Real := Real.pi\n",
+    );
+    const ts = tmp("mix.ts", `export const b = { title: "t" };`);
+    expect(checkWallSide(plainMd(), lean, ts).result).toBe("fail");
+  });
 });


### PR DESCRIPTION
## Problem

`checkWallSide`'s **mixed-signal split** (`"Lean file contains both archimedean … AND generic-R markers — split into two files"`) keyed on `ARCHIMEDEAN_LEAN_RE`, which lists the arithmetic tactics `norm_num` / `linarith` / `positivity` / `nlinarith` as archimedean markers. Those tactics discharge goals over **any** ordered field (or ℕ/ℤ numeric literals) and are **not** by themselves evidence of an ℝ specialisation.

Consequence: a generic `[Field R]` file that merely closes a literal identity with `norm_num` was mis-flagged as "mixing ℝ with generic-R". Concretely, `bring-residue-resolvent` (generic over `[Field R]`, no ℝ anywhere, one `norm_num`) has been a persistent false `wall-side-correct` fail.

## Fix

Add `ARCHIMEDEAN_TYPE_RE` = `ARCHIMEDEAN_LEAN_RE` **minus the four tactics** (token set otherwise *identical* — no broadening), and key **only the mixed-signal split** on it. The acknowledgement branch keeps the full `ARCHIMEDEAN_LEAN_RE` signal (tactics included), so an ℝ-typed block whose ℝ is caught only via a soft tactic still owes an acknowledgement — **no acknowledgement coverage is lost.**

## Verification (corpus-wide, real runs)

Ran the checker over **all 895** qou blocks with a `.lean`, before vs after:

| | count | blocks |
|---|---|---|
| **fail → pass** | 2 | `bring-residue-resolvent` (generic `[Field R]`, no ℝ), `universal-braid-branching` (acknowledged; its ℝ, if any, is not a mixed-split token) |
| **pass → fail (regressions)** | **0** | — |

The narrow token set (no broadening) is what keeps regressions at zero — broadening the ℝ match instead surfaced 12 genuine ℝ+generic-R mixes main currently misses (out of scope here).

Two unit tests added (`bring-residue` pattern → pass; genuine `Real.*`+generic-R → still flagged). Suite green: **11/11**. `bun build` passes.

## Not addressed (deliberately)

The narrow `: ℝ\b` token still misses `(x : ℝ)`-style ℝ (inherited from `ARCHIMEDEAN_LEAN_RE`); broadening it is a separate, higher-impact change (the 12 mixes above) left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vq3enHCsCuxp4CrRhwjLTg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vq3enHCsCuxp4CrRhwjLTg)_