### PR TITLE
fix(qa): configure lean packages at runtime + resolve Lake tree against content root

### DIFF
--- a/content/pipeline/qa-utils.ts
+++ b/content/pipeline/qa-utils.ts
@@ -28,6 +28,7 @@ import type {
   QaScriptSidecar,
 } from "../../schemas/block-qa";
 import { QA_CRITERIA_BY_ID } from "./qa-criteria-registry";
+import { findContentRepoRoot } from "./repo-root";
 
 // ── Hashing ─────────────────────────────────────────────────────
 
@@ -385,8 +386,13 @@ export function* walkBlocks(rootDir: string): Generator<BlockPaths> {
   // .lean source (wall-side, voice, q-usage, …) don't silently skip.
   // `resolveCanonicalLean` is the single source of truth for that walk;
   // a shared cache scans each Lake tree once across the whole block walk.
-  // Resolve REPO_ROOT relative to qa-utils.ts (= content/pipeline/).
-  const REPO_ROOT = resolve(import.meta.dir, "../..");
+  // The Lake tree lives in the CONTENT repo (e.g. qou/content/**/lean), not
+  // the folio-assistant tree this pipeline lives in — resolve against the
+  // content-repo root (findContentRepoRoot), else `resolve(import.meta.dir,
+  // "../..")` lands in folio-assistant and library-only blocks (no sibling
+  // .lean) resolve to `undefined`, silently skipping every checker that reads
+  // the .lean (wall-side, compute-prop-has-probe/-consumer, voice, q-usage).
+  const REPO_ROOT = findContentRepoRoot();
   const lakeCache: LakeTreeCache = new Map();
 
   function* recurse(d: string): Generator<BlockPaths> {

--- a/schemas/lean-packages.ts
+++ b/schemas/lean-packages.ts
@@ -77,3 +77,42 @@ export function formatLeanRef(parts: { package: string; decl: string }): string 
 }
 
 export const LEAN_REF_PATTERN = /^[a-z][a-z0-9-]*:[^\s:]+$/;
+
+/**
+ * Standard folio paper packages, applied at import time so the runtime
+ * pipelines (qa-sweep, validate, q-usage, …) that never call
+ * `configureLeanPackages()` still resolve library-tree `lean.ref` URIs.
+ *
+ * Before this default, the DI registry stayed EMPTY at runtime (only the
+ * unit test injected it), so `resolveCanonicalLean` returned `undefined`
+ * for every library-only block (no sibling `.lean`) and wall-side / voice /
+ * q-usage / compute-prop silently skipped them corpus-wide.
+ *
+ * Downstream repos with a different paper set may override by calling
+ * `configureLeanPackages(...)` after import (as the test does). Ideally this
+ * list is injected by the content repo; keeping it here as a default unbreaks
+ * the pipeline without a config-discovery mechanism. Mirrors AGENTS.md §0 and
+ * the qou-side static `schemas/lean-packages.ts`.
+ */
+export const DEFAULT_LEAN_PACKAGES: readonly LeanPackage[] = [
+  {
+    name: "qou",
+    paperDir: "quantum-observable-universe",
+    lakeRoot: "content/quantum-observable-universe/lean",
+    lib: "QOU",
+  },
+  {
+    name: "ugb",
+    paperDir: "unital-groebner-bases",
+    lakeRoot: "content/unital-groebner-bases/lean",
+    lib: "UGB",
+  },
+  {
+    name: "fred2005",
+    paperDir: "fred2005-formal-groups",
+    lakeRoot: "content/fred2005-formal-groups/lean",
+    lib: "Fred2005",
+  },
+];
+
+configureLeanPackages(DEFAULT_LEAN_PACKAGES);


### PR DESCRIPTION
## What

Two coupled bugs made **every library-only content block** (a `lean.ref` to a library decl with **no sibling `.lean`**) silently unresolvable at runtime — so `wall-side` / `voice` / `q-usage` / `compute-prop-has-probe` / `-consumer` all skipped them **corpus-wide**:

1. **Registry never configured at runtime.** `schemas/lean-packages.ts` is a DI registry (`configureLeanPackages`) but nothing calls it in the qa-sweep/validate **runtime** — only a unit test does. So `LEAN_PACKAGES` was empty and `leanPackageByName()` → `undefined`. Added `DEFAULT_LEAN_PACKAGES` (qou/ugb/fred2005, per AGENTS.md §0) applied at import; downstream can still override via `configureLeanPackages()`.
2. **Lake tree walked against the wrong root.** `qa-utils.ts resolveCanonicalLean` used `resolve(import.meta.dir, "../..")` (the folio-assistant tree) → `findContentRepoRoot()` (same class as #47).

## Verification

- `resolveCanonicalLean` now resolves both exemplar refs (`…JonesMobiusDiagonal.markov_eq_mobius_contact`, `…binding_isovector_mirror_from_chiral`).
- `compute-prop-has-probe` / `-consumer` for `lem:jones-mobius-diagonal` + `prop:isovector-chiral-residue` flip **fail→pass** (both back a sorry-free library proof). **Closes beans `g2go` + `2s3s`.**

## ⚠ Review note — corpus-wide behaviour change

This *enables* library-lean resolution corpus-wide, so blocks whose library `.lean` was previously skipped now get **real verdicts** from every `.lean`-reading checker. That's correct behaviour — any newly-surfaced fail was a latent true fail — but it's a broad change worth a careful CI/eyeball pass. The `DEFAULT_LEAN_PACKAGES` list hardcodes the three folio papers in the generic package; a content-repo-injected config would be cleaner long-term (flagged for your call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019ieTGMnRzVKhHkCyaVeTSn)_