### PR TITLE
schema: resync ComputationEngine union with the Zod enum (rust, python+rust)

### DIFF
--- a/schemas/constraints.ts
+++ b/schemas/constraints.ts
@@ -485,6 +485,7 @@ export const RemarkSchema = BlockBaseSchema.extend({
   interprets: z.string().min(1).optional(),
 });
 
+// Keep in sync with the `ComputationEngine` union in `types.ts`.
 const ComputationEngineSchema = z.enum([
   "snappea", "sympy", "mpmath", "sage", "python", "numpy", "scipy",
   "closed-form", "python+mpmath", "python+numpy+cvxpy",

--- a/schemas/types.ts
+++ b/schemas/types.ts
@@ -267,6 +267,13 @@ export type LeanValidation =
  * - sympy: Symbolic algebra (identities, polynomial evaluation)
  * - mpmath: Arbitrary-precision floating-point (Clausen functions, dilogarithms)
  * - sage: SageMath for number theory, algebraic geometry
+ * - rust: The `hecke-engine` crate (Layer 1 canonical compute core)
+ *
+ * Keep this union in sync with `ComputationEngineSchema` in
+ * `constraints.ts` — the Zod enum is what actually gates validation, so
+ * a value missing here fails silently at the type level rather than at
+ * validation time. That is how `rust` / `python+rust` came to be live in
+ * the schema but absent from this union.
  */
 export type ComputationEngine =
   | "snappea"
@@ -278,7 +285,9 @@ export type ComputationEngine =
   | "scipy"
   | "closed-form"
   | "python+mpmath"
-  | "python+numpy+cvxpy";
+  | "python+numpy+cvxpy"
+  | "rust"
+  | "python+rust";
 
 /**
  * Status of a computational verification.


### PR DESCRIPTION
Fixes a live drift between the two declarations of the computation-engine enum.

## The drift

The enum is declared twice, and the declarations disagree:

| | `types.ts` — `ComputationEngine` | `constraints.ts` — `ComputationEngineSchema` |
|---|---|---|
| `rust` | ✗ missing | ✓ present |
| `python+rust` | ✗ missing | ✓ present |

The **Zod enum is what gates validation**, so the missing union members fail *silently*: TypeScript code typed against `ComputationEngine` rejects a value the validator happily accepts, and nothing surfaces the mismatch at validation time.

This is not hypothetical — two blocks on `litlfred/qou` `main` use `engine: "rust"` today:

- `appendix-mass-binding-algorithms/mba-step01-categorical-action.ts`
- `appendix-mass-binding-algorithms/mba-step02-gs-reduction.ts`

## The fix

- Add `rust` and `python+rust` to the `ComputationEngine` union.
- Document `rust` in the engine-profile doc comment (the `hecke-engine` crate, Layer 1 canonical compute core).
- Put a **keep-in-sync pointer on each declaration** so the next edit to either one finds the other. That pointer is the part that prevents a recurrence; the two missing members are just the current symptom.

Net diff is 8 added lines across 2 files.

## Scope change since this PR was opened

The branch originally also added `lean` and `python-int`, to unblock two `litlfred/qou` blocks that were failing validation with those values (qou `main` was red repo-wide).

**That is no longer needed, and those additions have been dropped.** qou `main` has since relabelled both blocks to `engine: "python"` and repointed their `computation.script` at the shared Python probe — a coherent fix on the qou side, not a papering-over. Verified against current qou `main`: `bun run scripts/run-validate.ts content/quantum-observable-universe` → `✓ Valid`, exit 0.

Adding enum members with no consumer would have been speculative, so only the genuine drift fix remains. The branch name still reflects the original scope.

## Test plan

- [x] Net diff vs `main` confirmed to be the drift fix only (`git diff origin/main -- schemas/`)
- [x] qou `main` validates clean without the dropped `lean` / `python-int` members — exit 0
- [x] `engine: "rust"` confirmed live on 2 qou blocks, so the added members have real consumers
- [x] No other mirror of this enum exists in the repo (grepped `python+mpmath` across `.ts`/`.py`/`.json`/`.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W84nixmCVLrkhweKZDQYQ9