### PR TITLE
fix(qa-utils): guard entryIsFresh against missing field_hash (unblocks qa-sweep)

### DIFF
--- a/content/pipeline/qa-utils.ts
+++ b/content/pipeline/qa-utils.ts
@@ -628,7 +628,13 @@ export function entryIsFresh(
   // absent now (the criterion's lean-side / md-side did not apply
   // then and still does not), OR (b) the hashes match.
   for (const k of depends_on) {
-    const expected = entry.field_hash[k];
+    // Legacy / older-schema entries (e.g. agent-authored `n/a` verdicts
+    // written before the per-entry field_hash convention) may lack
+    // `field_hash` entirely. Optional-chain so a missing hash is treated
+    // as "not verifiable ⇒ stale": any currently-present depended-on file
+    // then trips the `!expected && actual` branch below (re-review), and
+    // the sweep no longer crashes with `undefined is not an object`.
+    const expected = entry.field_hash?.[k];
     const actual = current[k];
     if (!expected && !actual) continue; // both absent — still inapplicable
     if (!expected && actual) return false; // file appeared since audit


### PR DESCRIPTION
## Problem

`qa-sweep.ts` crashes on the qou corpus with:

```
TypeError: undefined is not an object (evaluating 'entry.field_hash[k]')
    at entryIsFresh (content/pipeline/qa-utils.ts:631)
```

Many committed `*.qa.json` sidecars carry legacy / older-schema criterion entries — in particular agent-authored `n/a` verdicts (`reviewer.kind: "agent"`) written before the per-entry `field_hash` convention — that lack `field_hash` entirely. `entryIsFresh` indexes `entry.field_hash[k]` unguarded, so the sweep aborts on the **first** such entry. This blocks sidecar refresh corpus-wide (every exposition-drain PR has had to defer its sidecars, accumulating stale `source_hashes.md` across ~15 chapters).

`field_hash` is typed required (`QaCriterionEntry.field_hash: QaFieldHash`), but the committed data predates that, so the runtime must be defensive.

## Fix

Optional-chain the access:

```ts
const expected = entry.field_hash?.[k];
```

A missing `field_hash` is now treated as **"not verifiable ⇒ stale"**: for any currently-present depended-on file, `expected` is `undefined` while `actual` is set, tripping the existing `if (!expected && actual) return false;` re-review branch. So such an entry is re-swept (gets a fresh verdict) instead of crashing the run — the safe, correct disposition. No behavior change for entries that *do* carry `field_hash`.

Single-line change (plus an explanatory comment); the only unguarded `field_hash[…]` access in the file.

## Impact

Unblocks `qa-sweep` on the qou corpus, so exposition-drain PRs can self-sweep their edited blocks and a single batch can clear the accumulated deferred-sidecar debt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WWe8KeBHVp3R92LGcxVqHR)_