### PR TITLE
fix(lake-cache): detect a GUTTED cache instead of reporting it present

### DIFF
--- a/scripts/lake-cache.sh
+++ b/scripts/lake-cache.sh
@@ -173,6 +173,38 @@ count_oleans() {
   find "$1/.lake" -name '*.olean' -type f 2>/dev/null | head -20000 | wc -l | tr -d ' '
 }
 
+# A restore stamps how many oleans it laid down. Counting alone cannot
+# distinguish a healthy cache from a GUTTED one: `lake build` re-resolves
+# the dep graph and can evict most of a restored Mathlib, leaving a count
+# that is nonzero — and so passes any `> 0` test — but far below what was
+# restored. Observed in the wild: 7268 -> 459, after which `restore`
+# reported "already present, nothing to do" and refused to repair.
+#
+# The stamp is written INTO `.lake/`, so it dies with the tree it
+# describes and needs no network to read. Checking against the cache
+# branch instead would mean fetching ~1.6 GB of split parts just to
+# answer `status`.
+STAMP_REL=".lake/.lake-cache-stamp"
+
+write_stamp() {  # root count branch
+  printf '%s %s\n' "$2" "$3" > "$1/$STAMP_REL" 2>/dev/null || true
+}
+
+# Echoes the stamped count, or nothing when unstamped (older caches, or
+# a tree built from source). Absence is not an error — it only means the
+# shortfall check cannot run.
+read_stamp_count() {
+  [ -f "$1/$STAMP_REL" ] || return 1
+  awk 'NR==1{print $1}' "$1/$STAMP_REL" 2>/dev/null | grep -E '^[0-9]+$'
+}
+
+# Exit 0 = gutted. A build may legitimately ADD oleans (a package's own
+# modules compile on top of restored deps), so only a SHORTFALL counts.
+is_gutted() {  # root have
+  local want; want=$(read_stamp_count "$1") || return 1
+  [ -n "$want" ] && [ "$2" -lt "$want" ]
+}
+
 cmd_status() {
   local root; root=$(resolve_lake_root)
   local slug pkg
@@ -186,6 +218,13 @@ cmd_status() {
   info "toolchain:  $slug"
   info "branch:     lake-cache/$pkg-$slug"
   info "oleans:     $n"
+  if is_gutted "$root" "$n"; then
+    local want; want=$(read_stamp_count "$root")
+    printf '\n  cache GUTTED — %s oleans on disk, %s were restored.\n' "$n" "$want"
+    printf '  Something evicted them; `lake build` is the usual culprit.\n'
+    printf '  Repair with: %s restore\n' "$PROG"
+    return 3
+  fi
   if [ "$n" -gt 0 ]; then
     printf '\n  cache PRESENT — %s oleans on disk. No restore needed.\n' "$n"
     return 0
@@ -207,9 +246,24 @@ Known packages: $(cmd_list_names | tr '\n' ' ')"
   local br="${BRANCH:-lake-cache/$pkg-$slug}"
 
   local have; have=$(count_oleans "$root")
-  if [ "$have" -gt 0 ]; then
+  if is_gutted "$root" "$have"; then
+    # Repair rather than no-op: the old `> 0` test called this "present"
+    # and refused, so the only recovery was `rm -rf .lake`. Extraction
+    # overlays the existing tree, restoring exactly the evicted files.
+    local want; want=$(read_stamp_count "$root")
+    warn "cache GUTTED — $have oleans on disk, $want were restored. Repairing."
+  elif [ "$have" -gt 0 ]; then
     printf 'cache already present (%s oleans) — nothing to do.\n' "$have"
     printf 'Force a re-restore by removing %s/.lake first.\n' "$root"
+    # Adopt an unstamped tree as its own baseline, so a cache restored by
+    # an older version of this script (or built from source) still gets
+    # shortfall protection from here on. Only ever written when absent —
+    # re-stamping on every call would ratchet the baseline upward and
+    # silently mask a gutting.
+    if ! read_stamp_count "$root" >/dev/null 2>&1; then
+      write_stamp "$root" "$have" "$br (adopted)"
+      info "stamped this tree at $have oleans as the shortfall baseline."
+    fi
     return 0
   fi
 
@@ -278,6 +332,7 @@ Known packages: $(cmd_list_names | tr '\n' ' ')"
     info "different lake-root. Rebuild, then: $PROG seed --branch $br"
     return 3
   fi
+  write_stamp "$root" "$n" "$br"
   printf '\nrestored %s oleans from %s — no rebuild needed.\n' "$n" "$br"
   return 0
 }
@@ -394,8 +449,20 @@ cmd_doctor() {
   printf '\nremote branches:\n'
   cmd_list | tail -n +2
   printf '\nnext step: '
-  if [ "$(count_oleans "$root")" -gt 0 ]; then
-    printf 'cache is present — build directly.\n'
+  local have; have=$(count_oleans "$root")
+  if is_gutted "$root" "$have"; then
+    printf 'cache GUTTED (%s on disk, %s restored) — run `%s restore` to repair.\n' \
+      "$have" "$(read_stamp_count "$root")" "$PROG"
+  elif [ "$have" -gt 0 ]; then
+    # Deliberately NOT "build directly": `lake build` re-resolves the dep
+    # graph and can evict most of a restored Mathlib (7268 -> 459 observed),
+    # so recommending it as the next step after a restore is what destroys
+    # the restore. To CHECK a file, `lean`-direct reuses the oleans and
+    # touches nothing.
+    printf 'cache is present.\n'
+    printf '  verify a file:  LEAN_PATH=<deps> lean path/to/File.lean\n'
+    printf '  build:          lake build  — WARNING: may evict restored oleans;\n'
+    printf '                  re-check with `%s status` afterwards.\n' "$PROG"
   else
     printf 'run `%s restore`.\n' "$PROG"
   fi


### PR DESCRIPTION
Found while using the new `lake-cache.sh` for real in a cloud container (qou, `v4-24-0`). The restore itself is excellent — **7268 oleans in ~2 minutes**, and it made per-file Lean verification possible where previously I'd been deferring it to reviewers. This fixes one gap in it.

## The bug

`restore`'s presence test is `oleans > 0`, so **any** nonzero count passes. Measured sequence:

| step | oleans |
|---|---:|
| `lake-cache.sh restore` → exit 0 | **7268** |
| `lake build QOU.Knot.WhiteheadSaddleClausen` (9 min, timed out) | **459** (mathlib alone: 228) |
| `lake-cache.sh restore` | **459** — *"cache already present — nothing to do."* **exit 0** |

It refused to repair. The only recovery was `rm -rf .lake`. And **exit 0 was actively wrong** — exit `3` (*"cache found but unusable"*) is the state that actually obtained, and the skill doc says `1` and `3` "are different and matter."

The doc lists this class as handled — *"'restored' but the build still runs cold | nothing checked that oleans actually landed | **Counts `.olean` files and fails if zero**"* — but *fails if zero* is too weak. A gutted cache is nonzero and sails straight through.

## The fix

A restore stamps the count it laid down into `.lake/.lake-cache-stamp`; `status` / `restore` / `doctor` compare against it.

- **Stamp lives inside `.lake/`** — it dies with the tree it describes, and reading it costs **no network**. Checking against the cache branch instead would mean fetching ~1.6 GB of split parts just to answer `status`.
- **Only a shortfall counts.** A build may legitimately *add* oleans (a package's own modules on top of restored deps), so `have >= want` is healthy.
- **`restore` now repairs** a gutted tree instead of no-opping — extraction overlays the existing tree, restoring exactly what was evicted.
- **Unstamped trees are adopted** at their current count on the next `restore`, so an existing cache gains protection with no re-download. Written **only when absent**: re-stamping every call would ratchet the baseline upward and silently mask a real gutting.
- **Fully backwards compatible** — an unstamped tree behaves exactly as today.

## `doctor` no longer says "build directly"

That advice is what destroys the restore it just reported — `lake build` re-resolves the dep graph and evicts. It now points at `lean`-direct for verification and warns that a build may evict, with a pointer to re-check via `status`.

## Test plan

- [x] `bash -n` clean
- [x] **Unstamped healthy cache does not false-alarm** — `status` exit 0 (backwards compat)
- [x] `restore` on a healthy unstamped cache no-ops **and** adopts a `7268` baseline
- [x] Simulated eviction (7268 → 5148): `status` reports **GUTTED, exit 3**
- [x] `doctor` next-step says *repair*, not *build directly*
- [x] `restore` **repairs** the gutted tree back to 7268 and re-stamps
- [x] `status` returns to exit 0 afterwards
- [ ] Not tested: the legacy committed-`.lake/`-tree restore path (no such branch to hand); the stamp write is common to both paths, but the overlay-repair behaviour was only exercised on the split-tarball path
- [ ] No shellcheck available in this container — `bash -n` only

## Two related gaps NOT fixed here

1. **`lake build` after `restore` destroys the restore.** This PR makes it *detectable and repairable*, but doesn't prevent it. A guard wrapper, or a `--keep-cache` build path, would.
2. **The cache carries dependency oleans only** — no QOU ones — so `lean`-direct verifies Mathlib-only files but fails with `unknown module prefix 'QOU'` on anything with intra-package imports. That cost a real verification this session (`WhiteheadSaddleClausen.lean` could not be checked at all). Seeding from a tree where the package library is also built would close it — possibly the existing `-new` / `-repthy-wedderburn` variants already do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FwtbgsYQNxC1Km7KqfNEpD

---
_Generated by [Claude Code](https://claude.ai/code/session_01FwtbgsYQNxC1Km7KqfNEpD)_