### PR TITLE
fix(qa-resolver): reject import-only aggregators + decl→file scan (126 mis-resolutions)

### DIFF
--- a/content/pipeline/qa-utils.ts
+++ b/content/pipeline/qa-utils.ts
@@ -281,6 +281,144 @@ function lakeBasenameMap(
  * Pass a shared `cache` when resolving many refs (e.g. a corpus sweep)
  * so the Lake tree is scanned once; omit it for single-block callers.
  */
+/**
+ * Does `file` textually declare a top-level `name` (theorem/def/…)?
+ *
+ * Used to reject the **import-only aggregator** trap: a ref like
+ * `qou:QOU.BraidKnot.foo` has module `QOU.BraidKnot`, whose direct
+ * module-path `QOU/BraidKnot.lean` is an `import …`-only aggregator that
+ * declares nothing. Candidate (a) must not return it — the decl `foo`
+ * lives in a leaf file under `QOU/BraidKnot/`. Lenient (comment-blind) on
+ * purpose: it only *gates* candidate (a), and a false positive there is no
+ * worse than the pre-fix behaviour.
+ */
+function fileDeclaresName(file: string, name: string): boolean {
+  let body: string;
+  try {
+    body = readFileSync(file, "utf-8");
+  } catch {
+    return false;
+  }
+  const short = name.includes(".") ? name.split(".").pop()! : name;
+  const esc = short.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(
+    `\\b(?:theorem|lemma|def|abbrev|instance|structure|class|inductive|opaque|axiom)\\s+(?:[\\w'.\\u00C0-\\uFFFF]*\\.)?${esc}\\b`,
+    "u",
+  ).test(body);
+}
+
+const _DECL_RE =
+  /^(?:@\[[^\]]*\]\s*)*(?:(?:private|protected|scoped|local|noncomputable|partial|unsafe|nonrec)\s+)*(?:theorem|lemma|def|abbrev|instance|structure|class|inductive|opaque|axiom)\s+([A-Za-z_À-￿][^\s:({\[⦃⟨]*)/u;
+const _NS_RE = /^namespace\s+([A-Za-z_À-￿][\w'.À-￿]*)/u;
+const _END_RE = /^end\b/;
+const _SEC_RE = /^section\b/;
+const _SHORT = " short ";
+
+/**
+ * Walk one Lake root once, indexing **fully-qualified declaration name →
+ * file** (namespace-aware). This is candidate (c): it resolves a
+ * `lean.ref` whose last segment is a *declaration* name whose file
+ * basename differs (e.g. `binding_isovector_mirror_from_chiral` living in
+ * `BindingIsovectorChiralResidue.lean`) — the case candidates (a) and (b)
+ * both miss. Unambiguous short names are also indexed under a sentinel key
+ * as a looser fallback. Comment/section aware so a keyword inside `/- … -/`
+ * or a `namespace … end` scope is handled correctly.
+ */
+function buildLakeDeclMap(absRoot: string): Map<string, string> {
+  const map = new Map<string, string>();
+  const short = new Map<string, string | null>();
+  const files: string[] = [];
+  try {
+    const stack: string[] = [absRoot];
+    while (stack.length) {
+      const dir = stack.pop()!;
+      for (const e of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, e.name);
+        if (e.isDirectory()) stack.push(full);
+        else if (e.isFile() && e.name.endsWith(".lean")) files.push(full);
+      }
+    }
+  } catch {
+    return map;
+  }
+  for (const file of files) {
+    let body: string;
+    try {
+      body = readFileSync(file, "utf-8");
+    } catch {
+      continue;
+    }
+    const nsStack: string[] = [];
+    const openKind: ("ns" | "sec")[] = [];
+    let blockDepth = 0;
+    for (const rawLine of body.split("\n")) {
+      // Strip block comments (`/- … -/`, nesting) and `--` line comments.
+      let line = "";
+      let i = 0;
+      while (i < rawLine.length) {
+        if (blockDepth > 0) {
+          if (rawLine.startsWith("-/", i)) {
+            blockDepth--;
+            i += 2;
+          } else if (rawLine.startsWith("/-", i)) {
+            blockDepth++;
+            i += 2;
+          } else i++;
+        } else if (rawLine.startsWith("/-", i)) {
+          blockDepth++;
+          i += 2;
+        } else if (rawLine.startsWith("--", i)) {
+          break;
+        } else {
+          line += rawLine[i];
+          i++;
+        }
+      }
+      const t = line.trim();
+      if (!t) continue;
+      let m: RegExpMatchArray | null;
+      if ((m = t.match(_NS_RE))) {
+        nsStack.push(m[1]);
+        openKind.push("ns");
+        continue;
+      }
+      if (_SEC_RE.test(t)) {
+        openKind.push("sec");
+        continue;
+      }
+      if (_END_RE.test(t)) {
+        if (openKind.pop() === "ns") nsStack.pop();
+        continue;
+      }
+      if ((m = t.match(_DECL_RE))) {
+        const declName = m[1];
+        const full = [nsStack.join("."), declName].filter(Boolean).join(".");
+        if (!map.has(full)) map.set(full, file);
+        const s = declName.includes(".") ? declName.split(".").pop()! : declName;
+        if (!short.has(s)) short.set(s, file);
+        else if (short.get(s) !== file) short.set(s, null);
+      }
+    }
+  }
+  for (const [k, v] of short) if (v && !map.has(_SHORT + k)) map.set(_SHORT + k, v);
+  return map;
+}
+
+/** Fetch (or lazily build + cache) the decl-name index for a Lake root. */
+function lakeDeclMap(
+  absRoot: string,
+  cache?: LakeTreeCache,
+): Map<string, string> {
+  const key = `${absRoot} decls`;
+  if (!cache) return buildLakeDeclMap(absRoot);
+  let m = cache.get(key);
+  if (!m) {
+    m = buildLakeDeclMap(absRoot);
+    cache.set(key, m);
+  }
+  return m;
+}
+
 export function resolveCanonicalLean(
   ref: string | undefined,
   repoRoot: string,
@@ -295,16 +433,31 @@ export function resolveCanonicalLean(
   }
   const pkg = leanPackageByName(parsed.package);
   if (!pkg) return undefined;
-  // (a) Direct module-path resolution.
+  const lakeRootAbs = resolve(repoRoot, pkg.lakeRoot);
+  // (a) Direct module-path — trust ONLY if the file actually declares the
+  //     decl. This rejects the import-only aggregator (`QOU/BraidKnot.lean`)
+  //     that a module-with-subdirectory shares its name with.
   const direct = resolve(
-    repoRoot,
-    pkg.lakeRoot,
+    lakeRootAbs,
     `${parsed.module.replace(/\./g, "/")}.lean`,
   );
-  if (existsSync(direct)) return direct;
+  const directExists = existsSync(direct);
+  if (directExists && fileDeclaresName(direct, parsed.name)) return direct;
   // (b) Basename fallback under the Lake tree.
-  const lakeRootAbs = resolve(repoRoot, pkg.lakeRoot);
-  return lakeBasenameMap(lakeRootAbs, cache).get(`${parsed.name}.lean`);
+  const byBasename = lakeBasenameMap(lakeRootAbs, cache).get(
+    `${parsed.name}.lean`,
+  );
+  if (byBasename) return byBasename;
+  // (c) Fully-qualified decl → file scan (decl-named ref whose file basename
+  //     differs AND whose module path is an aggregator).
+  const declMap = lakeDeclMap(lakeRootAbs, cache);
+  const byDecl = declMap.get(parsed.decl) ?? declMap.get(_SHORT + parsed.name);
+  if (byDecl) return byDecl;
+  // (safe fallback) preserve legacy behaviour: a ref that resolved to the
+  //   direct module-path before the (a)-gate still resolves to it, so no
+  //   previously-resolving ref regresses to `undefined`.
+  if (directExists) return direct;
+  return undefined;
 }
 
 /**

--- a/content/pipeline/qa-utils.ts
+++ b/content/pipeline/qa-utils.ts
@@ -312,7 +312,7 @@ const _DECL_RE =
 const _NS_RE = /^namespace\s+([A-Za-z_À-￿][\w'.À-￿]*)/u;
 const _END_RE = /^end\b/;
 const _SEC_RE = /^section\b/;
-const _SHORT = " short ";
+const _SHORT = "|short|";
 
 /**
  * Walk one Lake root once, indexing **fully-qualified declaration name →
@@ -409,7 +409,7 @@ function lakeDeclMap(
   absRoot: string,
   cache?: LakeTreeCache,
 ): Map<string, string> {
-  const key = `${absRoot} decls`;
+  const key = `${absRoot}|decls`;
   if (!cache) return buildLakeDeclMap(absRoot);
   let m = cache.get(key);
   if (!m) {

--- a/scripts/tests/lean-ref-coverage.test.ts
+++ b/scripts/tests/lean-ref-coverage.test.ts
@@ -179,6 +179,56 @@ describe("lean.ref candidate-2 (library tree) resolution", () => {
     }
   });
 
+  test("decl-named ref resolves to the leaf decl file, NOT an import-only aggregator (candidate c)", () => {
+    const { tmp, lake } = makeWorkspace();
+    try {
+      // An import-only aggregator sits at the ref's module path
+      // (`QOU/BraidKnot.lean`), sharing its name with the `BraidKnot/`
+      // subdirectory that holds the real decl file.
+      writeLake(
+        lake,
+        "QOU/BraidKnot.lean",
+        "import QOU.BraidKnot.BindingIsovectorChiralResidue\n",
+      );
+      // The decl lives in a leaf file whose basename ≠ the decl name.
+      const leaf = writeLake(
+        lake,
+        "QOU/BraidKnot/BindingIsovectorChiralResidue.lean",
+        [
+          "import Mathlib",
+          "namespace QOU.BraidKnot",
+          "theorem binding_isovector_mirror_from_chiral {R : Type*} [CommRing R] :",
+          "    True := trivial",
+          "end QOU.BraidKnot",
+        ].join("\n"),
+      );
+      const got = resolveCanonicalLean(
+        "qou:QOU.BraidKnot.binding_isovector_mirror_from_chiral",
+        REPO_ROOT,
+      );
+      // Resolves to the decl-bearing leaf, not the aggregator.
+      expect(got).toBe(leaf);
+      expect((got ?? "").replace(/\\/g, "/")).not.toMatch(/\/QOU\/BraidKnot\.lean$/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("(a) direct module-path still wins when the module file declares the decl", () => {
+    const { tmp, lake } = makeWorkspace();
+    try {
+      const modFile = writeLake(
+        lake,
+        "QOU/Basic.lean",
+        "import Mathlib\nnamespace QOU\ntheorem foo : True := trivial\nend QOU\n",
+      );
+      // `QOU/Basic.lean` genuinely declares `foo` → candidate (a) returns it.
+      expect(resolveCanonicalLean("qou:QOU.Basic.foo", REPO_ROOT)).toBe(modFile);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   test("unknown package / malformed ref resolves to undefined", () => {
     makeWorkspace();
     expect(resolveCanonicalLean("nope:QOU.X", REPO_ROOT)).toBeUndefined();


### PR DESCRIPTION
## Problem

`resolveCanonicalLean` (the single source of truth for `lean.ref` → on-disk Lean file) had a latent bug: strategy **(a)** resolves a ref's module path `<module>.lean` and returned it whenever the file merely *existed*. When a module has both a subdirectory **and** a same-named aggregator file — e.g. `QOU/BraidKnot.lean` doing `import QOU.BraidKnot.*` — (a) short-circuited to that **import-only aggregator** for *every* decl-named ref under the module. The aggregator declares nothing, so QA checkers silently scored an empty file → false-negatives (the `g2go` / `2s3s` "checker doesn't credit sorry-free Lean" reports were the visible tip).

### Empirical scope (qou corpus, sibling-less blocks, real `walkBlocks` pipeline)

| metric | before | after |
|---|---|---|
| resolved-to-import-only-aggregator | **126** | 13 |
| refs unresolved (`undefined`) | 21 | **0** |

~113 blocks now resolve to their real decl file; all 21 previously-unresolvable refs resolve. The residual 13 are candidate-1 chapter *siblings* (unrelated to this resolver) + 2 pre-existing **dangling refs** (`QOU.MassEndomorphism.rotation_step` / `AWDeformationPath` — decls that exist nowhere), which correctly hit the safe fallback.

## Fix (backward-compatible)

1. **(a) direct module-path** now returns the file only if it *actually declares the decl* (`fileDeclaresName`), so import-only aggregators fall through.
2. **(c) NEW** namespace-aware decl→file index (`buildLakeDeclMap`): resolves a ref whose last segment is a declaration whose file basename differs (`binding_isovector_mirror_from_chiral` → `BindingIsovectorChiralResidue.lean`). Comment/`section`/`namespace` aware; unambiguous short names indexed under a sentinel key as a looser fallback; cached per Lake root like the basename index.
3. **Safe fallback**: if all strategies miss, the legacy direct-path result is still returned — no ref that resolved before regresses to `undefined`.

Spot-checks now correct: `2s3s` → `BindingIsovectorChiralResidue.lean`; `g2go` → `JonesMobiusDiagonal.lean` (unchanged, via (a)); `QOU.Archimedean.genus_ideal_characterisation` → its real leaf file (was the aggregator).

## Tests

Two regression tests added to `lean-ref-coverage.test.ts` (decl-named ref vs import-only aggregator; (a)-still-wins when the module file declares the decl). Full suite green: `bun test` on `lean-ref-coverage` + `qa-tools` + `qa-sweep-merge` → **26 pass, 0 fail**.

## Note for reviewers

This restores QA *coverage* to ~113 previously-unaudited blocks — some may now legitimately surface checker findings that were silently skipped before. That is the intended effect (they should be audited); it is orthogonal to the resolver correctness here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013r3kQwMkhBFbFsxD6qjZgU)_