### PR TITLE
qa: honor QA_REPO_ROOT override so proof-lean-compiles scores in the miga sibling layout

### DIFF
--- a/content/pipeline/qa-checkers-extended.ts
+++ b/content/pipeline/qa-checkers-extended.ts
@@ -29,7 +29,17 @@ import { Q_USAGE_AUTOMATED_CHECKERS } from "./qa-checkers-q-usage";
 import { hashFile } from "./qa-utils";
 
 const __filename = fileURLToPath(import.meta.url);
-const REPO_ROOT = resolve(dirname(__filename), "..", "..");
+// The pipeline normally lives vendored inside the content repo
+// (`<repo>/content/pipeline/`), so REPO_ROOT is two levels up. When the
+// pipeline runs as a *sibling* checkout (the miga layout: content repo and
+// folio-assistant side by side, wired by a symlink), that heuristic points
+// at the folio-assistant clone instead of the content repo — the compile-
+// diagnostics / witness / computations paths then resolve to the wrong tree.
+// Honour an explicit `QA_REPO_ROOT` override for that case (defaults to the
+// legacy behaviour, so vendored / CI runs are unchanged).
+const REPO_ROOT = process.env.QA_REPO_ROOT
+  ? resolve(process.env.QA_REPO_ROOT)
+  : resolve(dirname(__filename), "..", "..");
 const CONTENT_DIR = resolve(dirname(__filename), "..");
 const COMPUTATIONS_DIR = join(REPO_ROOT, "folio-assistant", "computations");
 const BIB_QA_IMAGES_DIR = join(CONTENT_DIR, "bib-qa-images");

--- a/content/pipeline/qa-checkers-extended.ts
+++ b/content/pipeline/qa-checkers-extended.ts
@@ -37,10 +37,14 @@ const __filename = fileURLToPath(import.meta.url);
 // diagnostics / witness / computations paths then resolve to the wrong tree.
 // Honour an explicit `QA_REPO_ROOT` override for that case (defaults to the
 // legacy behaviour, so vendored / CI runs are unchanged).
-const REPO_ROOT = process.env.QA_REPO_ROOT
-  ? resolve(process.env.QA_REPO_ROOT)
+const QA_REPO_ROOT_OVERRIDE = process.env.QA_REPO_ROOT?.trim();
+const REPO_ROOT = QA_REPO_ROOT_OVERRIDE
+  ? resolve(QA_REPO_ROOT_OVERRIDE)
   : resolve(dirname(__filename), "..", "..");
-const CONTENT_DIR = resolve(dirname(__filename), "..");
+// CONTENT_DIR must honour the override too, so bibliography / detangler
+// checkers (references.ts, bib-qa.json, chapter manifests) read from the
+// content repo rather than the folio-assistant clone in the sibling layout.
+const CONTENT_DIR = join(REPO_ROOT, "content");
 const COMPUTATIONS_DIR = join(REPO_ROOT, "folio-assistant", "computations");
 const BIB_QA_IMAGES_DIR = join(CONTENT_DIR, "bib-qa-images");
 const BIB_QA_REPORT = join(CONTENT_DIR, "bib-qa.json");

--- a/content/pipeline/qa-utils.ts
+++ b/content/pipeline/qa-utils.ts
@@ -388,8 +388,9 @@ export function* walkBlocks(rootDir: string): Generator<BlockPaths> {
   // Resolve REPO_ROOT relative to qa-utils.ts (= content/pipeline/), unless
   // an explicit `QA_REPO_ROOT` override is set (the miga sibling-checkout
   // layout, where the pipeline is not vendored inside the content repo).
-  const REPO_ROOT = process.env.QA_REPO_ROOT
-    ? resolve(process.env.QA_REPO_ROOT)
+  const qaRepoRootOverride = process.env.QA_REPO_ROOT?.trim();
+  const REPO_ROOT = qaRepoRootOverride
+    ? resolve(qaRepoRootOverride)
     : resolve(import.meta.dir, "../..");
   const lakeCache: LakeTreeCache = new Map();
 

--- a/content/pipeline/qa-utils.ts
+++ b/content/pipeline/qa-utils.ts
@@ -385,8 +385,12 @@ export function* walkBlocks(rootDir: string): Generator<BlockPaths> {
   // .lean source (wall-side, voice, q-usage, …) don't silently skip.
   // `resolveCanonicalLean` is the single source of truth for that walk;
   // a shared cache scans each Lake tree once across the whole block walk.
-  // Resolve REPO_ROOT relative to qa-utils.ts (= content/pipeline/).
-  const REPO_ROOT = resolve(import.meta.dir, "../..");
+  // Resolve REPO_ROOT relative to qa-utils.ts (= content/pipeline/), unless
+  // an explicit `QA_REPO_ROOT` override is set (the miga sibling-checkout
+  // layout, where the pipeline is not vendored inside the content repo).
+  const REPO_ROOT = process.env.QA_REPO_ROOT
+    ? resolve(process.env.QA_REPO_ROOT)
+    : resolve(import.meta.dir, "../..");
   const lakeCache: LakeTreeCache = new Map();
 
   function* recurse(d: string): Generator<BlockPaths> {


### PR DESCRIPTION
## Problem

The QA checkers derive `REPO_ROOT` from the pipeline's own install location:
```ts
const REPO_ROOT = resolve(dirname(__filename), "..", "..");  // qa-checkers-extended.ts
const REPO_ROOT = resolve(import.meta.dir, "../..");          // qa-utils.ts
```
That assumes the pipeline is **vendored inside** the content repo (`<repo>/content/pipeline/`). In the **miga sibling-checkout layout** — content repo (e.g. `qou`) and `folio-assistant` side by side, wired by a symlink — `import.meta.url` resolves to the real `folio-assistant` clone, so `REPO_ROOT` points at `folio-assistant` instead of the content repo.

Consequence: every `REPO_ROOT`-relative read (`docs/audits/lean-compile-diagnostics.json`, witness paths, `computations/`) hits the wrong tree. In particular `checkProofLeanCompiles` reads a non-existent diagnostics file and mis-keys the `.lean` paths, so **`proof-lean-compiles` silently returns `n/a` for every block** even when the diagnostics cache in the content repo is fresh.

## Fix

Add an opt-in `QA_REPO_ROOT` env override to both `REPO_ROOT` definitions. Defaults to the legacy behavior (vendored / CI runs unchanged); sibling-checkout runs set `QA_REPO_ROOT=<content-repo>`.

## Verification

Against the `qou` corpus with the restored oleans + a fresh diagnostics cache:
- **Before:** `proof-lean-compiles` → `n/a` on all blocks.
- **After (`QA_REPO_ROOT=/path/to/qou`):** `proof-lean-compiles` → **162 pass**, remainder `n/a-no-lean` (no `.lean` sibling) / `n/a` (library-backed, not in cache).

No behavior change without the env var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJfbMYeKgon5vhxAwpuik5

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJfbMYeKgon5vhxAwpuik5)_