### PR TITLE
validate(defterm): promote defterm-marked from warning to error

### DIFF
--- a/content/pipeline/validate-defterm.ts
+++ b/content/pipeline/validate-defterm.ts
@@ -164,11 +164,16 @@ export function validateDefterms(
       }
     }
 
-    // defterm-marked (warning): every defines[] entry must have a defterm node
+    // defterm-marked (error): every defines[] entry must have a defterm node.
+    // Promoted warning → error 2026-07-07: as a warning this accumulated
+    // silently (17 unmarked terms piled up across the QOU corpus, only
+    // surfaced by a whole-paper validate). An unmarked defines[] term means
+    // the glossary/hyperref for that term is never emitted, so the block
+    // under-delivers on its own metadata — a hard authoring bug, not advisory.
     for (const slug of defines) {
       if (!usage.defs.has(slug)) {
         issues.push({
-          level: "warning",
+          level: "error",
           block: name,
           message: `defterm-marked: defines[] entry "${slug}" has no :defterm[${slug}] in this block's .md`,
           file: `${name}.md`,


### PR DESCRIPTION
## What

Promotes the `defterm-marked` validation rule from **warning → error** in `content/pipeline/validate-defterm.ts`.

## Why

An unmarked `defines[]` term never emits its glossary / `\hyperref` entry, so the block silently under-delivers on its own declared metadata. As a *warning*, this accumulated unnoticed: **17 unmarked terms** piled up across the QOU corpus and only surfaced when a whole-paper `validate` ran during a prepare-merge. The per-block QA sidecars carry no defterm signal, so authors never saw it in their normal flow. Making it an **error** turns it into a blocking authoring gate, stopping the recurrence.

## Safety

Verified the entire QOU corpus is clean of `defterm-marked` before this lands:
- `quantum-observable-universe` — the 17 stragglers fixed in **litlfred/qou#3476** (must merge first);
- `unital-groebner-bases` + `fred2005-formal-groups` — **0** content-block `defines[]`, 0 defterm-marked.

So once #3476 is on `main`, this errors nothing. **Sequencing: merge qou#3476 before this** (else qou CI would error on the pre-existing unmarked blocks).

`level: "error"` is already the established value elsewhere in the same file (e.g. `defterm-declared`, `refterm-resolves`) — no type change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuQCJFXPtjs2LmwewWdPfi

---
_Generated by [Claude Code](https://claude.ai/code/session_01SuQCJFXPtjs2LmwewWdPfi)_