### PR TITLE
fix(qa-utils): normalize dict-shaped criterion entries at load time

### DIFF
--- a/content/pipeline/qa-sweep.ts
+++ b/content/pipeline/qa-sweep.ts
@@ -49,8 +49,8 @@
  * @module content/pipeline/qa-sweep
  */
 
-import { existsSync } from "fs";
-import { resolve, relative, dirname } from "path";
+import { existsSync, statSync } from "fs";
+import { resolve, relative, dirname, join } from "path";
 import { fileURLToPath } from "url";
 
 // Stable anchor for path normalisation: repo root, computed from
@@ -62,6 +62,40 @@ import { fileURLToPath } from "url";
 // noisy diffs in CI vs local). The repo-root anchor is invariant.
 const __filename = fileURLToPath(import.meta.url);
 const REPO_ROOT = resolve(dirname(__filename), "..", "..");
+
+/**
+ * Root of the CONTENT repo that owns the swept blocks, discovered by
+ * walking up from the sweep target until a directory containing `.git`
+ * (a dir in a normal checkout, a file in a git worktree) or
+ * `folio.config.json` is found.
+ *
+ * Sidecar `paths` must be anchored HERE, not at `REPO_ROOT` (this
+ * platform checkout): anchoring at REPO_ROOT bakes the content
+ * checkout's *directory name* into every recorded path
+ * (`../qou/content/...`), which poisons sidecars when the sweep runs
+ * against a git worktree (`../agent-<id>/content/...` — dangling once
+ * the worktree is pruned; observed live in qou PR #3604). Paths
+ * relative to the content repo root (`content/...`) are invariant
+ * across checkout names, worktrees, and invocation cwd.
+ *
+ * REPO_ROOT remains the right anchor for the *checker script* hashes
+ * and script sidecars — those genuinely live in this platform repo.
+ */
+function findContentRepoRoot(startAbs: string): string {
+  let dir = statSync(startAbs).isDirectory() ? startAbs : dirname(startAbs);
+  while (true) {
+    if (existsSync(join(dir, ".git")) || existsSync(join(dir, "folio.config.json"))) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      // Fell off the filesystem root: fall back to the legacy anchor so
+      // the sweep still runs (paths then match the pre-fix behaviour).
+      return REPO_ROOT;
+    }
+    dir = parent;
+  }
+}
 import {
   hashBlockFiles,
   gitHeadSha,
@@ -156,6 +190,9 @@ interface BlockSweepResult {
 function run(): void {
   const args = parseArgs(process.argv.slice(2));
   const rootAbs = resolve(args.root);
+  // Anchor for recorded block paths: the content repo that owns the
+  // swept blocks (NOT this platform checkout — see findContentRepoRoot).
+  const contentRepoRoot = findContentRepoRoot(rootAbs);
   if (!existsSync(rootAbs)) {
     console.error(`qa-sweep: root not found: ${rootAbs}`);
     process.exit(2);
@@ -209,9 +246,9 @@ function run(): void {
     const qaPath = block.root + ".qa.json";
     const existingReport = loadQaReport(qaPath);
     const newPaths = {
-      ts: relative(REPO_ROOT, block.ts),
-      md: block.md ? relative(REPO_ROOT, block.md) : undefined,
-      lean: block.lean ? relative(REPO_ROOT, block.lean) : undefined,
+      ts: relative(contentRepoRoot, block.ts),
+      md: block.md ? relative(contentRepoRoot, block.md) : undefined,
+      lean: block.lean ? relative(contentRepoRoot, block.lean) : undefined,
     };
     let report: BlockQaReport = existingReport ?? {
       $schema: "block-qa/v1",

--- a/content/pipeline/qa-utils.ts
+++ b/content/pipeline/qa-utils.ts
@@ -596,6 +596,21 @@ export function loadQaReport(path: string): BlockQaReport | undefined {
   try {
     const raw = JSON.parse(readFileSync(path, "utf-8"));
     if (raw?.$schema !== "block-qa/v1") return undefined;
+    // Normalize malformed criterion values at the IO boundary: some
+    // agent-written sidecars carry a bare entry OBJECT where block-qa/v1
+    // requires a single-entry ARRAY (observed corpus-wide in qou on
+    // 2026-07-12: 83 sidecars × 13 `da-*` criteria). Downstream code
+    // (entryIsFresh iteration, preserveNonScriptEntries) assumes arrays
+    // and crashed with `existing.filter is not a function`. Wrapping here
+    // preserves the entry verbatim; any other non-array shape (string,
+    // number, null) is dropped as unrecoverable.
+    if (raw.criteria && typeof raw.criteria === "object") {
+      for (const [id, value] of Object.entries(raw.criteria)) {
+        if (Array.isArray(value)) continue;
+        if (value && typeof value === "object") raw.criteria[id] = [value];
+        else delete raw.criteria[id];
+      }
+    }
     return raw as BlockQaReport;
   } catch {
     return undefined;


### PR DESCRIPTION
## What

Third hardening fix in the qa-sweep robustness series (#59 `entryIsFresh` field_hash guard, #60 content-repo-root path anchoring). Some agent-written sidecars carry a **bare entry object** where block-qa/v1 requires a single-entry **array** — observed 2026-07-12 in qou: 83 sidecars × 13 `da-*` criteria from a `local/qa-agent-drain` run. Downstream array assumptions (`preserveNonScriptEntries`'s `existing.filter`, `entryIsFresh` iteration) crashed with `existing.filter is not a function`, killing a corpus-wide sweep mid-run.

## Fix

Normalize at the `loadQaReport` IO boundary (the single choke point every consumer goes through):
- a lone entry object is wrapped in a single-entry array, preserving it verbatim;
- any other non-array shape (string, number, null) is dropped as unrecoverable.

## Verification

Smoke test: a report with a well-formed array, a dict-shaped entry, a string value, and a null value loads with the array untouched, the dict wrapped, and the junk shapes dropped. The qou chapter that crashed the sweep now sweeps cleanly (the qou-side data was also repaired in litlfred/qou#3645; this PR makes the pipeline tolerant regardless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWe8KeBHVp3R92LGcxVqHR

---
_Generated by [Claude Code](https://claude.ai/code/session_01WWe8KeBHVp3R92LGcxVqHR)_