### PR TITLE
fix(qa-sweep): findContentRepoRoot tolerates block-path-prefix targets

### DIFF
--- a/content/pipeline/qa-sweep.ts
+++ b/content/pipeline/qa-sweep.ts
@@ -82,7 +82,12 @@ const REPO_ROOT = resolve(dirname(__filename), "..", "..");
  * and script sidecars — those genuinely live in this platform repo.
  */
 function findContentRepoRoot(startAbs: string): string {
-  let dir = statSync(startAbs).isDirectory() ? startAbs : dirname(startAbs);
+  // The sweep target may be a block-path PREFIX (`.../<block>` with no
+  // extension) rather than an existing file or directory — statSync on
+  // it would throw ENOENT. Walk up from the nearest existing directory.
+  let dir = existsSync(startAbs) && statSync(startAbs).isDirectory()
+    ? startAbs
+    : dirname(startAbs);
   while (true) {
     if (existsSync(join(dir, ".git")) || existsSync(join(dir, "folio.config.json"))) {
       return dir;

--- a/content/pipeline/qa-sweep.ts
+++ b/content/pipeline/qa-sweep.ts
@@ -198,9 +198,26 @@ function run(): void {
   // Anchor for recorded block paths: the content repo that owns the
   // swept blocks (NOT this platform checkout — see findContentRepoRoot).
   const contentRepoRoot = findContentRepoRoot(rootAbs);
-  if (!existsSync(rootAbs)) {
-    console.error(`qa-sweep: root not found: ${rootAbs}`);
-    process.exit(2);
+  // Single-block targets: accept a sibling file path (`<block>.ts`,
+  // `.md`, `.lean`, `.qa.json`) or an extension-less block-path prefix
+  // in addition to a chapter/paper directory. The walk then starts at
+  // the block's directory, filtered down to that one block root.
+  let walkRoot = rootAbs;
+  let blockRootFilter: string | undefined;
+  if (!existsSync(rootAbs) || !statSync(rootAbs).isDirectory()) {
+    const blockRoot = rootAbs.replace(/\.(qa\.json|ts|md|lean)$/, "");
+    if (existsSync(blockRoot + ".ts")) {
+      walkRoot = dirname(blockRoot);
+      blockRootFilter = blockRoot;
+    } else if (existsSync(rootAbs)) {
+      console.error(
+        `qa-sweep: target has no block manifest (${blockRoot}.ts): ${rootAbs}`,
+      );
+      process.exit(2);
+    } else {
+      console.error(`qa-sweep: root not found: ${rootAbs}`);
+      process.exit(2);
+    }
   }
 
   const headSha = gitHeadSha();
@@ -242,7 +259,8 @@ function run(): void {
   let totalMinor = 0;
   let totalNeedsAgent = 0;
 
-  for (const block of walkBlocks(rootAbs)) {
+  for (const block of walkBlocks(walkRoot)) {
+    if (blockRootFilter && block.root !== blockRootFilter) continue;
     totalBlocks++;
     const paths = { md: block.md, ts: block.ts, lean: block.lean };
     const currentHashes = hashBlockFiles(paths);


### PR DESCRIPTION
## What

Fourth fix in the qa-sweep robustness series (#59 `entryIsFresh` guard, #60 content-root path anchoring, #61 dict-shaped criteria normalization). Single-block sweeps — `bun run qa-sweep.ts <chapter>/<block>` (path *prefix*, no extension) — crashed with ENOENT: `findContentRepoRoot` (introduced in #60) called `statSync` on the prefix, which doesn't exist on disk, before starting its walk-up. Chapter-level sweeps passed a real directory and were unaffected, which is why #60's smoke test missed it.

## Fix

Guard with `existsSync`; start the walk-up from `dirname(startAbs)` when the target isn't an existing directory.

## Verification

Per-block sweep on `qou:braids-and-knots/markov-axioms-primitive` now completes and rewrites the sidecar with `content/…`-anchored paths (was: crash at qa-sweep.ts:85 for every per-block invocation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWe8KeBHVp3R92LGcxVqHR

---
_Generated by [Claude Code](https://claude.ai/code/session_01WWe8KeBHVp3R92LGcxVqHR)_