### PR TITLE
build: add MIT-safe PDF text extraction (poppler-utils + pypdf)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # Diagramming
     graphviz \
     plantuml \
+    # PDF text extraction (pdftotext; MIT-safe subprocess CLI, not an AGPL import)
+    poppler-utils \
     # LaTeX (for math authoring)
     texlive-full \
     latexmk \
@@ -73,6 +75,7 @@ RUN pip3 install --no-cache-dir --break-system-packages \
     pyyaml \
     jsonschema \
     lxml \
+    pypdf \
     leanblueprint
 
 # ─── Ruby gems ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Adds two **permissive, MIT-compatible** PDF text-extraction tools to the image:
- **`poppler-utils`** (apt) — the `pdftotext` CLI. High-quality extraction on math-heavy papers; used as a **subprocess** (mere aggregation → license-clean), already trusted in `scripts/docker-latex-build`.
- **`pypdf`** (pip) — BSD-licensed Python lib for programmatic use; already vendored in `scripts/split-pdf-by-chapter.py`.

## Why

Document-intake / paper-reading needs a reliable PDF text extractor. `pdfminer.six` **fails in sandboxed sessions** — its `cryptography` Rust binding panics (`pyo3_runtime.PanicException`), so agents can't read uploaded PDFs.

## License note (why not pymupdf)

The first cut of this PR used `pymupdf`, which extracts best — but it's **AGPL-3.0**, and folio-assistant is **MIT**. An AGPL `import fitz` in network-served code triggers AGPL §13 (offer-source), which is inconsistent with MIT. So this revision uses only permissive/subprocess-safe tools:
- `pdftotext` (poppler, GPL) is invoked as a **separate program** → "mere aggregation," no copyleft propagation into the MIT codebase (same status as the poppler already in the latex image).
- `pypdf` is BSD.

**Verified:** `pdftotext` cleanly extracts dense `math.GT` papers (arXiv 2012.00062, 68 pp incl. matrix/equation text) — the case that motivated this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)