### PR TITLE
fix(qa): key wall-side ack branch on hasRealType, not tactic-inclusive isArchimedean

### DIFF
--- a/content/pipeline/qa-checkers-voice.ts
+++ b/content/pipeline/qa-checkers-voice.ts
@@ -486,14 +486,24 @@ export function checkWallSide(
     });
   }
 
-  // Archimedean-without-acknowledgement. Deliberately keyed on the NARROW
-  // `isArchimedean` (tactic-inclusive), NOT the broadened `hasRealType`:
-  // extending this requirement to every spaced `(x : ℝ)` block would newly
-  // flag ~100 pre-existing ℝ-specialised blocks corpus-wide, a large backlog
-  // that belongs in its own change (each needs a §7c note), not this one —
-  // whose scope is the mixed-signal broadening + ack-escape. (Mirrors folio
-  // #42, which likewise deferred the ℝ broadening it identified.)
-  if (isArchimedean && (mdReadable || tsReadable) && !acknowledged()) {
+  // Archimedean-without-acknowledgement. Keyed on the real-field TYPE signal
+  // `hasRealType` (`ℝ` / `Real.*` / `LinearOrderedField`), NOT the
+  // tactic-inclusive `isArchimedean`. Rationale: `hasRealType`'s `\bReal\b`
+  // already subsumes every genuine archimedean construct — the `Real.sqrt` /
+  // `Real.exp` / `Real.pi` real-analysis functions all contain `Real` — while
+  // deliberately EXCLUDING the bare arithmetic tactics `norm_num` / `linarith`
+  // / `positivity` / `nlinarith`, which discharge goals over ℕ/ℤ/ℚ or any
+  // ordered ring and are NOT evidence of an ℝ specialisation. Keying on
+  // `isArchimedean` (as the prior narrow form did) false-flagged purely
+  // algebraic blocks whose only "archimedean" marker was a `norm_num` closing
+  // an integer identity (e.g. a partition-function count) — a §7c note there
+  // would mislabel generic-ring algebra as archimedean. The broadening from
+  // the narrow `\(ℝ\)` / `: ℝ\b` tokens to the bare-`ℝ` `hasRealType` newly
+  // requires acknowledgement on every spaced `(x : ℝ)` / `→ ℝ` block; those
+  // pre-existing ℝ-specialised blocks are §7c-noted in the same mechanical
+  // sweep as this change (the deferred backlog from folio #42/#48 is drained
+  // here, minus the tactic-only false positives which now correctly pass).
+  if (hasRealType && (mdReadable || tsReadable) && !acknowledged()) {
     hits.push({
       file: leanPath,
       line: 1,

--- a/scripts/tests/qa-checkers-voice.test.ts
+++ b/scripts/tests/qa-checkers-voice.test.ts
@@ -145,3 +145,61 @@ describe("checkWallSide — §7c acknowledgement via .ts authorNotes", () => {
     expect(checkWallSide(mdAck, lean, ts).result).toBe("pass");
   });
 });
+
+describe("checkWallSide — ack branch keyed on hasRealType, not tactic-inclusive isArchimedean", () => {
+  const plainMd = () => tmp("p.md", "The statement holds.");
+
+  test("tactic-only block (norm_num, NO ℝ / Real / generic-R) → pass (false-positive drop)", () => {
+    // The prior ack branch keyed on the tactic-inclusive `isArchimedean`, so a
+    // purely-algebraic block whose only "archimedean" marker was a `norm_num`
+    // closing an integer identity (e.g. a partition-function count) was
+    // wrongly flagged as needing a §7c note. `norm_num` / `linarith` /
+    // `positivity` / `nlinarith` discharge goals over ℕ / ℤ / ℚ or any ordered
+    // ring and are NOT evidence of an ℝ specialisation. Keyed on `hasRealType`
+    // this now correctly passes with no acknowledgement.
+    const lean = tmp(
+      "tacticonly.lean",
+      "theorem a8 : (2 : ℕ) + 2 = 4 := by norm_num\nexample : 0 ≤ (3 : ℤ) := by positivity\n",
+    );
+    const ts = tmp("tacticonly.ts", `export const b = { title: "a8" };`);
+    expect(checkWallSide(plainMd(), lean, ts).result).toBe("pass");
+  });
+
+  test("colonless bare-ℝ return type `→ ℝ` (no `: ℝ` token), no ack → fail (broadening)", () => {
+    // The narrow `: ℝ\\b` token required a colon, so a colonless `→ ℝ` /
+    // `ℝ³` form slipped through the ack requirement. The bare-`ℝ`
+    // `hasRealType` matcher catches it: an unacknowledged real-valued block
+    // is now flagged regardless of the ℝ's surface form.
+    const lean = tmp(
+      "colonless.lean",
+      "noncomputable def energy : ℕ → ℝ := fun n => (n : ℝ)\n",
+    );
+    const ts = tmp("colonless.ts", `export const b = { title: "energy" };`);
+    expect(checkWallSide(plainMd(), lean, ts).result).toBe("fail");
+  });
+
+  test("colonless bare-ℝ `→ ℝ` WITH a §7c ack → pass (ack escape)", () => {
+    const lean = tmp(
+      "colonlessack.lean",
+      "noncomputable def energy : ℕ → ℝ := fun n => (n : ℝ)\n",
+    );
+    const mdAck = tmp(
+      "colonlessack.md",
+      "**Archimedean specialisation (§7c).** real-valued at q₀.",
+    );
+    const ts = tmp("colonlessack.ts", `export const b = { title: "energy" };`);
+    expect(checkWallSide(mdAck, lean, ts).result).toBe("pass");
+  });
+
+  test("Real.exp (real-analysis fn, subsumed by \\bReal\\b) with no ack → fail", () => {
+    // hasRealType's `\\bReal\\b` already subsumes every `Real.*` real-analysis
+    // function, so dropping the explicit `Real.exp` alternative from the ack
+    // key loses no genuine coverage.
+    const lean = tmp(
+      "realexp.lean",
+      "noncomputable def k (t : ℝ) : ℝ := Real.exp (-t)\n",
+    );
+    const ts = tmp("realexp.ts", `export const b = { title: "k" };`);
+    expect(checkWallSide(plainMd(), lean, ts).result).toBe("fail");
+  });
+});


### PR DESCRIPTION
## Summary

The `wall-side-correct` archimedean-acknowledgement branch keyed on the tactic-inclusive `isArchimedean` (`ARCHIMEDEAN_LEAN_RE`), which includes the arithmetic tactics `norm_num` / `linarith` / `positivity` / `nlinarith`. Those discharge goals over ℕ/ℤ/ℚ or any ordered ring and are **not** evidence of an ℝ specialisation — so a purely-algebraic block whose only "archimedean" marker was a `norm_num` closing an integer identity (e.g. a partition-function count) was falsely required to carry a §7c note, **mislabelling generic-ring algebra as archimedean**.

## Fix

Re-key the ack branch on `hasRealType` (`ℝ` / `Real.*` / `LinearOrderedField`):

- **Drops 5 tactic-only false positives** (`a8-partition-function-identity`, `markov-trace-antipode-polynomial-symmetry`, `cyclotomic-strand-doubling`, `zeta8-witness-level2-su2`, `contact-affine-chart`) — they now correctly pass with no note.
- **Loses no genuine coverage**: `hasRealType`'s `\bReal\b` already subsumes every `Real.*` real-analysis function (`Real.exp` / `Real.sqrt` / `Real.pi` …).
- **Completes the token → bare-`ℝ` broadening** for the ack branch: colonless `→ ℝ` / `ℝ³` forms that the narrow `: ℝ\b` token missed now require acknowledgement. This drains the backlog #42/#48 explicitly deferred.

## Tests

+4 regression tests (**17 pass / 0 fail**):
- tactic-only block (`norm_num`, no ℝ) → **pass** (false-positive drop)
- colonless `→ ℝ` return type, no ack → **fail** (broadening)
- colonless `→ ℝ` + §7c ack → **pass** (ack escape)
- `Real.exp` (subsumed by `\bReal\b`) → **fail**

## Sequencing

The 121 ℝ-specialised corpus blocks this newly requires acknowledgement on are §7c-noted in the paired **qou PR #3418**, which must land **first** so no fail-window opens. Merge order: qou #3418 → this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vq3enHCsCuxp4CrRhwjLTg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vq3enHCsCuxp4CrRhwjLTg)_