### PR TITLE
fix(triviality-probe): union workspace + paper Lake roots on LEAN_PATH

### DIFF
--- a/content/pipeline/lean-triviality-probe.ts
+++ b/content/pipeline/lean-triviality-probe.ts
@@ -77,7 +77,7 @@
  */
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync } from "fs";
-import { join, dirname } from "path";
+import { join, dirname, resolve } from "path";
 import { execFileSync } from "child_process";
 import { tmpdir } from "os";
 import { mkdtempSync } from "fs";
@@ -99,18 +99,44 @@ const PROVABLE = /^\s*(?:@\[[^\]]*\]\s*)?(?:private\s+|protected\s+|noncomputabl
  * `.lake/build/lib` — pointing at the latter finds nothing and reads as
  * "unknown module prefix", which looks like a missing dependency rather
  * than a wrong path.
+ *
+ * Neither root is sufficient alone, so both are unioned. A restored
+ * cache splits across them: the paper root carries the paper's own
+ * modules, the workspace root carries the dependencies (in one measured
+ * checkout, 942 vs 5 own-oleans, against 5 vs 6990 for Mathlib). The
+ * paper root also holds near-empty *copies* of those dependency
+ * packages, and since LEAN_PATH resolves first-match by directory, those
+ * stubs shadow the complete copies if they come first — every
+ * Mathlib-importing file then fails to elaborate. So the workspace root
+ * is emitted FIRST, matching `scripts/lean-direct-env.sh`, which orders
+ * `.lake` before `content/<paper>/lean` for exactly this reason.
+ *
+ * Passing only `lakeRoot` reproduces the old single-root behaviour.
  */
-export function leanPathFor(lakeRoot: string): string {
-  const pkgs = join(lakeRoot, ".lake", "packages");
+export function leanPathFor(lakeRoot: string, workspaceRoot?: string): string {
   const out: string[] = [];
-  const own = join(lakeRoot, ".lake", "build", "lib", "lean");
-  if (existsSync(own)) out.push(own);
-  if (existsSync(pkgs)) {
-    for (const p of readdirSync(pkgs)) {
-      const d = join(pkgs, p, ".lake", "build", "lib", "lean");
-      if (existsSync(d)) out.push(d);
+  const seen = new Set<string>();
+  const push = (d: string) => {
+    if (existsSync(d) && !seen.has(d)) {
+      seen.add(d);
+      out.push(d);
     }
+  };
+  const addRoot = (root: string) => {
+    push(join(root, ".lake", "build", "lib", "lean"));
+    const pkgs = join(root, ".lake", "packages");
+    if (existsSync(pkgs)) {
+      for (const p of readdirSync(pkgs)) {
+        push(join(pkgs, p, ".lake", "build", "lib", "lean"));
+      }
+    }
+  };
+  // Workspace root first: its complete dependency copies must win the
+  // first-match over the paper root's vestigial stubs.
+  if (workspaceRoot && resolve(workspaceRoot) !== resolve(lakeRoot)) {
+    addRoot(workspaceRoot);
   }
+  addRoot(lakeRoot);
   return out.join(":");
 }
 
@@ -187,6 +213,7 @@ export function probeDeclaration(
   lakeRoot: string,
   leanBin: string,
   timeoutMs = 120_000,
+  workspaceRoot?: string,
 ): ProbeOutcome {
   const stripped = stripLeanComments(src);
   const decls = splitDeclarations(stripped);
@@ -196,7 +223,7 @@ export function probeDeclaration(
     return { status: "skipped", decl: declName, reason: "no-body" };
   }
 
-  const env = { ...process.env, LEAN_PATH: leanPathFor(lakeRoot) };
+  const env = { ...process.env, LEAN_PATH: leanPathFor(lakeRoot, workspaceRoot) };
   const dir = mkdtempSync(join(tmpdir(), "triv-probe-"));
   const file = join(dir, "P.lean");
 
@@ -315,7 +342,7 @@ Needs: scripts/lake-cache.sh restore-toolchain && ... restore`);
     if (!decl) continue;
     const short = decl.split(".").pop()!;
 
-    const r = probeDeclaration(src, short, abs, leanBin);
+    const r = probeDeclaration(src, short, abs, leanBin, 120_000, repoRoot);
     if (r.status === "skipped") {
       skipped++;
       skips[r.reason]++;

--- a/scripts/tests/lean-triviality-probe.test.ts
+++ b/scripts/tests/lean-triviality-probe.test.ts
@@ -14,9 +14,10 @@
  * and say so loudly, because a suite that silently passes when its
  * subject is absent is the same defect one level up.
  */
-import { describe, test, expect } from "bun:test";
-import { existsSync, readdirSync } from "fs";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { existsSync, readdirSync, mkdirSync, mkdtempSync, rmSync } from "fs";
 import { join } from "path";
+import { tmpdir } from "os";
 import { execFileSync } from "child_process";
 import {
   probeDeclaration,
@@ -240,5 +241,67 @@ describe("leanPathFor", () => {
     // pointing at a directory that exists but holds no oleans reads as
     // "unknown module prefix", which looks like a missing dependency.
     expect(leanPathFor("/nonexistent-lake-root")).toBe("");
+  });
+
+  // These need no Lean toolchain: `leanPathFor` only reads the filesystem.
+  describe("unioning the workspace root", () => {
+    let tmp: string;
+    let workspace: string;
+    let paper: string;
+
+    /** Create `<root>/.lake/build/lib/lean` and the named package dirs. */
+    const layout = (root: string, own: boolean, pkgs: string[]) => {
+      if (own) mkdirSync(join(root, ".lake", "build", "lib", "lean"), { recursive: true });
+      for (const p of pkgs) {
+        mkdirSync(join(root, ".lake", "packages", p, ".lake", "build", "lib", "lean"), {
+          recursive: true,
+        });
+      }
+    };
+
+    beforeEach(() => {
+      tmp = mkdtempSync(join(tmpdir(), "leanpath-"));
+      workspace = join(tmp, "ws");
+      paper = join(workspace, "content", "paper", "lean");
+      // The asymmetry this fix exists for: the paper root carries its own
+      // modules, the workspace root carries the dependencies — and the
+      // paper root ALSO holds near-empty stub copies of those same
+      // dependency packages.
+      layout(workspace, false, ["mathlib", "batteries"]);
+      layout(paper, true, ["mathlib", "batteries"]);
+    });
+
+    afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+    test("emits workspace package dirs BEFORE the paper root's stubs", () => {
+      const parts = leanPathFor(paper, workspace).split(":");
+      const wsMathlib = parts.indexOf(
+        join(workspace, ".lake", "packages", "mathlib", ".lake", "build", "lib", "lean"),
+      );
+      const paperMathlib = parts.indexOf(
+        join(paper, ".lake", "packages", "mathlib", ".lake", "build", "lib", "lean"),
+      );
+      expect(wsMathlib).toBeGreaterThanOrEqual(0);
+      expect(paperMathlib).toBeGreaterThanOrEqual(0);
+      // LEAN_PATH resolves first-match by directory. If the stub wins,
+      // every Mathlib-importing file fails to elaborate — and the probe
+      // reports that as a fact about the corpus.
+      expect(wsMathlib).toBeLessThan(paperMathlib);
+    });
+
+    test("still includes the paper root's own module dir", () => {
+      const parts = leanPathFor(paper, workspace).split(":");
+      expect(parts).toContain(join(paper, ".lake", "build", "lib", "lean"));
+    });
+
+    test("omitting the workspace root preserves single-root behaviour", () => {
+      const parts = leanPathFor(paper).split(":");
+      expect(parts.every((p) => p.startsWith(paper))).toBe(true);
+    });
+
+    test("does not duplicate when both roots resolve to the same path", () => {
+      const parts = leanPathFor(paper, paper).split(":");
+      expect(new Set(parts).size).toBe(parts.length);
+    });
   });
 });


### PR DESCRIPTION
## Summary

`leanPathFor` puts only **one** Lake root on `LEAN_PATH`. Neither root is sufficient alone, so Mathlib-importing files fail to elaborate and the probe reports that as a fact about the corpus.

**This PR has been rebased onto main and cut down. Half of its original scope is gone — see *What changed on rebase* below.**

## Root cause: neither Lake root is sufficient alone

The restored cache splits across two roots:

| | own `build/lib/lean` | `.lake/packages/mathlib` | `packages/batteries` |
|---|---|---|---|
| workspace root (repo root) | 0 | **6990** | **85** |
| paper Lake root (`content/<paper>/lean`) | **942** (the paper's modules) | 5 | 3 |

The paper root carries the paper's own oleans; the workspace root carries the restored dependencies. The paper root *also* holds near-empty **stub copies** of those dependency packages — and since `LEAN_PATH` resolves **first-match by directory**, passing only the paper root lets those stubs shadow the complete copies.

## The change

`leanPathFor(lakeRoot, workspaceRoot?)` emits the workspace root's package dirs first, so complete copies win the first-match, then the paper root's. This mirrors `scripts/lean-direct-env.sh`, which orders `.lake` before `content/<paper>/lean` for exactly this reason. Omitting the argument preserves the previous single-root behaviour.

`probeDeclaration` gains an optional trailing `workspaceRoot` and threads it through; the sweep passes `repoRoot`.

## What changed on rebase — half this PR was superseded

The branch was **83 commits behind main** and conflicted. The conflict was substantive, not textual: **#74 landed the same skip-reason idea on main independently**, and main's version is **richer** than this branch's —

| | this branch (dropped) | main via #74 (kept) |
|---|---|---|
| skip reasons | 4 (`file-does-not-elaborate`, `body-not-locatable`, …) | 4, but separates **`baseline-timeout`** from `baseline-fails` |
| shape | `ProbeResult \| ProbeSkipped` | status-tagged `ProbeOutcome` |
| extras | — | `SKIP_EXPLANATION`, unavailable-ladder-rung tracking, the "0 of N closed" sanity note |

So this PR **keeps main's architecture wholesale and grafts only the LEAN_PATH fix.** Diff drops from +387/−39 to a surgical change. Rebasing by resolving conflicts hunk-by-hunk would have partly reverted #74; that was avoided deliberately.

The `decl-not-found` example from the original writeup still stands and is now served by main's checker: `def:q-casimir` refs `QOU.QCasimir` while the file declares `QCasimirData` / `QCasimir_EF` / `QCasimir_eq_EF`, and elaborates clean.

## Test plan

- [x] **4 new tests** on the union: workspace dirs ordered before the paper root's stubs; the paper root's own dir still present; single-root behaviour preserved when the argument is omitted; no duplicates when both roots coincide. They touch only the filesystem, so they run **without a Lean toolchain**.
- [x] `bun test scripts/tests/lean-triviality-probe.test.ts` — **7 pass → 11 pass**, new tests all green
- [x] `bun run typecheck` — clean
- [x] `bunx eslint` on both changed files — clean
- [x] No other callers of `probeDeclaration` / `leanPathFor` outside the module and its test (grepped)

⚠️ **Pre-existing, not introduced here:** 7 tests in this file fail in a container with no Lean toolchain. Verified identical (**7 pass / 7 fail**) on clean `origin/main` with this branch stashed — the count is unchanged by this PR. They are the Lean-backed splice tests, which need `lean` to elaborate anything.

The full-corpus skip-rate numbers in the original writeup were measured against the pre-#74 probe and are **not** re-verified here — no Lean toolchain in this container. The mechanism is covered by the unit tests instead.

## Files

- [`content/pipeline/lean-triviality-probe.ts`](https://github.com/litlfred/folio-assistant/blob/claude/lean-triviality-probe-leanpath-fix-2026-08-07/content/pipeline/lean-triviality-probe.ts)
- [`scripts/tests/lean-triviality-probe.test.ts`](https://github.com/litlfred/folio-assistant/blob/claude/lean-triviality-probe-leanpath-fix-2026-08-07/scripts/tests/lean-triviality-probe.test.ts)

## Context

Found while running the triviality oracle over the qou corpus — one of a family of "look in the wrong place, then report the miss as a fact about the corpus" bugs; the others were litlfred/qou#4694 and litlfred/qou#4705.