### PR TITLE
fix(qa-sweep): anchor recorded block paths at the content repo root (worktree-safe)

### DIFF
--- a/content/pipeline/qa-sweep.ts
+++ b/content/pipeline/qa-sweep.ts
@@ -49,8 +49,8 @@
  * @module content/pipeline/qa-sweep
  */
 
-import { existsSync } from "fs";
-import { resolve, relative, dirname } from "path";
+import { existsSync, statSync } from "fs";
+import { resolve, relative, dirname, join } from "path";
 import { fileURLToPath } from "url";
 
 // Stable anchor for path normalisation: repo root, computed from
@@ -62,6 +62,40 @@ import { fileURLToPath } from "url";
 // noisy diffs in CI vs local). The repo-root anchor is invariant.
 const __filename = fileURLToPath(import.meta.url);
 const REPO_ROOT = resolve(dirname(__filename), "..", "..");
+
+/**
+ * Root of the CONTENT repo that owns the swept blocks, discovered by
+ * walking up from the sweep target until a directory containing `.git`
+ * (a dir in a normal checkout, a file in a git worktree) or
+ * `folio.config.json` is found.
+ *
+ * Sidecar `paths` must be anchored HERE, not at `REPO_ROOT` (this
+ * platform checkout): anchoring at REPO_ROOT bakes the content
+ * checkout's *directory name* into every recorded path
+ * (`../qou/content/...`), which poisons sidecars when the sweep runs
+ * against a git worktree (`../agent-<id>/content/...` — dangling once
+ * the worktree is pruned; observed live in qou PR #3604). Paths
+ * relative to the content repo root (`content/...`) are invariant
+ * across checkout names, worktrees, and invocation cwd.
+ *
+ * REPO_ROOT remains the right anchor for the *checker script* hashes
+ * and script sidecars — those genuinely live in this platform repo.
+ */
+function findContentRepoRoot(startAbs: string): string {
+  let dir = statSync(startAbs).isDirectory() ? startAbs : dirname(startAbs);
+  while (true) {
+    if (existsSync(join(dir, ".git")) || existsSync(join(dir, "folio.config.json"))) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      // Fell off the filesystem root: fall back to the legacy anchor so
+      // the sweep still runs (paths then match the pre-fix behaviour).
+      return REPO_ROOT;
+    }
+    dir = parent;
+  }
+}
 import {
   hashBlockFiles,
   gitHeadSha,
@@ -156,6 +190,9 @@ interface BlockSweepResult {
 function run(): void {
   const args = parseArgs(process.argv.slice(2));
   const rootAbs = resolve(args.root);
+  // Anchor for recorded block paths: the content repo that owns the
+  // swept blocks (NOT this platform checkout — see findContentRepoRoot).
+  const contentRepoRoot = findContentRepoRoot(rootAbs);
   if (!existsSync(rootAbs)) {
     console.error(`qa-sweep: root not found: ${rootAbs}`);
     process.exit(2);
@@ -209,9 +246,9 @@ function run(): void {
     const qaPath = block.root + ".qa.json";
     const existingReport = loadQaReport(qaPath);
     const newPaths = {
-      ts: relative(REPO_ROOT, block.ts),
-      md: block.md ? relative(REPO_ROOT, block.md) : undefined,
-      lean: block.lean ? relative(REPO_ROOT, block.lean) : undefined,
+      ts: relative(contentRepoRoot, block.ts),
+      md: block.md ? relative(contentRepoRoot, block.md) : undefined,
+      lean: block.lean ? relative(contentRepoRoot, block.lean) : undefined,
     };
     let report: BlockQaReport = existingReport ?? {
       $schema: "block-qa/v1",


### PR DESCRIPTION
## Problem

`qa-sweep.ts` records sidecar `paths` relative to `REPO_ROOT` — this **platform** checkout — which bakes the *content* checkout's directory name into every recorded path (`../qou/content/…`). When the sweep runs against a git worktree, sidecars get poisoned with `../agent-<id>/content/…` paths that dangle once the worktree is pruned. Observed live: qou PR #3604 committed 8 such sidecars (reverted there).

This is also why swarm agents in worktrees can't self-sweep — the recorded paths depend on where the sweep happens to run.

## Fix

- New `findContentRepoRoot(startAbs)`: walk up from the sweep target until a directory containing `.git` (dir in a normal checkout, file in a worktree) or `folio.config.json`; fall back to the legacy `REPO_ROOT` anchor if nothing is found.
- Record block `paths` relative to that content repo root (`content/…`) — invariant across checkout names, worktrees, and invocation cwd.
- `REPO_ROOT` remains the anchor for checker-script hashes and script sidecars, which genuinely live in this platform repo.

## Migration note

Recorded paths change format once (`../qou/content/…` → `content/…`) on the next sweep of each block. The qou corpus is about to get a full batch sidecar refresh anyway, which absorbs the one-time churn; thereafter paths are stable regardless of who/where sweeps.

Companion to #59 (the `entryIsFresh` field_hash guard) — together they make the sweep runnable from any checkout, including agent worktrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WWe8KeBHVp3R92LGcxVqHR)_