### PR TITLE
feat(qa-checkers): exempt §3b-cond conditional props from compute-prop-has-probe/-consumer

### DIFF
--- a/content/pipeline/qa-checkers-extended.ts
+++ b/content/pipeline/qa-checkers-extended.ts
@@ -362,8 +362,9 @@ function loadI1Audit(): Map<string, string> {
 const CONDITIONAL_CLASS_BANNER =
   /\*\*(?:Proposition|Theorem|Lemma|Corollary)\s*\((?:conditional on|assuming|given)\b/i;
 function isConditionalClassProp(mdPath: string | undefined): boolean {
-  if (!mdPath || !existsSync(mdPath)) return false;
-  return CONDITIONAL_CLASS_BANNER.test(readFileSync(mdPath, "utf-8").slice(0, 600));
+  // readMaybe degrades to "" on undefined / missing / unreadable (avoids a
+  // TOCTOU throw that would abort the whole sweep) → test("") is false.
+  return CONDITIONAL_CLASS_BANNER.test(readMaybe(mdPath).slice(0, 600));
 }
 
 export function checkComputePropHasProbe(

--- a/content/pipeline/qa-checkers-extended.ts
+++ b/content/pipeline/qa-checkers-extended.ts
@@ -351,12 +351,30 @@ function loadI1Audit(): Map<string, string> {
   return m;
 }
 
+/**
+ * A §3b-cond *conditional* proposition/theorem — one whose statement is
+ * explicitly gated on a conjectural hypothesis (the CLAUDE.md §4d banner
+ * `**Proposition (conditional on …)**`, which §4d keeps in prose) — is not a
+ * numerical prediction, so it needs no I1 compute probe / I2 consumer. The
+ * `sorry` in such a block's Lean is the intended conjectural class instance,
+ * not a missing proof. Detect the banner in the opening line of the `.md`.
+ */
+const CONDITIONAL_CLASS_BANNER =
+  /\*\*(?:Proposition|Theorem|Lemma|Corollary)\s*\((?:conditional on|assuming|given)\b/i;
+function isConditionalClassProp(mdPath: string | undefined): boolean {
+  if (!mdPath || !existsSync(mdPath)) return false;
+  return CONDITIONAL_CLASS_BANNER.test(readFileSync(mdPath, "utf-8").slice(0, 600));
+}
+
 export function checkComputePropHasProbe(
   tsPath: string | undefined,
   leanPath?: string | undefined,
+  mdPath?: string | undefined,
 ): CheckerResult {
   const ts = readTs(tsPath);
   if (!ts) return { result: "n/a", hits: [] };
+  // §3b-cond conditional results are not numerical predictions — exempt.
+  if (isConditionalClassProp(mdPath)) return { result: "pass", hits: [] };
   // Blocks with sorry-free Lean proofs are formally verified —
   // a computational probe is redundant for structural/algebraic
   // results. Only blocks making numerical predictions (those with
@@ -477,9 +495,12 @@ function loadI2AuditByWitness(): Map<
 export function checkComputePropHasConsumer(
   tsPath: string | undefined,
   leanPath?: string | undefined,
+  mdPath?: string | undefined,
 ): CheckerResult {
   const ts = readTs(tsPath);
   if (!ts) return { result: "n/a", hits: [] };
+  // §3b-cond conditional results need no compute consumer (see probe checker).
+  if (isConditionalClassProp(mdPath)) return { result: "pass", hits: [] };
   // Same exemption as compute-prop-has-probe: sorry-free Lean
   // proofs are formally verified — no compute consumer needed.
   if (leanPath && existsSync(resolve(REPO_ROOT, leanPath))) {
@@ -2563,8 +2584,9 @@ export const EXTENDED_AUTOMATED_CHECKERS: Record<
   "bib-cited-ref-has-screenshot": (p) =>
     checkBibCitedRefHasScreenshot(p.md, p.lean),
   // compute
-  "compute-prop-has-probe": (p) => checkComputePropHasProbe(p.ts, p.lean),
-  "compute-prop-has-consumer": (p) => checkComputePropHasConsumer(p.ts, p.lean),
+  "compute-prop-has-probe": (p) => checkComputePropHasProbe(p.ts, p.lean, p.md),
+  "compute-prop-has-consumer": (p) =>
+    checkComputePropHasConsumer(p.ts, p.lean, p.md),
   "compute-witness-exists": (p) => checkComputeWitnessExists(p.ts),
   "compute-lp-dual-present": (p) => checkComputeLpDualPresent(p.ts),
   // canonical

--- a/content/pipeline/qa-criteria-registry.ts
+++ b/content/pipeline/qa-criteria-registry.ts
@@ -1015,7 +1015,9 @@ const COMPUTE: QaCriterionDefinition[] = [
       "13-pattern audit: a numerical check that the proposition's claim " +
       "holds at a representative parameter point.",
     default_severity: "major",
-    depends_on: ["ts"],
+    // `lean` — sorry-free-proof exemption; `md` — §3b-cond conditional-banner
+    // exemption (a conditional result is not a numerical prediction).
+    depends_on: ["ts", "lean", "md"],
     automated: true,
     applies_to: ["theorem", "lemma", "proposition", "corollary"],
   },
@@ -1027,7 +1029,7 @@ const COMPUTE: QaCriterionDefinition[] = [
       "I13 of the 13-pattern audit). A prop with a probe but no consumer " +
       "is a NOT-WIRED prop. Routes to `compute-integration-watcher §B`.",
     default_severity: "major",
-    depends_on: ["ts"],
+    depends_on: ["ts", "lean", "md"],
     automated: true,
     applies_to: ["theorem", "lemma", "proposition", "corollary"],
   },


### PR DESCRIPTION
## What

A **conditional** proposition/theorem (CLAUDE.md §3b-cond) is gated on a conjectural hypothesis — its `**Proposition (conditional on …)**` banner (kept in prose per §4d) marks it as *not* a numerical prediction, and the `sorry` in its Lean is the intended conjectural class instance, not a missing proof. These blocks were false-flagged **NOT-WIRED** by `compute-prop-has-probe` / `-consumer` (they have neither a probe nor a sorry-free proof — by design).

## Fix

`checkComputePropHasProbe` / `-Consumer` now take `mdPath` and early-return `pass` when the `.md` opens with the conditional-class banner (`**(Proposition|Theorem|Lemma|Corollary) (conditional on|assuming|given …)**`). Registry `depends_on` gains `"lean"` + `"md"` (both are genuinely read — the sorry-free-proof exemption reads `lean`, the banner reads `md`).

## Verification (against qou)

- `quantum-universes/positive-definite-dagger` — **"Proposition (conditional on a formally-real pivotal structure)"** → `compute-prop-has-probe` / `-consumer` now **pass**.
- `climax-volume-mass/confinement-local-constancy` (unconditional control) → still **fail**.

Narrow exemption, no over-reach. Downstream: qou re-sweep flips `positive-definite-dagger`'s two verdicts to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019ieTGMnRzVKhHkCyaVeTSn)_