### PR TITLE
fix(build): load subsection blocks, not just direct section blocks

### DIFF
--- a/content/pipeline/build.ts
+++ b/content/pipeline/build.ts
@@ -94,11 +94,20 @@ export async function buildPaper(
       chapterSlugs.set(chIdx, slug);
       chapterMeta.set(chIdx, { slug, title: chapter.title, tabLabel: chapter.tabLabel });
 
-      // Load blocks from the chapter directory
+      // Load blocks from the chapter directory. Sections may nest one
+      // level of `subsections`, each carrying its own `blocks`; the render
+      // side (renderSection) flattens those, so the loader must too — else
+      // subsection-only blocks are never loaded into the block map and
+      // silently drop from the paper (their labels come out undefined).
       for (const sec of chapter.sections) {
         if (!("blocks" in sec)) continue;
         const section = sec as Section;
-        for (const rootName of section.blocks) {
+        const subBlocks = Array.isArray(section.subsections)
+          ? section.subsections.flatMap((s) =>
+              "blocks" in s ? (s as Section).blocks : [],
+            )
+          : [];
+        for (const rootName of [...section.blocks, ...subBlocks]) {
           if (blocks.has(rootName)) continue;
 
           const tsPath = join(chDir, `${rootName}.ts`);


### PR DESCRIPTION
## The bug

The block loader and the renderer disagree on `subsections`:

- **Load** (`content/pipeline/build.ts`) iterated only each section's direct `.blocks`.
- **Render** (`renderSection` in `content/pipeline/render-latex.ts:1358`) flattens `[...section.blocks, ...subsections.flatMap(s => s.blocks)]`.

So any block that lives **only** under a `section.subsections[].blocks` was never loaded into the `blocks` map. At render time `blocks.get(rootName)` returned `undefined`, the block was silently skipped, and its `\label` was never emitted — leaving downstream `\ref`/`\hyperref` to it undefined.

## Impact (QOU paper)

Discovered while chasing a single dangling `def:mass-identity` cross-ref. It turned out the whole "The mass identity" subsection (`mass-endomorphism.ts`, nested under `subsections:`) — the central mass definition plus its existence/uniqueness/su2/C blocks — was absent from every build, along with many other subsection-only blocks across the paper.

| | before | after |
|---|--:|--:|
| Pages | 1288 | **1441** (+153) |
| Fatal LaTeX errors | 0 | 0 |
| Undefined refs | 1 | **0** |
| Pipeline warnings | 69 | 15 |

## The fix

Mirror the renderer's flattening in the loader so load and render agree:

```js
const subBlocks = Array.isArray(section.subsections)
  ? section.subsections.flatMap((s) => "blocks" in s ? (s as Section).blocks : [])
  : [];
for (const rootName of [...section.blocks, ...subBlocks]) { … }
```

One level of `subsections`, matching `renderSection` exactly. The existing `if (blocks.has(rootName)) continue` dedup already prevents double-loading a block referenced from both places.

## Verification

Rebuilt the QOU paper (`--print-mode formal`) with this patch: AST validation ✓, 0 errors, and `latexmk` → **1441 pp, 0 fatal, 0 undefined refs** (vs 1288 pp / 1 undefined before). The `def:mass-identity` label and its family now emit correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkefgUbkjZEmBTVDfRKMwy

---
_Generated by [Claude Code](https://claude.ai/code/session_01KkefgUbkjZEmBTVDfRKMwy)_