### PR TITLE
Make the gates real: `any` to zero, the schemas to match their data, and CI that actually runs

### DIFF
--- a/.beans/folio-assistant-6fnb--tests-that-cannot-fail-3-tautologies-2-pass-as-ski.md
+++ b/.beans/folio-assistant-6fnb--tests-that-cannot-fail-3-tautologies-2-pass-as-ski.md
@@ -1,0 +1,101 @@
+---
+# folio-assistant-6fnb
+title: 'Tests that cannot fail: 3 tautologies, 2 pass-as-skip, and a chapters/ path in the wrong repo'
+status: completed
+type: bug
+priority: normal
+created_at: 2026-08-08T08:52:22Z
+updated_at: 2026-08-08T08:58:20Z
+---
+
+Now that `code-quality-gates.yml` actually runs (bean `cnlf`), the 431-pass
+count is load-bearing. Some of those passes cannot fail.
+
+## Tautologies — `expect(true).toBe(true)`
+
+- `latex-lean-coverage.test.ts:115` "coverage statistics logged" — a
+  `console.log` wearing a test's clothes.
+- `latex-lean-coverage.test.ts:162` "label prefixes match environment types"
+  — computes `mismatches`, logs them, then asserts nothing. The NAME claims a
+  property the body never checks, so CI prints
+  `✓ label prefixes match environment types` regardless.
+- `lean-projects.test.ts:159` — same shape, for the `sorry` counter.
+
+## Passing while skipping
+
+`latex-lean-coverage.test.ts:54-60` and `:84-90` do
+`console.log("ℹ Skipped: …"); return;` — the test PASSES. The rest of the
+suite uses `describe.skipIf(!folio)` / `test.skipIf`, which reports as `skip`.
+These two report as `pass`.
+
+## The generated-test loop is silently empty
+
+`for (const decl of uniqueDecls)` produces ZERO tests when no chapters are
+found, so "every `\lean{}` resolves to a declaration" contributes nothing and
+nothing says so.
+
+## …and the whole file is dead anyway
+
+`helpers.ts:66` — `CHAPTERS_DIR = join(REPO_ROOT, "chapters")` where
+`REPO_ROOT = resolve(import.meta.dir, "../..")`, i.e. the PLATFORM. But
+`chapters/*.tex` is `content_build` output and lives in the FOLIO; every CI
+invocation writes `--out-dir ../chapters/` from inside the folio. So
+`findChapterFiles()` returns [] even WITH a folio attached, and this file has
+never run its real assertions in either repo.
+
+That is the recurring split-repo defect again (8th instance): a path computed
+from the file's own location, correct before the split. `QOU_LEAN_DIR` two
+lines above already does the right thing (`FOLIO_ROOT ?? REPO_ROOT`), and the
+`FOLIO_ROOT` comment directly below warns about this exact symlink trap.
+
+Same defect in `content/pipeline/build.ts:291`: the DEFAULT `--out-dir` is
+`join(import.meta.dir, "../../chapters")` → the platform. CI always passes
+`--out-dir` explicitly, but `adapters/mcp-server/server.ts` invokes `build.ts`
+twice without it.
+
+
+---
+
+## Summary of Changes
+
+**`CHAPTERS_DIR` now resolves against the folio.** Proven with a synthetic
+folio (paper manifest + `chapters/ch01.tex` + the `folio-assistant/` symlink),
+running `latex-lean-coverage.test.ts` from inside it:
+
+| | before | after |
+|---|---|---|
+| from a real folio | **0 pass / 6 skip** | **6 pass / 1 fail** |
+
+The failure is correct — the fixture has no Lean source, so
+`QOU.Demo.thmDemo exists in Lean source` rightly fails. Coverage reported
+`1/1 formalizable (100.0%)`, and the label-prefix report caught the deliberate
+`BADPREFIX-oops`. Before the fix the file could not run in EITHER repo.
+
+Pinned by `scripts/tests/chapters-dir.test.ts`, which spawns a probe from a
+temp folio (module-level resolution needs a subprocess). Restoring the old path
+fails 2 of its 4 tests.
+
+**Three tautologies gone.** `expect(true).toBe(true)` × 3 — including one named
+`label prefixes match environment types` that computed the mismatches, logged
+them, and passed regardless. Each is now either a real assertion or a test
+renamed `(report)` that asserts the one thing which can break unnoticed: that
+it read a non-empty corpus.
+
+**Two pass-as-skip gone.** `console.log("ℹ Skipped: …"); return;` → `skipIf`,
+matching the convention the rest of the suite already used.
+
+**The silently-empty loop has a guard.** `for (const decl of uniqueDecls)`
+registers zero tests over an empty array, so the per-declaration checks vanished
+from the run with nothing reporting it. One test now notices.
+
+**`build.ts` had two defaults pointing at the platform.** `--out-dir` defaulted
+to `join(import.meta.dir, "../../chapters")`; measured from a folio it wrote to
+`/home/user/folio-assistant/chapters` and now writes to `<folio>/chapters`. And
+the default paper was `../quantum-observable-universe/quantum-observable-universe.ts`
+— a specific folio paper named in platform code, resolved to a path that exists
+in no checkout. It discovers papers via `findPapers()` now, as `validate.ts`
+already did: one paper is unambiguous, several or none exit 1 with a message
+naming the problem. All three branches exercised.
+
+Net: 431 pass → 430 pass, 29 skip → 35 skip, 0 fail. Five tests moved from
+"pass" to "skip" because they were never checking anything, and two were added.

--- a/.beans/folio-assistant-adpt--adapters-is-the-last-tree-outside-tsc-81-errors.md
+++ b/.beans/folio-assistant-adpt--adapters-is-the-last-tree-outside-tsc-81-errors.md
@@ -1,0 +1,45 @@
+---
+# folio-assistant-adpt
+title: 'adapters/** is the last tree outside tsc — 81 errors, including the MCP server'
+status: todo
+type: task
+priority: high
+created_at: 2026-08-08T01:10:00Z
+updated_at: 2026-08-08T01:10:00Z
+---
+
+`src/**`, `schemas/**`, `content/**` and `scripts/**` are all in
+`tsconfig.json`'s `include` and all at zero. `adapters/**` is the last tree
+outside it, and the largest: **81 errors**, measured on a clean checkout.
+
+It is not dead code. It holds the MCP server (`adapters/mcp-server/server.ts`),
+which is a live service, and `adapters/paper/resolver.ts`.
+
+Reproduce with a throwaway config extending `tsconfig.json` and
+`"include": ["adapters/**/*.ts"]`. Anything done in `adapters/` must measure
+against the 81 baseline — the project `tsc` is green regardless and says
+nothing about this tree.
+
+## The known shape of it
+
+Two errors are `Cannot find name 'e'` (`server.ts:162`, `:211`) — the same
+`catch` binding class already fixed twice elsewhere in this repo.
+
+The bulk is the discriminated union. Annotating the block imports as `<Block>`
+adds **27 errors**, because the consuming code reads `examples` / `proofs` /
+`lean` / `tex` / `caption` across kinds without narrowing. `Block` is the
+correct type; the code is what is wrong. That narrowing is the substantial
+piece of work here, and it is also what unblocks the largest remaining
+`no-explicit-any` bucket (bean `lnt1`): 88 `as any`, dominated by this tree.
+
+Do NOT annotate and revert as I did — that was right only as a holding action.
+Narrow properly, then annotate, then drain, then widen `include`.
+
+## Already paid off once
+
+Typing the PAPER imports as `<Paper>` immediately exposed that
+`PaperOutline.macros` was declared `Record<string, string>` while
+`Paper.macros` is `Record<string, PaperMacro>` — `{ tex, unicode? }` objects,
+which is what the viewer reads. Values passed through untouched so nothing
+broke, but any consumer doing string work on them would have got
+"[object Object]". Fixed; the rest of the tree will have more of these.

--- a/.beans/folio-assistant-adpt--adapters-is-the-last-tree-outside-tsc-81-errors.md
+++ b/.beans/folio-assistant-adpt--adapters-is-the-last-tree-outside-tsc-81-errors.md
@@ -1,12 +1,14 @@
 ---
 # folio-assistant-adpt
 title: 'adapters/** is the last tree outside tsc — 81 errors, including the MCP server'
-status: todo
+status: completed
 type: task
 priority: high
 created_at: 2026-08-08T01:10:00Z
 updated_at: 2026-08-08T01:10:00Z
 ---
+
+Claimed by session `3bada08b` on branch `claude/agent-4673-validation-9hffrd`.
 
 `src/**`, `schemas/**`, `content/**` and `scripts/**` are all in
 `tsconfig.json`'s `include` and all at zero. `adapters/**` is the last tree
@@ -43,3 +45,56 @@ Typing the PAPER imports as `<Paper>` immediately exposed that
 which is what the viewer reads. Values passed through untouched so nothing
 broke, but any consumer doing string work on them would have got
 "[object Object]". Fixed; the rest of the tree will have more of these.
+
+
+## Resolved — 81 -> 0, and `adapters/**` is in `include`
+
+Every tree is now compiled. A green `bun run typecheck` finally means what it
+says.
+
+**62 of the 81 were mine, and they were ReferenceErrors.** Commit `958c29e`
+("lint: drain no-unused-vars 111 -> 0") stripped the `e` binding from 38 catch
+blocks in `server.ts` whose bodies use it — `String(e)`, or the already-correct
+`e instanceof Error ? e.message : String(e)`. Every one throws at the moment
+its catch fires, i.e. exactly when something else has already gone wrong.
+Confirmed zero were broken before that commit. `tsc` caught the equivalent
+mistake in covered files at the time; these shipped because `adapters/**` was
+not in the program, and they are now on `main`.
+
+Three further defects, none mine, all invisible for the same reason:
+
+- `resolveOutline(paperId, branch)` — no such function has ever existed; it is
+  `resolvePaperOutline`. A ReferenceError on every request reaching it, so the
+  MCP server's chapter-number auto-derivation has never run. From `109a4ff`.
+- `--http` mode imported the SDK's NODE transport, whose
+  `handleRequest(req: IncomingMessage, res: ServerResponse, body?)` was being
+  handed a Bun `Request` and nothing else. The SDK ships
+  `WebStandardStreamableHTTPServerTransport`, whose signature is
+  `handleRequest(req: Request): Promise<Response>` — exactly what the `/mcp`
+  route already called. Switched.
+- `preview.ts` passed `detached: true` to `spawnSync`, which has no such
+  option and blocks until the child exits — so opening a viewer would hold the
+  tool call open for as long as the window stayed up. Now a detached `spawn`
+  with `unref()`.
+
+Interface-vs-reality drift, same family as the `macros` lie found earlier:
+`ResolvedSection` never declared `subsections` though the resolver builds and
+reads them; `ResolvedChapter` never declared `dir` or `tabLabel` and typed
+`number` as required when appendices get `undefined`; `ChapterOutline` the
+same. `ResolvedBlock.lean` omitted `sorryFree` — a real `LeanRef` field that
+`render-latex` says "wins outright" for proof status — so the server dropped
+it, and two response builders picked fields explicitly and lost it while a
+third kept it. `ch._dir` was read and assigned nowhere at all.
+
+Two `resolvePaper(id)` call sites dereferenced a `ResolvedPaper | null`
+straight into `.chapters`, where every other handler in the file 404s.
+
+VERIFIED BY RUNNING BOTH MODES after 40+ edits to that file: HTTP `/mcp`
+returns a real `tools/list`, and stdio `initialize` returns a proper protocol
+response.
+
+Not done: the `<Block>` narrowing. Annotating the block imports still costs 27
+errors because the consuming code reads `examples` / `proofs` / `lean` / `tex`
+/ `caption` across kinds without narrowing the union. That is now the ONLY
+thing standing between here and the `no-explicit-any` bulk (88 `as any`), and
+it is a clean piece of work rather than a blocked one, since the tree compiles.

--- a/.beans/folio-assistant-adpt--adapters-is-the-last-tree-outside-tsc-81-errors.md
+++ b/.beans/folio-assistant-adpt--adapters-is-the-last-tree-outside-tsc-81-errors.md
@@ -93,8 +93,45 @@ VERIFIED BY RUNNING BOTH MODES after 40+ edits to that file: HTTP `/mcp`
 returns a real `tools/list`, and stdio `initialize` returns a proper protocol
 response.
 
-Not done: the `<Block>` narrowing. Annotating the block imports still costs 27
-errors because the consuming code reads `examples` / `proofs` / `lean` / `tex`
-/ `caption` across kinds without narrowing the union. That is now the ONLY
-thing standing between here and the `no-explicit-any` bulk (88 `as any`), and
-it is a clean piece of work rather than a blocked one, since the tree compiles.
+## The `<Block>` narrowing: DONE
+
+Annotating the block imports cost 27 errors across ten fields. Ten narrowing
+accessors (`bLean`, `bProofs`, `bTex`, …) using the `in` operator — real checks,
+not casts — plus `withSource` for the one spread that widened a required `ref`
+to optional.
+
+A blanket regex over `blk.<field>` over-applied to loops where `blk` is a
+`ResolvedBlock` (which declares those fields directly), so those were reverted
+by line range. That is the third time in this session a blanket replace has
+over-reached; the lesson is not learned by writing it down, only by measuring
+after.
+
+**`blk.status` was a phantom.** Nine sites read it, including
+`if (blk.status === "proved" || blk.status === "mathlib_ok") provedCount++`.
+There is no block-level `status`: the schema says `FormalizationStatus` is
+"derived at build time from .lean file content. NOT stored in content block .ts
+manifests". So the MCP server's proof-status counters have always been 0, and
+its `status` response field always `undefined`. Now derived from the block's
+`lean` via `leanStatusBucket`, exported from `render-latex.ts` so there is one
+mapping rather than two.
+
+Measured live: 3124 blocks now report `stubbed: 2128, drafted: 967,
+compiled: 29`. Note what that means — it reflects what the MANIFESTS declare
+(`lean.validation` / `sorryFree`), not the build. The paper's 692/704
+sorry-free figure comes from `lean-coverage.ts` inspecting real `.lean` files,
+which is precisely why the schema keeps build-derived status out of manifests.
+
+## And the server was rooted in the wrong repo
+
+Found by trying to verify the above against the folio: `paths.ts` set
+`REPO_ROOT = resolve(import.meta.dir, "../..")`, the PLATFORM. Every constant
+derives from it — `CONTENT_DIR`, `CHAPTERS_DIR`, `MAIN_TEX`, `LEAN_DIR`,
+`BUILD_DIR`, `TODOS_DIR` — and all are folio concepts that do not exist there.
+Run from the qou checkout it answered `Paper not found` for every paper, and
+its git operations ran against the platform repo rather than the content
+branches it exists to switch between.
+
+Seventh instance of this defect class, after `q-usage-audit`, `validate`,
+`validate-bib`, `export-json`, `readme-metadata` and `refresh-authors-note`.
+Fixed with `findContentRepoRoot()`; the server now reports
+`repo: /workspace/qou` and serves 35 chapters / 3124 blocks.

--- a/.beans/folio-assistant-cnlf--code-quality-gatesyml-never-runs-and-3-of-its-4-jo.md
+++ b/.beans/folio-assistant-cnlf--code-quality-gatesyml-never-runs-and-3-of-its-4-jo.md
@@ -1,0 +1,85 @@
+---
+# folio-assistant-cnlf
+title: code-quality-gates.yml never runs — and 3 of its 4 jobs scan trees this repo does not have
+status: completed
+type: bug
+priority: normal
+created_at: 2026-08-08T08:34:47Z
+updated_at: 2026-08-08T08:39:38Z
+---
+
+The workflow whose header says *"Without this job none of that is enforced:
+the ratchet only works if something runs it"* is `on: workflow_dispatch:`
+only. It has never run automatically. Every ratchet landed since PR #68 —
+`bun test` 428/0, `eslint .` with all rules at `error`, `tsc --noEmit` over
+all five trees — is enforced by nothing.
+
+Measured on `b740d31`: of 33 workflows, exactly two auto-trigger
+(`atomic-mass-gen-check.yml`, `docs-site.yml`) and neither runs any TS check.
+
+Worse, flipping the trigger alone would produce a green CI that checks
+almost nothing. Three of the four jobs scan trees that do not exist here:
+
+| job | scans | present in this repo |
+|---|---|---|
+| `lean-bare-import` (hard) | `content/**/*.lean` | **0 files** — `content/` holds only `pipeline/` |
+| `python-imports` (warn) | `folio-assistant/computations`, `tools` | **neither dir exists**; the first path is folio-relative |
+| `rust-wildcard` (warn) | `tools/**/*.rs` | **0 `.rs` files anywhere** |
+| `typescript` (hard) | `bun test` / lint / tsc | real |
+
+The Lean gate prints `OK — no bare 'import Mathlib' in content/**/*.lean`
+having looked at nothing. "None found" and "nothing to look at" are
+different facts and the log conflates them — the same defect class as the
+rest of this session.
+
+Note the workflow was added by THIS session (`b886cdf`, "ci: give the
+ratchet something to run in") with a commit message that correctly diagnoses
+"no folio-assistant workflow triggers on `pull_request`" — and was then
+written dispatch-only. The fix for "nothing runs the ratchet" was itself
+something that never runs.
+
+Also: `tsconfig.json`'s comments promise "a green `bun run typecheck`", and
+`package.json` has no `typecheck` script.
+
+
+---
+
+## Summary of Changes
+
+**The gate now runs.** `on:` gains `pull_request` and `push: [main]`, with no
+`paths:` filter — a filter is how a whole-repo gate stops covering the file
+that broke it, and how a filtered-out required check blocks a branch forever.
+
+**Two jobs that scanned nothing now say so.** `lean-bare-import` and
+`rust-wildcard` print `SKIP — … Nothing scanned.` and exit 0 when their tree
+is absent, instead of `OK — no bare 'import Mathlib'` / `OK — no non-test
+wildcard imports`. "None found" and "nothing to look at" are different facts.
+Both are FOLIO trees, so in this repo they always skip; they stay for folios
+that vendor the workflow. Note this deliberately differs from the
+`lean-build.yml` precedent (hard-fail preflight): that workflow is entirely
+folio, this one is mixed, and hard-failing here would redden every platform PR.
+
+**The Python job was worse than vacuous and is now a hard gate.** It scanned
+`folio-assistant/computations tools`; neither exists here, and the first is a
+FOLIO-RELATIVE path (inside a folio the platform is the `folio-assistant/`
+symlink). ruff *warned* about the missing paths and **exited 0** — so
+`continue-on-error` was not even load-bearing; the step reported a clean
+baseline it had never computed. Repointed at the six trees holding the 44 real
+`.py` files, which surfaced **24 live F401s** across 18 files. All 24 drained
+(`ruff --fix`, every touched file re-checked with `py_compile`), none in an
+`__init__.py` and none with `__all__`, so the rule is promoted to `error` per
+the same discipline as eslint.
+
+**Also:** `package.json` had no `typecheck` script, though `tsconfig.json` and
+three beans all promise "a green `bun run typecheck`". Added. And
+`__pycache__/` was not gitignored, so the `py_compile` verification above
+staged bytecode dirs.
+
+### Guards
+
+`scripts/tests/workflow-yaml.test.ts` gains three: the gate triggers on
+`pull_request`, carries no `paths:` filter, and its TypeScript job runs all
+three of `bun test` / `bun run lint` / `tsc --noEmit`. Each verified to bite by
+reverting the change it protects. The four shell jobs were also run locally:
+both SKIP paths print and exit 0, and the Python gate exits 1 on a planted
+unused import.

--- a/.beans/folio-assistant-lnt1--eslint-warning-backlog-337-mostly-explicit-any.md
+++ b/.beans/folio-assistant-lnt1--eslint-warning-backlog-337-mostly-explicit-any.md
@@ -1,7 +1,7 @@
 ---
 # folio-assistant-lnt1
 title: 'ESLint backlog: 171 no-explicit-any (track 2 AST partly drained)'
-status: todo
+status: in-progress
 type: task
 priority: normal
 created_at: 2026-08-07T18:00:00Z
@@ -264,3 +264,44 @@ renderer and the typed one and diffed. **Byte-identical, zero differences.**
 
 Track 2 continues in the other AST files; track 1 (content structure,
 ~55, start `adapters/paper/resolver.ts`) and track 3 (heterogeneous) unchanged.
+
+
+## Chunk 2: `catch (e: any)` drained, `importTsBranch` made generic — 171 -> 158
+
+`catch (e: any)` (6) is gone: five were `e.message ?? e`, now behind an
+`errMsg(e)` helper using the `instanceof Error` idiom already used across the
+repo; the sixth reads `e.status` / `e.stdout` / `e.stderr` off an
+`execFileSync` throw, which Node types as plain `Error`, so the extra fields
+are named in a local `Partial<{…}>` rather than any-cast.
+
+`importTsBranch` returned `Promise<unknown>`, so all twelve call sites cast —
+and every one reached for `as any` rather than the `Chapter` / `Paper` the
+schema already defines. It is generic now (`T = unknown`, so an un-annotated
+call stays honest) and the cast moved to the type argument.
+
+TWO LESSONS, both worth keeping:
+
+1. `adapters/**` is NOT in the tsconfig program (only what `src/` transitively
+   imports is). A green project `tsc` says nothing about it. Checked directly:
+   **81 pre-existing errors** there. Any future work in `adapters/` must
+   measure against that baseline rather than trusting `bun run typecheck`.
+
+2. Annotating the BLOCK imports as `<Block>` added **27 errors**, because the
+   consuming code reads `examples` / `proofs` / `lean` / `tex` / `caption`
+   across kinds without narrowing the discriminated union. `Block` is the
+   correct type and the code is what is wrong, but fixing that is a real piece
+   of work in a file with 81 pre-existing errors and no tsc coverage. Reverted
+   to `as any` there, deliberately, rather than shipping 27 new errors or
+   inventing a looser type to paper over it.
+
+The `Paper` annotation DID pay off immediately: `PaperOutline.macros` was
+declared `Record<string, string>` while `Paper.macros` is
+`Record<string, PaperMacro>` — `{ tex, unicode? }` objects, which is what the
+viewer actually reads (`buildKatexMacros` uses `def.tex`). Values passed
+through untouched so nothing broke, but the type was a lie and any consumer
+doing string work on them would have got "[object Object]". Corrected; adapters
+back to its 81 baseline.
+
+Remaining 158, by shape: 88 `as any`, 39 `param: any`, 20 `any[]`, 18 other.
+The `as any` bucket is the bulk and is dominated by `adapters/`, which wants
+its own tsc baseline first — see lesson 1.

--- a/.beans/folio-assistant-lnt1--eslint-warning-backlog-337-mostly-explicit-any.md
+++ b/.beans/folio-assistant-lnt1--eslint-warning-backlog-337-mostly-explicit-any.md
@@ -1,11 +1,11 @@
 ---
 # folio-assistant-lnt1
 title: 'ESLint backlog: 171 no-explicit-any (track 2 AST partly drained)'
-status: in-progress
+status: completed
 type: task
 priority: normal
 created_at: 2026-08-07T18:00:00Z
-updated_at: 2026-08-07T20:35:00Z
+updated_at: 2026-08-08T08:23:05Z
 ---
 
 `bun run lint` now runs (it never could before — no config, and neither
@@ -305,3 +305,70 @@ back to its 81 baseline.
 Remaining 158, by shape: 88 `as any`, 39 `param: any`, 20 `any[]`, 18 other.
 The `as any` bucket is the bulk and is dominated by `adapters/`, which wants
 its own tsc baseline first — see lesson 1.
+
+
+---
+
+## Done — 201 → 0, and the rule is an error
+
+Drained to zero across five commits on `claude/agent-4673-validation-9hffrd`.
+`@typescript-eslint/no-explicit-any` is promoted to `error` in
+`eslint.config.mjs`, which empties the `warn` tier entirely — every rule is now
+an error. Verified the ratchet bites by planting an `any`.
+
+Gate at close: `tsc --noEmit` 0 errors over all five trees, 422 tests / 0 fail,
+`eslint .` exit 0, and the HTTP server boots.
+
+**Both lessons in the section above are resolved, not worked around.**
+
+Lesson 1 (`adapters/**` outside the tsconfig program) — closed by bean
+`folio-assistant-adpt`: all five trees are in `include` now, so a green
+`bun run typecheck` finally means what it says.
+
+Lesson 2 (annotating block imports as `<Block>` added 27 errors, reverted) —
+this was the right call at the time and the wrong resting place. `Block` IS the
+correct type; the consuming code reads `examples`/`proofs`/`lean`/`tex`/
+`caption` across kinds without narrowing. Fixed properly with one accessor per
+field (`blockLean`, `blockProofs`, `blockExamples`, `blockTex`, `blockCaption`
+in `adapters/manifest-entries.ts`), shared by both resolvers, and the imports
+are `<Block>` now.
+
+### What the drain surfaced
+
+Typing these was not cosmetic. In rough order of severity:
+
+- **The generated skill registry never validated against its own schema** — 15
+  issues, `packages.N.{repo,path,ref} Required`. `SkillRegistry.packages` was
+  declared as external package *references* while the generator has only ever
+  written local package *manifests*. `roleAssignments` was never emitted at all
+  despite being required and having three rules on disk. Hooks were emitted in
+  the raw `.claude/settings.json` shape rather than `SessionHook`.
+  `scripts/tests/registry.test.ts` now runs the generator and validates it.
+- **Two `LifecycleStage` enums**, and the hand-written one was wrong:
+  `develop`/`revise` in place of `plan`/`author`/`retire`. Across 18 skill
+  definitions and 5 package manifests, `author` appears 18 times and
+  `develop`/`revise` zero.
+- **A second `FeedbackItem`** in `src/types.ts`, drifted from the schema one in
+  four ways — including narrowing `origin` so a `qc`-origin item (the
+  validation pipeline's own output) could not pass through the layer.
+- **`SkillDefinition` missing `lifecycleStages` and `schemaRef`**, present on
+  18/18 files; and its documented `schemas` field had no Zod counterpart, so
+  `.parse()` stripped it.
+- **`blk.status` was a phantom in the paper resolver too** (already fixed in
+  the MCP server) — a derived field never stored in manifests, so the "proved"
+  counter was always 0 and every block stub's `status` was `undefined`.
+- **`renderBlock` was handed a `ResolvedBlock`** — the viewer's projection —
+  for the lightning-PDF path, silently dropping every kind-specific field it
+  switches on.
+- **Feedback status/priority were never validated**: `{"status":"banana"}` was
+  persisted to `main` verbatim and then matched no filter anywhere, so the item
+  vanished from every view of itself.
+- **PACKAGES.md had always shipped empty** — gated on loose `*.json` files in
+  `skills/` that have never existed.
+- **The two resolvers disagreed about which sections carry blocks**, so the
+  folio landing page undercounted papers the viewer rendered correctly.
+- **Five mdast guards could never fire** in the refterm codemod; `code`/`math`
+  are literal nodes with no children to reach.
+
+Pinned by four new test files: `manifest-entries`, `registry`,
+`codemod-refterm`, plus the existing parity/dispensation suites.

--- a/.beans/folio-assistant-quue--work-queue-after-pr-68-what-is-mine-what-is-a-si.md
+++ b/.beans/folio-assistant-quue--work-queue-after-pr-68-what-is-mine-what-is-a-si.md
@@ -1,11 +1,11 @@
 ---
 # folio-assistant-quue
 title: 'Work queue after PR #68 — mine, a sibling''s, or already done'
-status: todo
+status: completed
 type: task
 priority: normal
 created_at: 2026-08-08T00:05:00Z
-updated_at: 2026-08-08T00:05:00Z
+updated_at: 2026-08-08T08:24:47Z
 ---
 
 Index bean, written by session `3bada08b` after folio-assistant #68 merged
@@ -73,3 +73,39 @@ dispatching it also publishes — `publish.yml`'s deploy job is gated on
 `github.event_name == 'workflow_dispatch'`, and under `workflow_call` that
 resolves to the caller's event, so a manual qou build pushes to `gh-pages`
 (`keep_files: true`, so a merge rather than a wipe).
+
+
+---
+
+## Update after `ec2b2aa` — the unclaimed queue is EMPTY
+
+All three "ready to work" items are done, and `main` has since moved 10 commits
+(through #70, the sibling lake-cache cluster, merged into this branch at
+`0092e8d` with `tsc`/lint/428 tests green).
+
+1. **`folio-assistant-lnt1`** — DONE. `no-explicit-any` 201 → 0 and the rule is
+   promoted to `error`, which empties the `warn` tier entirely: every eslint
+   rule is now an error. See that bean for what the drain surfaced — most
+   consequentially that the generated skill registry had never validated
+   against its own schema (15 issues), and three schemas had drifted from the
+   data they describe.
+2. **`folio-assistant-tnbf`** — DONE. The framing turned out to be wrong (they
+   are all FOLIO workflows, not overlapping platform ones); see the bean.
+3. **`scripts/**` into `tsconfig.json`'s `include`** — DONE, and `adapters/**`
+   with it (`folio-assistant-adpt`). All five trees are compiled; a green
+   `bun run typecheck` finally means what it says.
+
+Everything still open is either a sibling's or deferred by its own text:
+`02kc` / `5d7z` / `ga7e` (lake-cache cluster — `main` has since landed more of
+it), `nimj` (Nazrin, in progress elsewhere), `15gn` (LeanDojo, deferred).
+
+**Still outstanding and still not automatable from here:** qou #4673 needs a
+manual `build.yml` dispatch from the Actions tab — the GitHub App has
+`actions: read` on qou but not `actions: write`, so the dispatch endpoint
+returns 403. Dispatching also publishes (`publish.yml`'s deploy job is gated on
+`github.event_name == 'workflow_dispatch'`, which under `workflow_call`
+resolves to the caller's event), so a manual qou build pushes to `gh-pages` —
+`keep_files: true`, so a merge rather than a wipe.
+
+This bean has served its purpose as an index; closing it. A future session
+should start from `beans list` rather than from here.

--- a/.beans/folio-assistant-quue--work-queue-after-pr-68-what-is-mine-what-is-a-si.md
+++ b/.beans/folio-assistant-quue--work-queue-after-pr-68-what-is-mine-what-is-a-si.md
@@ -1,0 +1,92 @@
+---
+# folio-assistant-quue
+title: 'Work queue after PR #68 — mine, a sibling''s, or already done'
+status: todo
+type: task
+priority: normal
+created_at: 2026-08-08T00:05:00Z
+updated_at: 2026-08-08T00:05:00Z
+---
+
+Index bean, written by session `3bada08b` after folio-assistant #68 merged
+(`2cfde74`). Orders the remaining open work and records who owns what, so the
+next session does not pick up a sibling's cluster or redo something `main`
+already carries. **No sibling bean was edited to write this.**
+
+## Ready to work — unclaimed
+
+**1. `folio-assistant-tsca` — 26 typecheck errors in `content/**`.**
+The highest-value one, because it closes a ratchet rather than paying down
+debt: `schemas/**` is in `tsconfig.json`'s `include` now, `content/**` is not,
+and until it is, most of the pipeline is still uncompiled. That gap has already
+shipped two `ReferenceError`s (`_ctx` in `constraints.ts`, unbound `dir` in
+`validate.ts`), both under commit messages claiming a clean `tsc`.
+
+Measured on `2cfde74`, in descending size:
+
+    8  content/pipeline/validate-bib.ts
+    4  content/pipeline/audit-wiring.ts
+    3  content/pipeline/bib-qa.ts
+    2  content/pipeline/validate-references-human-review.ts
+    2  content/pipeline/export-json.ts
+    2  content/pipeline/export-bibtex.ts
+    5  across validate-references, validate, qa-sweep, qa-checkers-voice,
+       proof-axis-dashboard, codemod-refterm (1 each)
+
+Reproduce with a throwaway config extending `tsconfig.json` and
+`"include": ["content/**/*.ts"]`. Drain to zero, then move `content/**` into
+the real `include` in the same change — the drain is only worth doing if it
+cannot silently come back.
+
+`scripts/**` is untried beyond a rough count (~15 more, several in tests).
+Widen it after `content/**`, not with it.
+
+**2. `folio-assistant-lnt1` — 171 `no-explicit-any`.**
+Bigger and genuinely wants the per-bucket plan already written in that bean;
+108 of the original 201 annotate something this repo already has a type for.
+Not a sweep — each `any` is a separate typing decision. `render-latex.ts` is
+done (30 -> 0, and its 21 structural errors too, verified byte-identical over
+3483 rendered qou blocks).
+
+**3. `folio-assistant-tnbf` — Lean workflow sprawl.**
+Cheaper than it looks now: this session mapped all 33 workflows and their
+triggers while fixing two that did not parse. Useful facts to start from —
+only `atomic-mass-gen-check.yml` and `docs-site.yml` auto-trigger at all;
+everything else is `workflow_dispatch`. So "which of these actually runs" has
+a short answer, and folding the redundant ones is mostly a question of what
+`lake-cache.sh` now subsumes. `scripts/tests/workflow-yaml.test.ts` will catch
+a YAML mistake made while folding them.
+
+## Do NOT claim — a sibling's active cluster
+
+`folio-assistant-02kc`, `folio-assistant-5d7z`, `folio-assistant-ga7e` are one
+lake-cache cluster with two recent sibling branches on it
+(`claude/lake-cache-gutted-detection-2026-08-07`,
+`claude/llm-authoring-pipeline-review-jrplaj`), and `main` has since landed
+their tooling side. On `2cfde74`, `scripts/lake-cache.sh` carries 27 `trace`
+references, 9 `gutted`, and 5 static-library checks, and
+`scripts/reseed-lean-cache.sh` exists at ~15 KB.
+
+**That is the detection and the automation, not the data.** Whether the
+production cache branches have actually been reseeded is a question about
+orphan-branch contents, not about this repo, and cannot be answered by reading
+it. Do not mark these resolved on the strength of the tooling existing — and do
+not resolve them at all; they are not ours.
+
+`folio-assistant-nimj` (Nazrin as triviality oracle) is likewise in-progress
+elsewhere.
+
+## Deferred by its own text
+
+`folio-assistant-15gn` — LeanDojo premise index, CI-only artifact. Left as it
+stands.
+
+## Not a bean, but outstanding
+
+qou #4673 is unblocked and needs a **manual** `build.yml` dispatch from the
+Actions tab. Not automatable from here: the GitHub App has `actions: read` on
+qou but not `actions: write`, so the dispatch endpoint returns 403. Note that
+dispatching it also publishes — `publish.yml`'s deploy job is gated on
+`github.event_name == 'workflow_dispatch'`, and under `workflow_call` that
+resolves to the caller's event, so a manual qou build pushes to `gh-pages`
+(`keep_files: true`, so a merge rather than a wipe).

--- a/.beans/folio-assistant-quue--work-queue-after-pr-68-what-is-mine-what-is-a-si.md
+++ b/.beans/folio-assistant-quue--work-queue-after-pr-68-what-is-mine-what-is-a-si.md
@@ -15,47 +15,30 @@ already carries. **No sibling bean was edited to write this.**
 
 ## Ready to work — unclaimed
 
-**1. `folio-assistant-tsca` — 26 typecheck errors in `content/**`.**
-The highest-value one, because it closes a ratchet rather than paying down
-debt: `schemas/**` is in `tsconfig.json`'s `include` now, `content/**` is not,
-and until it is, most of the pipeline is still uncompiled. That gap has already
-shipped two `ReferenceError`s (`_ctx` in `constraints.ts`, unbound `dir` in
-`validate.ts`), both under commit messages claiming a clean `tsc`.
+**~~1. `folio-assistant-tsca`~~ — DONE.** 26 typecheck errors in `content/**`
+-> 0, and `content/**` is now in `tsconfig.json`'s `include`, so the ratchet is
+closed. Ten of the 26 were `Cannot find module`: the whole bibliography
+subsystem (six entry points) threw at import and could not run. Spun off
+`folio-assistant-zdrf` — TS/Zod schema drift that was silently stripping
+`lean` from every provable — which is also done.
 
-Measured on `2cfde74`, in descending size:
+**1. `folio-assistant-lnt1` — 171 `no-explicit-any`.** Now first in the queue.
+Wants the per-bucket plan already written in that bean; 108 of the original 201
+annotate something this repo already has a type for. Not a sweep — each `any`
+is a separate typing decision. `render-latex.ts` is done (30 -> 0, plus its 21
+structural errors, verified byte-identical over 3483 rendered qou blocks).
 
-    8  content/pipeline/validate-bib.ts
-    4  content/pipeline/audit-wiring.ts
-    3  content/pipeline/bib-qa.ts
-    2  content/pipeline/validate-references-human-review.ts
-    2  content/pipeline/export-json.ts
-    2  content/pipeline/export-bibtex.ts
-    5  across validate-references, validate, qa-sweep, qa-checkers-voice,
-       proof-axis-dashboard, codemod-refterm (1 each)
+**2. `folio-assistant-tnbf` — Lean workflow sprawl.**
+Cheaper than it looks: this session mapped all 33 workflows and their triggers
+while fixing two that did not parse. Only `atomic-mass-gen-check.yml` and
+`docs-site.yml` auto-trigger at all, so "which of these actually runs" has a
+short answer, and folding the redundant ones is mostly a question of what
+`lake-cache.sh` now subsumes. `scripts/tests/workflow-yaml.test.ts` catches a
+YAML mistake made while folding them.
 
-Reproduce with a throwaway config extending `tsconfig.json` and
-`"include": ["content/**/*.ts"]`. Drain to zero, then move `content/**` into
-the real `include` in the same change — the drain is only worth doing if it
-cannot silently come back.
-
-`scripts/**` is untried beyond a rough count (~15 more, several in tests).
-Widen it after `content/**`, not with it.
-
-**2. `folio-assistant-lnt1` — 171 `no-explicit-any`.**
-Bigger and genuinely wants the per-bucket plan already written in that bean;
-108 of the original 201 annotate something this repo already has a type for.
-Not a sweep — each `any` is a separate typing decision. `render-latex.ts` is
-done (30 -> 0, and its 21 structural errors too, verified byte-identical over
-3483 rendered qou blocks).
-
-**3. `folio-assistant-tnbf` — Lean workflow sprawl.**
-Cheaper than it looks now: this session mapped all 33 workflows and their
-triggers while fixing two that did not parse. Useful facts to start from —
-only `atomic-mass-gen-check.yml` and `docs-site.yml` auto-trigger at all;
-everything else is `workflow_dispatch`. So "which of these actually runs" has
-a short answer, and folding the redundant ones is mostly a question of what
-`lake-cache.sh` now subsumes. `scripts/tests/workflow-yaml.test.ts` will catch
-a YAML mistake made while folding them.
+**3. `scripts/**` into `tsconfig.json`'s `include`.** The next rung of the same
+ratchet, ~15 errors, several in test files. Drain to zero, then widen — never
+widen first.
 
 ## Do NOT claim — a sibling's active cluster
 

--- a/.beans/folio-assistant-tnbf--lean-workflow-sprawl-lean-ci-lean-build-lean-build.md
+++ b/.beans/folio-assistant-tnbf--lean-workflow-sprawl-lean-ci-lean-build-lean-build.md
@@ -1,10 +1,66 @@
 ---
 # folio-assistant-tnbf
 title: 'Lean workflow sprawl: lean_ci / lean-build / lean-build-sidecar / lake-cache-refresh'
-status: todo
+status: completed
 type: task
 created_at: 2026-08-07T15:01:58Z
 updated_at: 2026-08-07T15:01:58Z
 ---
 
 Four overlapping Lean workflows plus two scripts and five skills. Audit what each actually does now that lake-cache.sh is the single service, and fold the redundant ones.
+
+
+Audited by session `3bada08b` on branch `claude/agent-4673-validation-9hffrd`.
+
+## The framing was wrong — they do not overlap, they are all FOLIO workflows
+
+The bean asked what each does "now that lake-cache.sh is the single service"
+and which are redundant. That is not the finding. **All four build
+`content/<paper>/lean/`, which is folio content — folio-assistant is the
+platform and has no papers, so none of them can run here at all.**
+
+`lake-cache-refresh.yml` already says so, in a ⚠ block: "THIS WORKFLOW BELONGS
+IN THE CONTENT REPO, NOT HERE (bean 8agu)". The other three have exactly the
+same dependency and no such warning.
+
+**23 hardcoded `quantum-observable-universe` references** across three of them
+— `lean_ci.yml` (13), `lean-build.yml` (6), `lean-build-sidecar.yml` (1) — one
+folio's paper name baked into platform CI. Same defect class as
+`q-usage-audit`, `export-json`, `readme-metadata`, `refresh-authors-note` and
+the MCP server, at CI level. `lake-cache-refresh.yml` is the exception and
+shows the pattern: it reads its roster from `.github/lake-packages.json`, whose
+own `$comment` states the copy here is a SAMPLE because "the lake-root paths
+below resolve only in a CONTENT repo".
+
+## Fixed here
+
+- **Preflight on all three**, mirroring `qa-sweep.yml`: refuse with a clear
+  message when no `content/<paper>/lean/lakefile.toml` exists, instead of
+  failing partway through `lake build` with an opaque error. Verified in both
+  repos — refuses in the platform, finds 3 Lean packages in qou.
+- **Header drift.** `lean_ci.yml` documented `push (main)` and
+  `pull_request (main)` triggers it does not have, and `lean-build-sidecar.yml`
+  said it builds "on every push to a working branch". Both are
+  `workflow_dispatch`-only, per the 2026-06-30 auto-trigger directive. A header
+  claiming triggers a workflow lacks reads as coverage that is not there —
+  the same failure mode as `eslint .` being a documented command that had never
+  run.
+
+## NOT done, deliberately
+
+**Moving them to the folio.** That is the real fix — it is what was done for
+`qou-paper-builder` earlier in this session, and what bean 8agu already
+concluded for `lake-cache-refresh.yml`. Not done here for two reasons:
+
+1. `lake-cache-refresh.yml` is inside a sibling's active cluster
+   (`folio-assistant-02kc`, `-5d7z`, `-ga7e`, two live branches). Moving a
+   workflow they are changing invites a conflict.
+2. It is a cross-repo change with a licence/ownership dimension, which the
+   owner decided explicitly last time rather than having it inferred.
+
+**De-hardcoding the 23 paper references.** The correct pattern exists
+(`.github/lake-packages.json` + the shared `lake-cache-restore` action), so
+this is a port rather than a design problem — but it is ~550 lines of CI I
+cannot execute from here, and shipping untested CI that *looks* folio-agnostic
+is worse than CI that is honestly folio-specific behind a preflight. It should
+be done in the folio, after the move, where it can be dispatched and observed.

--- a/.beans/folio-assistant-tsca--tsconfig-covered-6-of-69-pipeline-files.md
+++ b/.beans/folio-assistant-tsca--tsconfig-covered-6-of-69-pipeline-files.md
@@ -1,12 +1,14 @@
 ---
 # folio-assistant-tsca
 title: 'tsconfig covered 6 of 69 pipeline files — 48 errors remain in content/'
-status: todo
+status: completed
 type: task
 priority: normal
 created_at: 2026-08-07T23:05:00Z
 updated_at: 2026-08-07T23:05:00Z
 ---
+
+Claimed by session `3bada08b` on branch `claude/agent-4673-validation-9hffrd`.
 
 `tsconfig.json` had `"include": ["src/**/*.ts"]`, so `tsc --noEmit -p .`
 compiled `src/` plus only what `src/` transitively imports — **6 of the 69**
@@ -57,3 +59,52 @@ looks in `<platform>/content/objects`, finds no manifests, and reports
 `q-usage-audit.ts` (`findContentRepoRoot`). With that and two further defects
 fixed, the folio validates end-to-end for the first time: `fred2005-formal-groups`
 0 issues, `quantum-observable-universe` 0 issues, exit 0.
+
+## Resolved — 26 -> 0, and `content/**` is in `include`
+
+The drain was not typing nits. Ten of the 26 were `Cannot find module`:
+`../../schemas/references` (6) and `csl-json` (4). The reference database is
+FOLIO content (qou `content/schema/references.ts`, ~7900 lines of CSL-JSON) and
+`csl-json` was a folio dependency. So six pipeline entry points — `validate-bib`,
+`bib-qa`, `export-bibtex`, `export-json`, `validate-references`,
+`validate-references-human-review` — **threw at import and could not run at
+all**. Verified by running each.
+
+Fixed with `content/pipeline/references-registry-di.ts`, mirroring
+`value-registry-di.ts` exactly. Proven end-to-end against qou's real registry:
+463 entries through the Proxy, and `export-bibtex` ran to completion.
+
+DOWNSTREAM COST, and NOT fixed here because it is folio content: qou's
+committed `references.bib` has **372 entries against 463** in the CSL source,
+and lacks a DOI correction made 2026-07-06. Its generator is `export-bibtex.ts`.
+The LaTeX bibliography the paper builds from has been frozen since 2026-07-04.
+Regenerating it is the owner's call.
+
+Real defects found behind the type errors, each fixed:
+
+- `qa-sweep` `details[].outcome` omitted `"warn"` and `"n/a"` while assigning
+  `CheckerResult["result"]` verbatim — a soft finding was written to the JSON
+  as a value the type said could not occur. Now references the source type.
+- `proof-axis-dashboard` used `evidence` as a string, but the schema is
+  `string | Array<{line?, text?}>`; `ev.includes("no declarations")` on the
+  array form is exact-element membership, so that mismatch never fired.
+- `audit-wiring` typed `BlockAudit.label` as `string` while `block.label` is
+  optional, so every unlabelled block collided on the `undefined` key of
+  `blocksByLabel` — and `allLabels`, hence the `uses[]` resolution, inherited it.
+- `validate-bib` computed both roots from `__dirname` (platform, not folio) and
+  subtracted CSL `date-parts` values typed `string | number`; a non-numeric year
+  yields `NaN`, and `Math.abs(NaN) > 1` is false, so a malformed year read as a
+  MATCH.
+- `export-json` hardcoded `quantum-observable-universe` as its default paper.
+
+## Open question NOT decided here
+
+`EquationBlock` is the only member of the `Block` union that does not extend
+the shared base, so it is the only kind without `uses` — the editorial relation
+AGENTS.md treats as central. That looks unintended, but changing the schema
+touches validation, the viewer and content, so it is left for the owner.
+
+## Next rung
+
+`scripts/**` is still outside `include` (~15 errors, several in test files).
+Same ratchet: drain to zero, then widen.

--- a/.beans/folio-assistant-tsca--tsconfig-covered-6-of-69-pipeline-files.md
+++ b/.beans/folio-assistant-tsca--tsconfig-covered-6-of-69-pipeline-files.md
@@ -108,3 +108,38 @@ touches validation, the viewer and content, so it is left for the owner.
 
 `scripts/**` is still outside `include` (~15 errors, several in test files).
 Same ratchet: drain to zero, then widen.
+
+
+## `scripts/**` rung: DONE, 15 -> 0
+
+Its errors were not typing nits either:
+
+- `computeStats(paperDir, contentRoot)` was called with ONE argument from
+  `readme-metadata.ts` and `refresh-authors-note.ts`, so `contentRoot` was
+  `undefined` at runtime.
+- Both read `conjectures.with_lean_file` and
+  `conjectures.percent_class_axiomatized`, NEITHER of which existed on `Stats`
+  — so the README and the authors' note were interpolating `undefined`. Both
+  are now computed in `lean-coverage.ts` beside their `provable` and
+  `definitions` siblings, from data already gathered.
+- Both scripts hardcoded `quantum-observable-universe` and derived their roots
+  from `import.meta.dir`, i.e. the platform. `refresh-authors-note` read the
+  note from `<platform>/content/…`, which does not exist.
+- `refresh-authors-note`'s `CONJECTURE_RE` no longer matched the note at all:
+  the prose was rewritten to distinguish PRIMARY conjectures ("famous external
+  open problems it connects to … are tallied separately") and the pattern still
+  expected the old wording. It now matches the two bold spans separately, so
+  the sentence between them can be reworded without breaking again, and it
+  computes from `primary_class_axiomatized` — using the all-conjectures figure
+  would have contradicted the sentence around it.
+- `fast-xml-parser` was imported by `scripts/tests/report.ts` and was not a
+  dependency. `run-tests.sh` invokes that file, so it was added rather than
+  the file excluded.
+
+Verified by RUNNING both, against the folio, not just by type-checking:
+`readme-metadata` emits real coverage numbers (`conjectures_with_lean: 166`,
+`conjectures_percent: 92.4` — the two previously-`undefined` fields), and
+`refresh-authors-note --check` reports "authors-note.md is up to date", which
+confirms the primary stats were the right choice.
+
+`adapters/**` is the last tree outside `include` — bean `folio-assistant-adpt`.

--- a/.beans/folio-assistant-zdrf--zod-silently-stripped-fields-ts-declared.md
+++ b/.beans/folio-assistant-zdrf--zod-silently-stripped-fields-ts-declared.md
@@ -1,0 +1,70 @@
+---
+# folio-assistant-zdrf
+title: 'Zod silently stripped fields TS declared — including `lean` on every provable'
+status: completed
+type: bug
+priority: high
+created_at: 2026-08-08T00:30:00Z
+updated_at: 2026-08-08T00:45:00Z
+---
+
+Fixed by session `3bada08b` on branch `claude/agent-4673-validation-9hffrd`.
+
+Started as one loose end from `folio-assistant-tsca`: `EquationBlock` was the
+only member of the `Block` union with no `uses`. It was the visible edge of a
+broader drift between `schemas/types.ts` (the TS contract) and
+`schemas/constraints.ts` (the Zod schemas that actually validate).
+
+The Zod objects are neither `.strict()` nor `.passthrough()`, so the default
+applies: **an unknown key is stripped, silently, and the parse succeeds**.
+Verified directly — a prose block carrying `uses: ["def:a"]` parsed clean and
+came back with `uses === undefined`.
+
+What was being stripped:
+
+| kind(s) | field | corpus impact (qou) |
+|---|---|---|
+| theorem, lemma, proposition, corollary, algorithm | **`lean`** | the link into Lean, on exactly the kinds whose point is to carry one |
+| proof | `of` | 8 blocks — the canonical reverse link to the provable |
+| example | `interprets` | (algorithm and remark already had it) |
+| prose, diagram | `title`, `uses` | 25 + 4 blocks with `uses`, 106 with `title` |
+| equation | `uses`, `title` | 0 blocks today |
+
+`lean` is the serious one. `DefinitionSchema` declared it; `ProvableBaseSchema`
+did not, so every theorem/lemma/proposition/corollary/algorithm had its
+`lean: { ref: … }` dropped at the validation boundary. Nothing crashed, because
+no caller consumes the parsed output — `safeParse` is used for success/failure
+only, and the constraint rules read the original imported block. The cost was
+that Zod could never *validate* those fields.
+
+Fixed by bringing Zod up to TS in each case, and `EquationBlock` up to its
+three standalone siblings (`+uses +title +tags`).
+
+`scripts/tests/schema-ts-zod-parity.test.ts` pins field-set agreement per kind,
+resolving TS `extends` and Zod `.extend()` chains on both sides. 17 tests.
+Two traps worth recording: the two Zod base schemas are declared WITHOUT
+`export`, so a regex requiring it silently yields empty field sets and the test
+passes vacuously; and several schemas nest `z.object({…})` inside a field, so
+bodies need brace counting rather than a lazy `\n\}`.
+
+## `uses-resolve` covered 9 of 15 kinds
+
+Found while measuring the above. The check that catches dangling editorial
+references skipped `algorithm`, `proof`, `prose`, `equation`, `diagram` and
+`table` — **925 blocks in qou declare `uses` on a skipped kind**, `proof` (435)
+and `table` (445) being the bulk. AGENTS.md calls `uses[]` the relation every
+ordering metric is computed from.
+
+Widened to all fifteen. Measured before landing: **19 findings**, not hundreds.
+
+  - 9 genuine dangling labels, e.g. `lemma:cyclotomic-strand-doubling` where
+    the convention is `lem:`.
+  - 10 `*-table-data` blocks carrying `uses: [""]` beside
+    `title: "Data table N from "` — an extraction generator that failed to
+    substitute its source label.
+
+The empty entry had been passing through as a non-finding; it is now reported
+explicitly, and labels are quoted in the message, because `Unresolved uses: `
+with nothing after it reads as a checker bug rather than a content defect.
+
+**Those 19 are qou content and are NOT fixed here** — they are the owner's.

--- a/.github/scripts/agent_review.py
+++ b/.github/scripts/agent_review.py
@@ -43,7 +43,7 @@ import os
 import re
 import requests
 
-from qou_lib.config import REQUIRED_REVIEW_SECTIONS, VALID_VERDICTS
+from qou_lib.config import REQUIRED_REVIEW_SECTIONS
 from qou_lib.skills import load_all_skills, load_skill
 
 # ---------------------------------------------------------------------------

--- a/.github/scripts/axiom_report.py
+++ b/.github/scripts/axiom_report.py
@@ -19,7 +19,6 @@ published alongside the interactive documentation.
 import argparse
 import re
 import subprocess
-import sys
 from datetime import datetime, timezone
 from pathlib import Path
 

--- a/.github/scripts/formalizer.py
+++ b/.github/scripts/formalizer.py
@@ -25,14 +25,12 @@ from qou_lib.config import (
     CHAPTER_FILES,
     CHAPTER_LEAN_FILES,
     CHAPTERS_DIR,
-    ENV_TYPES,
     LABEL_RE,
     LEAN_DIR,
     LEAN_KEYWORDS,
     MAX_ENV_SCAN_LINES,
     REPO_ROOT,
 )
-from qou_lib.git_utils import get_commit_sha
 
 DEFAULT_GLOSSARY = REPO_ROOT / "glossary.json"
 

--- a/.github/scripts/generate-folio-index.py
+++ b/.github/scripts/generate-folio-index.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 import argparse
 import html as html_mod
 import json
-import sys
 from pathlib import Path
 
 _TEMPLATE = r"""<!DOCTYPE html>

--- a/.github/scripts/generate-index.py
+++ b/.github/scripts/generate-index.py
@@ -21,9 +21,6 @@ from __future__ import annotations
 
 import argparse
 import html as html_mod
-import json
-import os
-import sys
 from pathlib import Path
 
 # ---------------------------------------------------------------------------

--- a/.github/scripts/generate-qa.py
+++ b/.github/scripts/generate-qa.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 import argparse
 import html as html_mod
 import re
-import sys
 from pathlib import Path
 
 # ---------------------------------------------------------------------------

--- a/.github/scripts/ontologist.py
+++ b/.github/scripts/ontologist.py
@@ -27,7 +27,6 @@ from qou_lib.config import (
     BEGIN_RE,
     CHAPTER_FILES,
     CHAPTERS_DIR,
-    ENV_TYPES,
     LABEL_RE,
     LEAN_DIR,
     MAX_ENV_SCAN_LINES,

--- a/.github/scripts/qou_lib/skills.py
+++ b/.github/scripts/qou_lib/skills.py
@@ -1,6 +1,5 @@
 """Utilities for loading skill definitions from .claude/skills/."""
 
-from pathlib import Path
 
 from .config import SKILLS_DIR
 

--- a/.github/workflows/code-quality-gates.yml
+++ b/.github/workflows/code-quality-gates.yml
@@ -1,46 +1,59 @@
 # Code-quality gates — cheap, fast static checks that protect compute infra.
 #
-# Three gates (per docs/handover/2026-06-09-affectionate-hopper-handover.md §2):
+# Four jobs (the first three per
+# docs/handover/2026-06-09-affectionate-hopper-handover.md §2).
+#
+# TWO of the four jobs gate THIS repo; two scan trees only a folio has. Which
+# is which is stated in each job, and a job with nothing to scan says so
+# rather than printing OK — see the note on `lean-bare-import`.
 #
 #   1. Lean bare-import gate — HARD FAIL on `import Mathlib` (the whole
 #      library). A bare `import Mathlib` pulls the entire Mathlib build cone
 #      into a single content-block / lib file, which is what drives the
 #      >9-min full-library `lake build` timeout. Targeted imports keep the
-#      per-file dependency cone (and CI build) small. Zero offenders today
-#      (the 2 historical ones — alpha-k-derivation-procedure.lean and
-#      AppendixSurreals/FigureEightCasimirWeight.lean — were narrowed), so
-#      this is a true regression gate.
+#      per-file dependency cone (and CI build) small. FOLIO tree: the Lean
+#      sources live in `content/<paper>/lean/`, so in the platform repo this
+#      job has nothing to scan and skips.
 #
-#   2. Python unused / wildcard imports — WARN-ONLY ratchet. ruff F401
-#      (unused import) + F403 (`from x import *`) over the compute tree.
-#      Warn-only on the current baseline; tighten to a hard gate once the
-#      live offenders (universal-ilp.py wildcard; substrate facade
-#      re-exports) are resolved or annotated (`# noqa: F403` / `__all__`).
+#   2. Python unused / wildcard imports — HARD GATE (promoted from
+#      warn-only). ruff F401 (unused import) + F403 (`from x import *`) over
+#      this repo's Python. It used to scan `folio-assistant/computations` and
+#      `tools`, neither of which exists here — ruff warned about the missing
+#      paths and exited 0, so the step reported a clean baseline it had never
+#      computed. Repointed at the trees that hold the 44 real files, which
+#      surfaced 24 live F401s; those were drained, so the rule is an error.
 #
 #   3. TypeScript gate — HARD FAIL on `bun test`, `bun run lint`, and
-#      `tsc --noEmit`. All three are green as of PR #68 and each is a real
-#      regression gate rather than a baseline report:
-#        - the suite went 201 pass / 29 fail -> 287 / 0 (the 29 were
-#          split-repo assertions that had been red long enough to read as
-#          background noise, which is exactly the cost — a genuine
-#          regression would not have stood out);
-#        - `bun run lint` had NEVER run (no config, no dependency) and now
-#          exits 0. Its config promotes a rule to `error` only once that
-#          rule's count is zero, so a red lint always means a regression
-#          rather than pre-existing debt. `no-explicit-any` is still on
-#          `warn` by design and does not fail this gate.
+#      `tsc --noEmit`. Each is a real regression gate rather than a baseline
+#      report: the suite is 428 pass / 0 fail; `tsc` covers all five trees
+#      (`src`, `schemas`, `content`, `scripts`, `adapters`), not just `src`;
+#      and `eslint` has every rule at `error` — the `warn` tier is empty, so
+#      a red lint always means a regression rather than pre-existing debt.
 #      Without this job none of that is enforced: the ratchet only works if
-#      something runs it.
+#      something runs it — which is exactly what went wrong, see `on:` below.
 #
 #   4. Rust wildcard imports — WARN-ONLY ratchet. Lightweight grep report
 #      of non-test `use ...::*;` in tools/ (full `clippy -D
 #      clippy::wildcard_imports` is the eventual upgrade, but a cargo build
 #      on every PR is too heavy for a static gate; the grep ratchet flags
-#      new wildcard imports cheaply).
+#      new wildcard imports cheaply). FOLIO tree: zero `.rs` files here, so
+#      this job skips.
 
 name: Code-quality gates
 
 on:
+  # This workflow was added by the commit "ci: give the ratchet something to
+  # run in", whose message correctly reported that "no folio-assistant workflow
+  # triggers on `pull_request`" — and was then written `workflow_dispatch`-only,
+  # so it never ran. The fix for "nothing runs the ratchet" was itself something
+  # that never runs. Of 33 workflows here, exactly two auto-trigger
+  # (atomic-mass-gen-check, docs-site) and neither runs any TypeScript check.
+  #
+  # No `paths:` filter. The TypeScript job is the gate for the whole repo, and
+  # a filter is how a gate stops covering the file that broke it.
+  pull_request:
+  push:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -60,6 +73,19 @@ jobs:
       - name: No bare `import Mathlib`
         run: |
           set -euo pipefail
+          # Say which of the two facts this is. `content/` in the PLATFORM repo
+          # holds only `pipeline/` — zero .lean files — so this printed
+          # "OK — no bare 'import Mathlib'" having looked at nothing at all.
+          # "None found" and "nothing to look at" are different, and a gate that
+          # reports the first while meaning the second is worse than no gate:
+          # it reads as coverage. The Lean tree lives in the FOLIO; this job is
+          # here for folios that vendor this workflow.
+          count=$(find content -name '*.lean' 2>/dev/null | wc -l)
+          if [ "$count" -eq 0 ]; then
+            echo "SKIP — no content/**/*.lean in this repo (the Lean tree lives in the folio). Nothing scanned."
+            exit 0
+          fi
+          echo "Scanning $count Lean file(s)…"
           if matches=$(grep -rnE '^import Mathlib[[:space:]]*$' \
                 content --include='*.lean' 2>/dev/null); then
             echo "::error::Bare 'import Mathlib' found — use targeted imports (#min_imports). Offenders:"
@@ -69,10 +95,10 @@ jobs:
             done
             exit 1
           fi
-          echo "OK — no bare 'import Mathlib' in content/**/*.lean"
+          echo "OK — no bare 'import Mathlib' in $count Lean file(s)"
 
   python-imports:
-    name: Python unused/wildcard imports (warn-only)
+    name: Python unused/wildcard imports (hard)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -84,17 +110,36 @@ jobs:
       - name: Install ruff
         run: pip install "ruff>=0.5"
 
-      # WARN-ONLY: report F401 (unused) + F403 (wildcard) but never fail CI
-      # on the current baseline. Flip `continue-on-error` off (and drop the
-      # `|| true`) to make it a hard gate once the baseline is clean.
-      - name: ruff F401,F403 (report)
-        continue-on-error: true
-        # `continue-on-error` (above) keeps the job green; do NOT add `|| true`
-        # — that would mask the step's own failed status in the Actions UI.
+      # HARD GATE, promoted from warn-only. Same rule as eslint: a check is an
+      # error only once its count is zero, and this repo's count is zero — the
+      # 24 live F401s were drained in the same commit that repointed the scan.
+      # `continue-on-error` is gone with it; a new unused import fails here.
+      - name: ruff F401,F403
+        #
+        # Was pointed at `folio-assistant/computations tools`. Neither exists
+        # here: `tools/` is a folio tree, and `folio-assistant/computations` is
+        # a FOLIO-RELATIVE path (inside a folio, the platform is the
+        # `folio-assistant/` symlink) — so in this repo it would mean
+        # `folio-assistant/folio-assistant/computations`. ruff exits non-zero on
+        # a missing path, and `continue-on-error` swallowed that, so the step
+        # has been reporting a clean baseline it never computed.
+        #
+        # Scan the trees that hold this repo's 44 Python files. Missing paths
+        # are dropped rather than passed to ruff, and an empty set is stated.
         run: |
+          set -uo pipefail
+          targets=""
+          for d in scripts .github/scripts content/pipeline schemas src adapters; do
+            [ -d "$d" ] && targets="$targets $d"
+          done
+          if [ -z "$targets" ]; then
+            echo "SKIP — no Python trees present in this repo. Nothing scanned."
+            exit 0
+          fi
+          echo "Scanning:$targets"
           ruff check --select F401,F403 --output-format=github \
             --exclude '**/_deprecated/**' \
-            folio-assistant/computations tools
+            $targets
 
   typescript:
     name: TypeScript — tests, lint, types (hard)
@@ -135,6 +180,15 @@ jobs:
         continue-on-error: true
         run: |
           set -uo pipefail
+          # Same distinction as the Lean gate: there are ZERO .rs files in this
+          # repo, so "OK — no non-test wildcard imports" was reporting a clean
+          # result for a scan of nothing. `tools/` is a folio tree; this job is
+          # here for folios that vendor this workflow.
+          count=$(find tools -name '*.rs' 2>/dev/null | wc -l)
+          if [ "$count" -eq 0 ]; then
+            echo "SKIP — no tools/**/*.rs in this repo (the Rust tree lives in the folio). Nothing scanned."
+            exit 0
+          fi
           # Char class covers digits too (e.g. base64::prelude::*, sha2::*) and
           # underscores (wasm_bindgen::prelude::*, extendr_api::prelude::*).
           matches=$(grep -rnE '^[[:space:]]*use [A-Za-z0-9_:]+::\*;' \
@@ -146,5 +200,5 @@ jobs:
               echo "  $line"
             done
           else
-            echo "OK — no non-test wildcard imports in tools/**/*.rs"
+            echo "OK — no non-test wildcard imports in $count Rust file(s)"
           fi

--- a/.github/workflows/lean-build-sidecar.yml
+++ b/.github/workflows/lean-build-sidecar.yml
@@ -5,7 +5,9 @@
 # ───
 # Lean builds are slow and verbose. Instead of building locally and
 # pasting terminal output, this workflow builds the root Lake workspace
-# in CI on every push to a working branch, then commits
+# in CI — on manual dispatch, NOT "on every push": the `on:` below is
+# `workflow_dispatch` only, per the 2026-06-30 auto-trigger directive — then
+# commits
 # `build-logs/lean-build-status.json` (per-paper pass/fail, failing
 # modules, extracted file:line:col errors + sorry locations) back to the
 # branch. An agent reads that sidecar straight from the branch.
@@ -49,6 +51,23 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
+
+      # PREFLIGHT. This builds `content/<paper>/lean/`, which is FOLIO content —
+      # folio-assistant is the platform and has no papers, so a run here fails
+      # partway through `lake build` with an opaque error. Refuse up front and
+      # say which repo was expected. Mirrors `qa-sweep.yml`'s preflight, and the
+      # ⚠ already carried by `lake-cache-refresh.yml`.
+      - name: Preflight — a folio must be attached
+        run: |
+          roots=$(find content -mindepth 3 -maxdepth 3 -name lakefile.toml -path '*/lean/*' 2>/dev/null)
+          if [ -z "$roots" ]; then
+            echo "::error::no content/<paper>/lean/lakefile.toml found."
+            echo "::error::This is a FOLIO workflow: it builds a paper's Lean package."
+            echo "::error::folio-assistant is the PLATFORM and carries no papers."
+            echo "::error::Run it from the content repo, where content/<paper>/lean/ exists."
+            exit 1
+          fi
+          echo "lean packages: $(echo "$roots" | tr '\n' ' ')"
 
       - name: Install Lean via elan
         run: |

--- a/.github/workflows/lean-build.yml
+++ b/.github/workflows/lean-build.yml
@@ -34,6 +34,23 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
+      # PREFLIGHT. This builds `content/<paper>/lean/`, which is FOLIO content —
+      # folio-assistant is the platform and has no papers, so a run here fails
+      # partway through `lake build` with an opaque error. Refuse up front and
+      # say which repo was expected. Mirrors `qa-sweep.yml`'s preflight, and the
+      # ⚠ already carried by `lake-cache-refresh.yml`.
+      - name: Preflight — a folio must be attached
+        run: |
+          roots=$(find content -mindepth 3 -maxdepth 3 -name lakefile.toml -path '*/lean/*' 2>/dev/null)
+          if [ -z "$roots" ]; then
+            echo "::error::no content/<paper>/lean/lakefile.toml found."
+            echo "::error::This is a FOLIO workflow: it builds a paper's Lean package."
+            echo "::error::folio-assistant is the PLATFORM and carries no papers."
+            echo "::error::Run it from the content repo, where content/<paper>/lean/ exists."
+            exit 1
+          fi
+          echo "lean packages: $(echo "$roots" | tr '\n' ' ')"
+
       # Lean is pre-installed in the paper-assistant image (via elan).
       - name: Verify Lean installation
         run: |

--- a/.github/workflows/lean_ci.yml
+++ b/.github/workflows/lean_ci.yml
@@ -2,9 +2,14 @@
 #
 # Triggers
 # ────────
-#   push (main)            – commits that touch lean/, chapters/, or manifests
-#   pull_request (main)    – PRs targeting main with lean/chapter changes
-#   workflow_dispatch      – manual run
+#   workflow_dispatch      – manual run, and the ONLY trigger.
+#
+#   This block used to also list `push (main)` and `pull_request (main)`.
+#   Neither exists: the `on:` below is dispatch-only, per the owner directive
+#   of 2026-06-30 that disabled auto-triggers repo-wide over Actions billing
+#   (see `qou/.github/workflows/build.yml`, which states it). A header that
+#   claims triggers a workflow does not have reads as coverage that is not
+#   there.
 #
 # Phases
 # ──────
@@ -69,6 +74,23 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
+
+      # PREFLIGHT. This builds `content/<paper>/lean/`, which is FOLIO content —
+      # folio-assistant is the platform and has no papers, so a run here fails
+      # partway through `lake build` with an opaque error. Refuse up front and
+      # say which repo was expected. Mirrors `qa-sweep.yml`'s preflight, and the
+      # ⚠ already carried by `lake-cache-refresh.yml`.
+      - name: Preflight — a folio must be attached
+        run: |
+          roots=$(find content -mindepth 3 -maxdepth 3 -name lakefile.toml -path '*/lean/*' 2>/dev/null)
+          if [ -z "$roots" ]; then
+            echo "::error::no content/<paper>/lean/lakefile.toml found."
+            echo "::error::This is a FOLIO workflow: it builds a paper's Lean package."
+            echo "::error::folio-assistant is the PLATFORM and carries no papers."
+            echo "::error::Run it from the content repo, where content/<paper>/lean/ exists."
+            exit 1
+          fi
+          echo "lean packages: $(echo "$roots" | tr '\n' ' ')"
 
       - name: Install CI tools
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ dist/
 # Generated files — regenerate with `npm run generate:all`
 schemas/generated/
 content/audit-tex-source.json
+
+# Python bytecode. There are 44 .py files here and no ignore for their
+# artefacts, so any `python -m py_compile` / import leaves `__pycache__`
+# directories staged for the next `git add -A`.
+__pycache__/
+*.py[cod]

--- a/adapters/manifest-entries.ts
+++ b/adapters/manifest-entries.ts
@@ -1,0 +1,88 @@
+/**
+ * Helpers for reading author-written manifest entries.
+ *
+ * Both resolvers — `adapters/mcp-server/server.ts` and
+ * `adapters/paper/resolver.ts` — walk the same `.ts` manifests and had grown
+ * their own byte-identical copies of `tryParseLeanRef` and `sectionBlockNames`,
+ * each taking `any`. Two copies of a shape decision is how the two resolvers
+ * came to disagree about which `sections[]` entries count: one skipped
+ * everything without a `blocks` array, the other skipped only bare references.
+ *
+ * One copy, one predicate, one place to pin in a test.
+ *
+ * @module folio-assistant/adapters/manifest-entries
+ */
+
+import type { Block, Section, SectionRef } from "../schemas/types.js";
+import { parseLeanRef, type ParsedLeanRef } from "../schemas/lean-packages.js";
+
+/**
+ * Is this `sections[]` entry a bare reference to a section file, rather than
+ * an inline section?
+ *
+ * The test is "names a target AND carries no blocks", not merely "has no
+ * blocks": a `{ title, subsections }` entry is an inline section that happens
+ * to keep every block in its subsections, and classifying it as a reference
+ * drops all of them. `Section.blocks` is required by the schema, but authored
+ * manifests omit it in exactly that case, which is why the runtime test cannot
+ * be replaced by the static type.
+ */
+export function isSectionRef(sec: Section | SectionRef): sec is SectionRef {
+  return "name" in sec && !("blocks" in sec);
+}
+
+/**
+ * Flatten a section manifest into the ordered list of block root-names it
+ * contributes: the section's own `blocks`, then each subsection's `blocks` in
+ * declaration order.
+ *
+ * The viewer / MCP resolution layer has no subsection nesting, so subsection
+ * content is surfaced inline under the parent section. The order mirrors the
+ * LaTeX renderer (`render-latex.ts`: parent blocks first, then each
+ * `\subsection` with its blocks), keeping viewer and PDF block order in sync.
+ * Without this, blocks living only inside `subsections[]` never reach any
+ * resolver consumer and the section renders empty in the viewer.
+ */
+export function sectionBlockNames(sec: Section): string[] {
+  const own: string[] = Array.isArray(sec.blocks) ? sec.blocks : [];
+  const subs: string[] = Array.isArray(sec.subsections)
+    ? sec.subsections.flatMap((s) => (s && !isSectionRef(s) && Array.isArray(s.blocks) ? s.blocks : []))
+    : [];
+  return subs.length ? [...own, ...subs] : own;
+}
+
+/**
+ * A block's `lean` field, for the kinds that declare one.
+ *
+ * `Block` is a discriminated union and only the provable kinds carry `lean`,
+ * so `blk.lean` is a type error on the union — which is why both resolvers
+ * reached it through an `any`-typed block instead. Note there is no companion
+ * `blk.status`: `FormalizationStatus` is documented as derived at build time
+ * from .lean content and "NOT stored in content block .ts manifests", so every
+ * `blk.status` read against a manifest was `undefined`. Derive it from this
+ * instead, via `leanStatusBucket`.
+ */
+export function blockLean(blk: Block) {
+  return "lean" in blk ? blk.lean : undefined;
+}
+
+/** As `blockLean`, for the other fields only some block kinds declare. */
+export const blockProofs = (b: Block) => ("proofs" in b ? b.proofs : undefined);
+export const blockExamples = (b: Block) => ("examples" in b ? b.examples : undefined);
+export const blockTex = (b: Block) => ("tex" in b ? b.tex : undefined);
+export const blockCaption = (b: Block) => ("caption" in b ? b.caption : undefined);
+
+/**
+ * Parse a block's `lean.ref` URI; returns `undefined` on a missing or
+ * malformed ref, so callers degrade to sibling-only resolution rather than
+ * throwing.
+ */
+export function tryParseLeanRef(blk: Block): ParsedLeanRef | undefined {
+  const ref = blockLean(blk)?.ref;
+  if (typeof ref !== "string" || ref.length === 0) return undefined;
+  try {
+    return parseLeanRef(ref);
+  } catch {
+    return undefined;
+  }
+}

--- a/adapters/mcp-server/git.ts
+++ b/adapters/mcp-server/git.ts
@@ -269,16 +269,26 @@ export function fileExistsBranch(branch: string | undefined, relPath: string): b
 
 /**
  * Import a .ts module — from disk if current branch, via temp file otherwise.
+ *
+ * Generic in the module's default export. It returned `Promise<unknown>`, so
+ * every one of the dozen call sites cast the result — and they all reached for
+ * `as any` rather than `as Chapter` / `as Block` / `as Paper`, which the schema
+ * already defines. The cast moves to the type argument, where it is at least
+ * named. Still a claim about a dynamically imported module, not a check: `T`
+ * defaults to `unknown` so an un-annotated call stays honest.
  */
-export async function importTsBranch(branch: string | undefined, relPath: string): Promise<unknown> {
+export async function importTsBranch<T = unknown>(
+  branch: string | undefined,
+  relPath: string,
+): Promise<T> {
   if (isCurrentBranch(branch)) {
     const absPath = resolve(REPO_ROOT, relPath);
     delete require.cache?.[absPath];
     // Bust ESM module cache with timestamp query param
     const mod = await import(`${absPath}?t=${Date.now()}`);
-    return mod.default ?? mod;
+    return (mod.default ?? mod) as T;
   }
-  return gitImportTs(branch!, relPath);
+  return gitImportTs(branch!, relPath) as Promise<T>;
 }
 
 /**

--- a/adapters/mcp-server/paths.ts
+++ b/adapters/mcp-server/paths.ts
@@ -6,9 +6,23 @@
 
 import { resolve } from "path";
 import { readFileSync } from "fs";
+import { findContentRepoRoot } from "../../content/pipeline/repo-root";
 
-/** Repository root directory. */
-export const REPO_ROOT = resolve(import.meta.dir, "../..");
+/**
+ * The FOLIO's root — the content repo this server serves.
+ *
+ * Every constant below is a folio concept: `content/`, `chapters/`,
+ * `main.tex`, the Lake workspace, `build/`, `todos/`. None of them exist in
+ * folio-assistant, which is the platform. This was
+ * `resolve(import.meta.dir, "../..")`, so the server rooted itself in the
+ * platform and reported `Paper not found` for every paper in the folio it was
+ * launched from — and its git operations ran against the platform repo rather
+ * than the content branches it is meant to switch between.
+ *
+ * Same defect class as `q-usage-audit`, `validate`, `validate-bib`,
+ * `export-json`, `readme-metadata` and `refresh-authors-note`.
+ */
+export const REPO_ROOT = findContentRepoRoot();
 
 /** Content objects directory. */
 export const CONTENT_DIR = resolve(REPO_ROOT, "content");

--- a/adapters/mcp-server/server.ts
+++ b/adapters/mcp-server/server.ts
@@ -158,7 +158,7 @@ function ensureWorktree(): boolean {
     }
     worktreeReady = true;
     return true;
-  } catch {
+  } catch (e) {
     log("feedback", "worktree error", String(e));
     return false;
   }
@@ -207,7 +207,7 @@ function commitFeedbackToMain(paperId: string, rootName: string, content: string
       }
       log("feedback", `push failed after retries: ${relPath}`);
     }
-  } catch {
+  } catch (e) {
     log("feedback", "commit error", String(e));
   }
 }
@@ -266,7 +266,10 @@ function resolveLeanSource(
   blk: any,
   chRel: string,
   rootName: string,
-  branch: string,
+  // `string | undefined`, matching `readFileBranch` (which this forwards to)
+  // and both call sites, where `br` is the optional `?branch=` query param.
+  // Declaring it `string` was simply narrower than every party involved.
+  branch: string | undefined,
 ): string | undefined {
   if (!blk?.lean) return undefined;
   const parsed = tryParseLeanRef(blk);
@@ -323,7 +326,12 @@ interface ResolvedBlock {
   uses?: string[];
   examples?: string[];
   proofs?: string[];
-  lean?: { ref: string; file?: string; validation?: string; source?: string };
+  /** `sorryFree` is a real `LeanRef` field (schemas/types.ts) and the
+   *  strongest proof-status signal — `render-latex` says it "wins outright"
+   *  over the `validation` enum. The `...blk.lean` spreads below carry it;
+   *  omitting it here made it invisible to every consumer and unreadable at
+   *  the one site that tried. */
+  lean?: { ref: string; file?: string; validation?: string; sorryFree?: boolean; source?: string };
   status?: string;
   tex?: string;
   caption?: string;
@@ -337,12 +345,22 @@ interface ResolvedSection {
   title: string;
   label?: string;
   blocks: ResolvedBlock[];
+  /** One structural level deeper. The resolver builds these and the block
+   *  lookup below reads them; the interface simply never declared it. */
+  subsections?: ResolvedSection[];
 }
 
 interface ResolvedChapter {
-  number: number;
+  /** Optional in practice: the resolver sets `undefined` for a chapter that
+   *  carries a `tabLabel` (appendices), auto-numbering only the rest. */
+  number?: number;
   title: string;
   label?: string;
+  /** Set for appendices instead of a number. */
+  tabLabel?: string;
+  /** Chapter directory. Pushed by `resolvePaper` and read by the block
+   *  lookup — declared here for the first time. */
+  dir?: string;
   sections: ResolvedSection[];
   todos?: unknown[];
 }
@@ -506,7 +524,7 @@ async function resolvePaper(id: string, branch?: string): Promise<(ResolvedPaper
               status: blk.status, tex: blk.tex, caption: blk.caption, tags: blk.tags, rendered: rendered || figRendered,
               md, todos: blockTodos
             });
-          } catch { res.push({ rootName, kind: "error", md: `Failed to load ${rootName}: ${e}` }); }
+          } catch (e) { res.push({ rootName, kind: "error", md: `Failed to load ${rootName}: ${e}` }); }
         }
         return res;
       };
@@ -607,9 +625,13 @@ function invalidatePaperCache(paperId?: string): void {
 // ── Paper outline (lightweight — no blocks/md/lean) ─────────────
 
 interface ChapterOutline {
-  number: number;
+  /** Undefined for a chapter carrying a `tabLabel` — same rule as
+   *  `ResolvedChapter.number`, which this mirrors. */
+  number?: number;
   title: string;
   label?: string;
+  /** Set for appendices instead of a number — the resolver pushes it. */
+  tabLabel?: string;
   dir: string;
   sections: { title: string; label?: string; blockCount: number }[];
 }
@@ -684,7 +706,7 @@ interface SectionStub {
   label?: string;
   blockCount: number;
   /** Lightweight block summaries for sidebar (no md/lean source). */
-  blockStubs: { rootName: string; kind: string; label?: string; title?: string; status?: string; lean?: { decl?: string; file?: string; validation?: string }; todoCount: number }[];
+  blockStubs: { rootName: string; kind: string; label?: string; title?: string; status?: string; lean?: { ref?: string; file?: string; validation?: string; sorryFree?: boolean }; todoCount: number }[];
 }
 
 interface ChapterDetail {
@@ -727,7 +749,7 @@ async function resolveChapterDetail(
           label: blk.label,
           title: blk.title,
           status: blk.status,
-          lean: blk.lean ? { ref: blk.lean.ref, validation: blk.lean.validation } : undefined,
+          lean: blk.lean ? { ref: blk.lean.ref, validation: blk.lean.validation, sorryFree: blk.lean.sorryFree } : undefined,
           todoCount: feedback.filter((t: any) => t.status === "open").length,
         });
       } catch {
@@ -745,7 +767,11 @@ async function resolveChapterDetail(
 
   // Auto-derive chapter number from outline
   let chapterNumber: number | undefined;
-  const outline = await resolveOutline(paperId, branch);
+  // `resolvePaperOutline`, the function that exists — this called
+  // `resolveOutline`, which never has. A ReferenceError on every request that
+  // reached it, so the chapter-number auto-derivation below has never run.
+  // Landed in 109a4ff and invisible because `adapters/**` was never compiled.
+  const outline = await resolvePaperOutline(paperId, branch);
   if (outline) {
     const idx = outline.chapters.findIndex((c: ChapterOutline) => c.dir === chapterDir);
     if (idx >= 0) chapterNumber = outline.chapters[idx].number;
@@ -841,7 +867,7 @@ async function resolveSection(
         ...(blk.defaultView ? { defaultView: blk.defaultView } : {}),
         ...(blk.views ? { views: blk.views } : {}),
       });
-    } catch {
+    } catch (e) {
       blocks.push({ rootName, kind: "error", md: `Failed to load ${rootName}: ${e}` });
     }
   }
@@ -929,7 +955,7 @@ Respond in JSON with exactly these fields:
       };
     }
     return fallbackCharacterization(diff);
-  } catch {
+  } catch (e) {
     return { ...fallbackCharacterization(diff), error: `Claude API error: ${e instanceof Error ? e.message : String(e)}` };
   }
 }
@@ -1027,7 +1053,7 @@ Respond in JSON with exactly these fields:
       };
     }
     return { assessment: "Failed to parse AI response.", actionable: false };
-  } catch {
+  } catch (e) {
     return {
       assessment: `Feedback: "${todo.summary}". Priority: ${todo.priority}.`,
       actionable: false,
@@ -1208,7 +1234,7 @@ async function handleViewerRequest(url: URL): Promise<Response | null> {
         dirty: changes.length > 0,
         changes,
       }, { headers: { "Cache-Control": "no-cache", "Access-Control-Allow-Origin": "*" } });
-    } catch {
+    } catch (e) {
       log('git', `status: error — ${e}`);
       return Response.json({ error: String(e) }, { status: 500, headers: { "Access-Control-Allow-Origin": "*" } });
     }
@@ -1246,7 +1272,7 @@ async function handleViewerRequest(url: URL): Promise<Response | null> {
         }
       }
       return Response.json(imports, { headers: { "Access-Control-Allow-Origin": "*" } });
-    } catch {
+    } catch (e) {
       return Response.json({ error: String(e) }, { status: 500 });
     }
   }
@@ -1258,7 +1284,7 @@ async function handleViewerRequest(url: URL): Promise<Response | null> {
     try {
       const data = await resolveFolio(branch);
       return Response.json(data, { headers: { "Cache-Control": "no-cache", "Access-Control-Allow-Origin": "*" } });
-    } catch {
+    } catch (e) {
       return Response.json({ error: String(e) }, { status: 500 });
     }
   }
@@ -1273,7 +1299,7 @@ async function handleViewerRequest(url: URL): Promise<Response | null> {
       const data = await resolvePaper(id, branch);
       if (!data) return Response.json({ error: `Paper not found: ${id}` }, { status: 404 });
       return Response.json(data, { headers: { "Cache-Control": "no-cache", "Access-Control-Allow-Origin": "*" } });
-    } catch {
+    } catch (e) {
       const msg = e instanceof Error ? e.stack || e.message : String(e);
       log('error', `GET /api/paper id=${id} branch=${branch}: ${msg}`);
       return Response.json({ error: msg }, { status: 500 });
@@ -1290,7 +1316,7 @@ async function handleViewerRequest(url: URL): Promise<Response | null> {
       const data = await resolvePaperOutline(id, branch);
       if (!data) return Response.json({ error: `Paper not found: ${id}` }, { status: 404 });
       return Response.json(data, { headers: { "Cache-Control": "max-age=300", "Access-Control-Allow-Origin": "*" } });
-    } catch {
+    } catch (e) {
       const msg = e instanceof Error ? e.stack || e.message : String(e);
       log('error', `GET /api/paper/outline id=${id} branch=${branch}: ${msg}`);
       return Response.json({ error: msg }, { status: 500 });
@@ -1308,7 +1334,7 @@ async function handleViewerRequest(url: URL): Promise<Response | null> {
       const data = await resolveChapterDetail(id, chapter, branch);
       if (!data) return Response.json({ error: `Chapter not found: ${chapter}` }, { status: 404 });
       return Response.json(data, { headers: { "Cache-Control": "max-age=300", "Access-Control-Allow-Origin": "*" } });
-    } catch {
+    } catch (e) {
       const msg = e instanceof Error ? e.stack || e.message : String(e);
       log('error', `GET /api/paper/chapter id=${id} chapter=${chapter}: ${msg}`);
       return Response.json({ error: msg }, { status: 500 });
@@ -1327,7 +1353,7 @@ async function handleViewerRequest(url: URL): Promise<Response | null> {
       const data = await resolveSection(id, chapter, parseInt(sectionIdx, 10), branch);
       if (!data) return Response.json({ error: `Section not found: ${chapter}[${sectionIdx}]` }, { status: 404 });
       return Response.json(data, { headers: { "Cache-Control": "max-age=300", "Access-Control-Allow-Origin": "*" } });
-    } catch {
+    } catch (e) {
       const msg = e instanceof Error ? e.stack || e.message : String(e);
       log('error', `GET /api/paper/section id=${id} chapter=${chapter} section=${sectionIdx}: ${msg}`);
       return Response.json({ error: msg }, { status: 500 });
@@ -1346,7 +1372,9 @@ async function handleViewerRequest(url: URL): Promise<Response | null> {
       if (!paperData) return Response.json({ error: `Paper not found: ${id}` }, { status: 404 });
       // Search all chapters and sections for the block
       for (const ch of paperData.chapters || []) {
-        const chDir = ch._dir || ch.dir;
+        // `_dir` is read nowhere else and assigned nowhere at all, so this
+        // always fell through to `ch.dir`. Dropped rather than declared.
+        const chDir = ch.dir;
         if (!chDir) continue;
         for (let si = 0; si < (ch.sections || []).length; si++) {
           try {
@@ -1354,11 +1382,11 @@ async function handleViewerRequest(url: URL): Promise<Response | null> {
             if (!secData || !secData.blocks) continue;
             const found = secData.blocks.find((b: any) => b.label === label);
             if (found) return Response.json(found, { headers: { "Cache-Control": "max-age=300", "Access-Control-Allow-Origin": "*" } });
-          } catch { log('warn', `GET /api/paper/block resolveSection ${chDir}[${si}]: ${e}`); continue; }
+          } catch (e) { log('warn', `GET /api/paper/block resolveSection ${chDir}[${si}]: ${e}`); continue; }
         }
       }
       return Response.json({ error: `Block not found: ${label}` }, { status: 404 });
-    } catch {
+    } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       return Response.json({ error: msg }, { status: 500 });
     }
@@ -1431,7 +1459,7 @@ async function handleViewerRequest(url: URL): Promise<Response | null> {
       const diff = computePaperDiff(basePaper, headPaper, base, head);
       if (mb) (diff as any).mergeBase = mb;
       return Response.json(diff, { headers: { "Cache-Control": "no-cache", "Access-Control-Allow-Origin": "*" } });
-    } catch {
+    } catch (e) {
       return Response.json({ error: String(e) }, { status: 500 });
     }
   }
@@ -1455,7 +1483,7 @@ async function handleViewerRequest(url: URL): Promise<Response | null> {
       return Response.json({ ...summary, diff: diff.summary }, {
         headers: { "Cache-Control": "no-cache", "Access-Control-Allow-Origin": "*" },
       });
-    } catch {
+    } catch (e) {
       return Response.json({ error: String(e) }, { status: 500 });
     }
   }
@@ -1469,6 +1497,10 @@ async function handleViewerRequest(url: URL): Promise<Response | null> {
     if (!label) return Response.json({ error: "Missing ?label= parameter" }, { status: 400 });
     try {
       const paper = await resolvePaper(id);
+      // `resolvePaper` returns `ResolvedPaper | null`; the file's other
+      // handlers 404 on null, these two dereferenced it straight into
+      // `paper.chapters` — a TypeError on any unknown paper id.
+      if (!paper) return Response.json({ error: `Paper not found: ${id}` }, { status: 404 });
       // Find the block's rootName and chapter directory
       let rootName: string | null = null;
       let chapterDir: string | null = null;
@@ -1503,7 +1535,7 @@ async function handleViewerRequest(url: URL): Promise<Response | null> {
       return Response.json({ label, rootName, chapterDir, commits }, {
         headers: { "Cache-Control": "no-cache", "Access-Control-Allow-Origin": "*" },
       });
-    } catch {
+    } catch (e) {
       return Response.json({ error: String(e) }, { status: 500 });
     }
   }
@@ -1519,7 +1551,13 @@ async function handleViewerRequest(url: URL): Promise<Response | null> {
     const buf = gitShowBinaryAt(sha, filePath);
     if (!buf) return new Response("Not found at that commit", { status: 404 });
     const ext = extname(filePath);
-    return new Response(buf, {
+    // Node's `Buffer` IS a `Uint8Array` at
+    // runtime and Bun accepts it, but TS's `BodyInit` union does not name it,
+    // so the call resolved against the `URLSearchParams` overload and failed.
+    // A view over `buf.buffer` does not help either: that is `ArrayBufferLike`,
+    // which could be a `SharedArrayBuffer`, and `BufferSource` wants a plain
+    // `ArrayBuffer`. Copying is the honest fix, and these are static assets.
+    return new Response(new Uint8Array(buf), {
       headers: {
         "Content-Type": MIME[ext] || "application/octet-stream",
         "Cache-Control": "public, max-age=31536000, immutable",
@@ -1536,6 +1574,10 @@ async function handleViewerRequest(url: URL): Promise<Response | null> {
     if (!label) return Response.json({ error: "Missing ?label= parameter" }, { status: 400 });
     try {
       const paper = await resolvePaper(id);
+      // `resolvePaper` returns `ResolvedPaper | null`; the file's other
+      // handlers 404 on null, these two dereferenced it straight into
+      // `paper.chapters` — a TypeError on any unknown paper id.
+      if (!paper) return Response.json({ error: `Paper not found: ${id}` }, { status: 404 });
       // Build block index and reverse dependency map
       const allBlocks: Array<{ label: string; kind: string; title: string; uses: string[] }> = [];
       const reverseDeps = new Map<string, string[]>();
@@ -1576,7 +1618,7 @@ async function handleViewerRequest(url: URL): Promise<Response | null> {
           .map(b => ({ label: b.label, kind: b.kind, title: b.title })),
         totalAffected: transitive.length,
       }, { headers: { "Cache-Control": "no-cache", "Access-Control-Allow-Origin": "*" } });
-    } catch {
+    } catch (e) {
       return Response.json({ error: String(e) }, { status: 500 });
     }
   }
@@ -1692,7 +1734,7 @@ async function handleViewerRequest(url: URL): Promise<Response | null> {
         latexLog: texLog || undefined,
         exitCode: latexResult.status,
       }, { status: 500, headers: { "Access-Control-Allow-Origin": "*" } });
-    } catch {
+    } catch (e) {
       return Response.json({ error: String(e) }, { status: 500, headers: { "Access-Control-Allow-Origin": "*" } });
     }
   }
@@ -1859,7 +1901,7 @@ async function handleViewerRequest(url: URL): Promise<Response | null> {
           if (blockObj) {
             blockTexParts.push(renderBlock(blockObj as any, mdContent));
           }
-        } catch {
+        } catch (e) {
           blockTexParts.push(`% Error rendering ${b.label}: ${String(e)}`);
         }
       }
@@ -1938,7 +1980,7 @@ async function handleViewerRequest(url: URL): Promise<Response | null> {
         blockCount: chainBlocks.length,
         exitCode: latexResult.status,
       }, { status: 500, headers: { "Access-Control-Allow-Origin": "*" } });
-    } catch {
+    } catch (e) {
       return Response.json({ error: String(e) }, { status: 500, headers: { "Access-Control-Allow-Origin": "*" } });
     }
   }
@@ -2019,7 +2061,7 @@ async function handlePostRequest(url: URL, req: Request): Promise<Response | nul
       invalidatePaperCache(body.paperId);
       log('edit', `block saved: ${body.paperId}/${body.rootName}`, `${body.md.length} chars → ${mdPath}`);
       return Response.json({ ok: true, path: mdPath });
-    } catch {
+    } catch (e) {
       return Response.json({ error: String(e) }, { status: 500 });
     }
   }
@@ -2056,7 +2098,7 @@ async function handlePostRequest(url: URL, req: Request): Promise<Response | nul
       invalidatePaperCache(body.paperId);
       log('revert', `block reverted: ${body.paperId}/${body.rootName}`, `to commit ${body.sha.slice(0, 8)}`);
       return Response.json({ ok: true, sha: body.sha, path: mdPath });
-    } catch {
+    } catch (e) {
       return Response.json({ error: String(e) }, { status: 500 });
     }
   }
@@ -2089,7 +2131,7 @@ async function handlePostRequest(url: URL, req: Request): Promise<Response | nul
       log('feedback', `created: ${body.paperId}/${body.rootName}`, `id=${todo.id} priority=${todo.priority} assignee=${todo.assignee}`);
 
       return Response.json({ ok: true, todo });
-    } catch {
+    } catch (e) {
       return Response.json({ error: String(e) }, { status: 500 });
     }
   }
@@ -2155,7 +2197,7 @@ async function handlePostRequest(url: URL, req: Request): Promise<Response | nul
         ok: true,
         branch: currentBranch(),
       }, { headers: { "Access-Control-Allow-Origin": "*" } });
-    } catch {
+    } catch (e) {
       log('git', `checkout: error — ${e}`);
       return Response.json({ error: String(e) }, { status: 500, headers: { "Access-Control-Allow-Origin": "*" } });
     }
@@ -2346,7 +2388,7 @@ async function handlePostRequest(url: URL, req: Request): Promise<Response | nul
                   blocks.push({
                     kind: blk.kind, label: blk.label, title: blk.title,
                     status: blk.status,
-                    lean: blk.lean ? { ref: blk.lean.ref, validation: blk.lean.validation } : null,
+                    lean: blk.lean ? { ref: blk.lean.ref, validation: blk.lean.validation, sorryFree: blk.lean.sorryFree } : null,
                     section: sec.title,
                   });
                 }
@@ -2397,7 +2439,7 @@ async function handlePostRequest(url: URL, req: Request): Promise<Response | nul
             default:
               return JSON.stringify({ error: `Unknown tool: ${name}` });
           }
-        } catch {
+        } catch (e) {
           return JSON.stringify({ error: String(e) });
         }
       }
@@ -2601,7 +2643,7 @@ These become clickable buttons so users don't have to type. Make them specific t
             controller.enqueue(encoder.encode(`data: [DONE]\n\n`));
             logDebug("chat", "stream complete (after tool rounds)");
             controller.close();
-          } catch {
+          } catch (e) {
             log("chat", "stream error", String(e));
             controller.enqueue(encoder.encode(`data: ${JSON.stringify({ error: String(e) })}\n\n`));
             controller.enqueue(encoder.encode(`data: [DONE]\n\n`));
@@ -2611,7 +2653,7 @@ These become clickable buttons so users don't have to type. Make them specific t
       });
 
       return new Response(readable, { headers: sseHeaders });
-    } catch {
+    } catch (e) {
       return Response.json({ error: String(e) }, { status: 500, headers: { "Access-Control-Allow-Origin": "*" } });
     }
   }
@@ -2652,7 +2694,7 @@ These become clickable buttons so users don't have to type. Make them specific t
       return Response.json({ ok: true, paperId: id, uploadDir: `uploads/${id}`, meta }, {
         headers: { "Access-Control-Allow-Origin": "*" },
       });
-    } catch {
+    } catch (e) {
       return Response.json({ error: String(e) }, { status: 500 });
     }
   }
@@ -2715,7 +2757,7 @@ These become clickable buttons so users don't have to type. Make them specific t
             format = "latex";
           }
         }
-      } catch {
+      } catch (e) {
         log("import", `arXiv source fetch failed for ${arxivId}:`, String(e));
       }
 
@@ -2741,7 +2783,7 @@ These become clickable buttons so users don't have to type. Make them specific t
       return Response.json({ ok: true, paperId: id, uploadDir: `uploads/${id}`, meta }, {
         headers: { "Access-Control-Allow-Origin": "*" },
       });
-    } catch {
+    } catch (e) {
       return Response.json({ error: String(e) }, { status: 500 });
     }
   }
@@ -2844,7 +2886,7 @@ These become clickable buttons so users don't have to type. Make them specific t
       return Response.json({ ok: true, paperId: body.paperId, meta, blocks, summary }, {
         headers: { "Access-Control-Allow-Origin": "*" },
       });
-    } catch {
+    } catch (e) {
       return Response.json({ error: String(e) }, { status: 500 });
     }
   }
@@ -2924,7 +2966,7 @@ These become clickable buttons so users don't have to type. Make them specific t
         generated,
         path: `content/${body.paperId}/${chDir}`,
       }, { headers: { "Access-Control-Allow-Origin": "*" } });
-    } catch {
+    } catch (e) {
       return Response.json({ error: String(e) }, { status: 500 });
     }
   }
@@ -2951,7 +2993,7 @@ These become clickable buttons so users don't have to type. Make them specific t
 
       const triage = await triageFeedback(todo, blockContent, blockKind, body.paperId, body.rootName);
       return Response.json(triage, { headers: { "Access-Control-Allow-Origin": "*" } });
-    } catch {
+    } catch (e) {
       return Response.json({ error: String(e) }, { status: 500 });
     }
   }
@@ -2970,7 +3012,7 @@ These become clickable buttons so users don't have to type. Make them specific t
       if (body.status !== undefined) todos[idx].status = body.status;
       writeFeedback(body.paperId, body.rootName, todos);
       return Response.json({ ok: true, todo: todos[idx] });
-    } catch {
+    } catch (e) {
       return Response.json({ error: String(e) }, { status: 500 });
     }
   }
@@ -2991,7 +3033,7 @@ These become clickable buttons so users don't have to type. Make them specific t
       todos.splice(idx, 1);
       writeFeedback(body.paperId, body.rootName, todos);
       return Response.json({ ok: true });
-    } catch {
+    } catch (e) {
       return Response.json({ error: String(e) }, { status: 500 });
     }
   }
@@ -3038,14 +3080,19 @@ server.tool = function (...args: Parameters<typeof origTool>) {
   const toolName = args[0] as string;
   // The handler is the last argument
   const handler = args[args.length - 1] as (...a: unknown[]) => Promise<unknown>;
-  args[args.length - 1] = async (...handlerArgs: unknown[]) => {
+  // `args` is a tuple whose last slot is a union of overload-specific handler
+  // shapes; TS has no way to say "same overload, different last element", so
+  // an in-place replacement cannot be expressed. Widen for the WRITE ONLY —
+  // one expression, not the whole wrapper — and `origTool(...args)` below is
+  // still checked against the real signature.
+  (args as unknown[])[args.length - 1] = async (...handlerArgs: unknown[]) => {
     const start = Date.now();
     log('mcp', `→ ${toolName}`, JSON.stringify(handlerArgs[0] || {}).slice(0, 120));
     try {
       const result = await handler(...handlerArgs);
       log('mcp', `← ${toolName}`, `ok (${Date.now()-start}ms)`);
       return result;
-    } catch {
+    } catch (e) {
       log('mcp', `✗ ${toolName}`, `error: ${e instanceof Error ? e.message : String(e)} (${Date.now()-start}ms)`);
       throw e;
     }
@@ -3150,11 +3197,21 @@ if (mode === "stdio") {
 } else {
   // HTTP mode — MCP + viewer on same port
   const port = FOLIO_PORT;
-  const { StreamableHTTPServerTransport } = await import(
-    "@modelcontextprotocol/sdk/server/streamableHttp.js"
+  // The WEB-STANDARD transport, whose `handleRequest(req: Request):
+  // Promise<Response>` is exactly what the `/mcp` route below calls.
+  //
+  // This imported `StreamableHTTPServerTransport`, whose `handleRequest` is
+  // Node's `(req: IncomingMessage, res: ServerResponse, body?)`. It was being
+  // handed a Bun `Request` and nothing else, so `--http` mode — documented as
+  // the remote/Docker deployment path — could never have served `/mcp`.
+  // Invisible because `adapters/**` was never type-checked.
+  const { WebStandardStreamableHTTPServerTransport } = await import(
+    "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js"
   );
 
-  const httpTransport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+  const httpTransport = new WebStandardStreamableHTTPServerTransport({
+    sessionIdGenerator: undefined,
+  });
   await server.connect(httpTransport);
 
   Bun.serve({

--- a/adapters/mcp-server/server.ts
+++ b/adapters/mcp-server/server.ts
@@ -19,6 +19,7 @@
  * @module scripts/mcp-server/server
  */
 
+import type { Paper, Chapter, PaperMacro } from "../../schemas/types";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { registerRenderTools } from "./tools/render.js";
@@ -406,7 +407,7 @@ async function resolveFolio(branch?: string): Promise<{ title: string; papers: F
   const papers: FolioEntry[] = [];
   for (const ref of folioData.papers) {
     try {
-      const paperMod = (await importTsBranch(br, `content/${ref.dir}/${ref.dir}.ts`)) as any;
+      const paperMod = await importTsBranch<Paper>(br, `content/${ref.dir}/${ref.dir}.ts`);
       let blockCount = 0, provedCount = 0, todoCount = 0, chapCount = 0;
 
       for (const chRef of paperMod.chapters || []) {
@@ -463,7 +464,7 @@ async function resolvePaper(id: string, branch?: string): Promise<(ResolvedPaper
   const paperRel = `content/${id}/${id}.ts`;
   if (!fileExistsBranch(br, paperRel)) return null;
 
-  const paperMod = (await importTsBranch(br, paperRel)) as any;
+  const paperMod = await importTsBranch<Paper>(br, paperRel);
   const chapters: ResolvedChapter[] = [];
 
   // Auto-number chapters from manifest order
@@ -472,7 +473,7 @@ async function resolvePaper(id: string, branch?: string): Promise<(ResolvedPaper
     const chRel = `content/${id}/${chRef.dir}`;
     const chTsRel = `${chRel}/${chRef.dir}.ts`;
     if (!fileExistsBranch(br, chTsRel)) continue;
-    const ch = (await importTsBranch(br, chTsRel)) as any;
+    const ch = await importTsBranch<Chapter>(br, chTsRel);
     const chapterNumber = ch.tabLabel != null ? undefined : autoNum++;
 
     const sections: ResolvedSection[] = [];
@@ -619,7 +620,13 @@ interface PaperOutline {
   authors: string[];
   affiliations?: string[];
   date?: string;
-  macros?: Record<string, string>;
+  /** `Paper.macros` is `Record<string, PaperMacro>` — `{ tex, unicode? }`
+   *  objects, which is what the viewer reads (`buildKatexMacros` uses
+   *  `def.tex`). This declared `Record<string, string>`; the values passed
+   *  through untouched so nothing broke at runtime, but the type was a lie and
+   *  any consumer doing string work on them would get "[object Object]".
+   *  Surfaced only once the paper import stopped being `as any`. */
+  macros?: Record<string, PaperMacro>;
   chapters: ChapterOutline[];
   branch: string;
 }
@@ -633,7 +640,7 @@ async function resolvePaperOutline(id: string, branch?: string): Promise<PaperOu
   const paperRel = `content/${id}/${id}.ts`;
   if (!fileExistsBranch(br, paperRel)) return null;
 
-  const paperMod = (await importTsBranch(br, paperRel)) as any;
+  const paperMod = await importTsBranch<Paper>(br, paperRel);
   const chapters: ChapterOutline[] = [];
 
   // Auto-number chapters from manifest order
@@ -642,7 +649,7 @@ async function resolvePaperOutline(id: string, branch?: string): Promise<PaperOu
     const chRel = `content/${id}/${chRef.dir}`;
     const chTsRel = `${chRel}/${chRef.dir}.ts`;
     if (!fileExistsBranch(br, chTsRel)) continue;
-    const ch = (await importTsBranch(br, chTsRel)) as any;
+    const ch = await importTsBranch<Chapter>(br, chTsRel);
     const chapterNumber = ch.tabLabel != null ? undefined : autoNum++;
 
     const sections: ChapterOutline["sections"] = [];
@@ -701,7 +708,7 @@ async function resolveChapterDetail(
   const chTsRel = `${chRel}/${chapterDir}.ts`;
   if (!fileExistsBranch(br, chTsRel)) return null;
 
-  const ch = (await importTsBranch(br, chTsRel)) as any;
+  const ch = await importTsBranch<Chapter>(br, chTsRel);
   const sections: SectionStub[] = [];
 
   for (const sec of ch.sections || []) {
@@ -769,7 +776,7 @@ async function resolveSection(
   const chTsRel = `${chRel}/${chapterDir}.ts`;
   if (!fileExistsBranch(br, chTsRel)) return null;
 
-  const ch = (await importTsBranch(br, chTsRel)) as any;
+  const ch = await importTsBranch<Chapter>(br, chTsRel);
 
   // Filter to real sections (skip name-only refs)
   const realSections = (ch.sections || []).filter(

--- a/adapters/mcp-server/server.ts
+++ b/adapters/mcp-server/server.ts
@@ -19,7 +19,8 @@
  * @module scripts/mcp-server/server
  */
 
-import type { Paper, Chapter, PaperMacro } from "../../schemas/types";
+import type { Paper, Chapter, Block, PaperMacro } from "../../schemas/types";
+import { leanStatusBucket } from "../../content/pipeline/render-latex";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { registerRenderTools } from "./tools/render.js";
@@ -318,6 +319,46 @@ interface ResolvedRenderedAsset {
   hash?: string;
 }
 
+/**
+ * Field accessors for the `Block` discriminated union.
+ *
+ * Only some kinds carry `lean`, `proofs`, `tex`, `caption` and the simulator
+ * fields, so reading them off the bare union is a type error at every site —
+ * which is why the block imports were `as any`. The `in` operator narrows
+ * properly, so each of these is a real check rather than a cast.
+ *
+ * `blockStatus` is different: there IS no block-level `status`.
+ * `FormalizationStatus` is documented in the schema as "derived at build time
+ * from .lean file content. NOT stored in content block .ts manifests", so
+ * every `blockStatus(blk)` read in this file was `undefined`. It is derived from the
+ * block's `lean` field here, via the one existing mapper.
+ */
+const bLean = (b: Block) => ("lean" in b ? b.lean : undefined);
+const bProofs = (b: Block) => ("proofs" in b ? b.proofs : undefined);
+const bExamples = (b: Block) => ("examples" in b ? b.examples : undefined);
+const bTex = (b: Block) => ("tex" in b ? b.tex : undefined);
+const bCaption = (b: Block) => ("caption" in b ? b.caption : undefined);
+const bSimulator = (b: Block) => ("simulator" in b ? b.simulator : undefined);
+const bHtml = (b: Block) => ("html" in b ? b.html : undefined);
+const bViews = (b: Block) => ("views" in b ? b.views : undefined);
+const bDefaultView = (b: Block) => ("defaultView" in b ? b.defaultView : undefined);
+const blockStatus = (b: Block) => leanStatusBucket(bLean(b));
+
+/**
+ * A block's `lean` with the resolved source attached, in `ResolvedBlock`'s
+ * shape. Spreading `{ ...bLean(blk), source }` widens `ref` to optional —
+ * `LeanRef.ref` is required, but a spread of a possibly-undefined value is
+ * not — while `ResolvedBlock.lean.ref` requires it. Building it explicitly
+ * keeps both sides honest.
+ */
+function withSource(
+  lean: ReturnType<typeof bLean>,
+  source: string | undefined,
+): ResolvedBlock["lean"] {
+  if (!lean) return undefined;
+  return { ...lean, ref: lean.ref, source };
+}
+
 interface ResolvedBlock {
   rootName: string;
   kind: string;
@@ -328,7 +369,7 @@ interface ResolvedBlock {
   proofs?: string[];
   /** `sorryFree` is a real `LeanRef` field (schemas/types.ts) and the
    *  strongest proof-status signal — `render-latex` says it "wins outright"
-   *  over the `validation` enum. The `...blk.lean` spreads below carry it;
+   *  over the `validation` enum. The `...bLean(blk)` spreads below carry it;
    *  omitting it here made it invisible to every consumer and unreadable at
    *  the one site that tried. */
   lean?: { ref: string; file?: string; validation?: string; sorryFree?: boolean; source?: string };
@@ -441,7 +482,12 @@ async function resolveFolio(branch?: string): Promise<{ title: string; papers: F
             blockCount++;
             try {
               const blk = (await importTsBranch(br, blkRel)) as any;
-              if (blk.status === "proved" || blk.status === "mathlib_ok") provedCount++;
+              // `blockStatus(blk)` does not exist. `FormalizationStatus` is
+              // documented in the schema as "derived at build time from .lean
+              // file content. NOT stored in content block .ts manifests", so
+              // this counter has always been 0. The block's own `lean` field is
+              // the signal, mapped by the one existing mapper.
+              if (leanStatusBucket(bLean(blk)) === "compiled") provedCount++;
               const fb = readFeedback(ref.dir, rootName);
               if (fb.length) todoCount += fb.filter((t: any) => t.status !== "resolved" && t.status !== "wontfix").length;
             } catch {}
@@ -504,7 +550,7 @@ async function resolvePaper(id: string, branch?: string): Promise<(ResolvedPaper
           const blkTsRel = `${chRel}/${rootName}.ts`;
           const blkMdRel = `${chRel}/${rootName}.md`;
           try {
-            const blk = (await importTsBranch(br, blkTsRel)) as any;
+            const blk = await importTsBranch<Block>(br, blkTsRel);
             const md = readFileBranch(br, blkMdRel) || "";
             const feedback = readFeedback(id, rootName);
             const blockTodos = feedback.length ? [...feedback] : undefined;
@@ -520,8 +566,8 @@ async function resolvePaper(id: string, branch?: string): Promise<(ResolvedPaper
             }] : undefined;
             res.push({
               rootName, kind: blk.kind, label: blk.label, title: blk.title, uses: blk.uses,
-              examples: blk.examples, proofs: blk.proofs, lean: blk.lean ? { ...blk.lean, source: leanSource } : undefined,
-              status: blk.status, tex: blk.tex, caption: blk.caption, tags: blk.tags, rendered: rendered || figRendered,
+              examples: bExamples(blk), proofs: bProofs(blk), lean: withSource(bLean(blk), leanSource),
+              status: blockStatus(blk), tex: bTex(blk), caption: bCaption(blk), tags: blk.tags, rendered: rendered || figRendered,
               md, todos: blockTodos
             });
           } catch (e) { res.push({ rootName, kind: "error", md: `Failed to load ${rootName}: ${e}` }); }
@@ -741,15 +787,17 @@ async function resolveChapterDetail(
     for (const rootName of sectionBlockNames(section)) {
       const blkTsRel = `${chRel}/${rootName}.ts`;
       try {
-        const blk = (await importTsBranch(br, blkTsRel)) as any;
+        const blk = await importTsBranch<Block>(br, blkTsRel);
+        const blkLean = bLean(blk);
         const feedback = readFeedback(paperId, rootName);
         blockStubs.push({
           rootName,
           kind: blk.kind,
           label: blk.label,
           title: blk.title,
-          status: blk.status,
-          lean: blk.lean ? { ref: blk.lean.ref, validation: blk.lean.validation, sorryFree: blk.lean.sorryFree } : undefined,
+          status: blockStatus(blk),
+          // Bound once: TS narrows a const, not repeated calls.
+          lean: blkLean ? { ref: blkLean.ref, validation: blkLean.validation, sorryFree: blkLean.sorryFree } : undefined,
           todoCount: feedback.filter((t: any) => t.status === "open").length,
         });
       } catch {
@@ -817,7 +865,7 @@ async function resolveSection(
     const blkTsRel = `${chRel}/${rootName}.ts`;
     const blkMdRel = `${chRel}/${rootName}.md`;
     try {
-      const blk = (await importTsBranch(br, blkTsRel)) as any;
+      const blk = await importTsBranch<Block>(br, blkTsRel);
       const md = readFileBranch(br, blkMdRel) || "";
 
       const feedback = readFeedback(paperId, rootName);
@@ -851,21 +899,21 @@ async function resolveSection(
         label: blk.label,
         title: blk.title,
         uses: blk.uses,
-        examples: blk.examples,
-        proofs: blk.proofs,
-        lean: blk.lean ? { ...blk.lean, source: leanSource } : undefined,
-        status: blk.status,
-        tex: blk.tex,
-        caption: blk.caption,
+        examples: bExamples(blk),
+        proofs: bProofs(blk),
+        lean: withSource(bLean(blk), leanSource),
+        status: blockStatus(blk),
+        tex: bTex(blk),
+        caption: bCaption(blk),
         tags: blk.tags,
         rendered: rendered || figRendered2,
         md,
         todos: blockTodos,
         // Simulator fields
-        ...(blk.simulator ? { simulator: blk.simulator } : {}),
-        ...(blk.html ? { html: blk.html } : {}),
-        ...(blk.defaultView ? { defaultView: blk.defaultView } : {}),
-        ...(blk.views ? { views: blk.views } : {}),
+        ...(bSimulator(blk) ? { simulator: bSimulator(blk) } : {}),
+        ...(bHtml(blk) ? { html: bHtml(blk) } : {}),
+        ...(bDefaultView(blk) ? { defaultView: bDefaultView(blk) } : {}),
+        ...(bViews(blk) ? { views: bViews(blk) } : {}),
       });
     } catch (e) {
       blocks.push({ rootName, kind: "error", md: `Failed to load ${rootName}: ${e}` });
@@ -2327,8 +2375,15 @@ async function handlePostRequest(url: URL, req: Request): Promise<Response | nul
                     if (nl && blk.lean?.file) stats.leanFormalized++;
                     if (nl && !blk.lean?.file) stats.leanMissing++;
                     if (blk.lean?.validation === "error") stats.leanError++;
-                    if (blk.status === "has_sorry") stats.hasSorry++;
-                    if (blk.status === "proved" || blk.status === "mathlib_ok") stats.proved++;
+                    // Same phantom `blk.status` as above — both counters
+                    // were always 0, while the two lines directly above already
+                    // read the correct `blk.lean`. `stubbed` is the closest
+                    // available analogue of `has_sorry`: per
+                    // `leanStatusBucket`'s own definition a *cited* sorry is
+                    // `drafted` (a deliberate deferral) rather than a stub.
+                    const bucket = leanStatusBucket(blk.lean);
+                    if (bucket === "stubbed") stats.hasSorry++;
+                    if (bucket === "compiled") stats.proved++;
                     stats.openTodos += (blk.todos || []).filter((t: any) => t.status === "open").length;
                   }
                 }

--- a/adapters/mcp-server/server.ts
+++ b/adapters/mcp-server/server.ts
@@ -19,8 +19,18 @@
  * @module scripts/mcp-server/server
  */
 
-import type { Paper, Chapter, Block, PaperMacro } from "../../schemas/types";
-import { leanStatusBucket } from "../../content/pipeline/render-latex";
+import type { Paper, Chapter, Block, PaperMacro, FeedbackItem, Section, RenderedAsset, Folio } from "../../schemas/types";
+import { FeedbackItemSchema } from "../../schemas/constraints";
+import {
+  INVALID_ENUM, parseTodoPriority, parseTodoStatus, TODO_PRIORITIES, TODO_STATUSES,
+} from "../../src/core/feedback.js";
+// `renderBlock` was reached through `await import(join(REPO_ROOT, …))`, which
+// types as `any` — so nothing checked what was handed to it, and a
+// `ResolvedBlock` went in for two years where a `Block` was declared. The
+// module is already loaded eagerly for `leanStatusBucket`, so the dynamic
+// import deferred nothing; importing it here is what makes the call site
+// typecheck.
+import { leanStatusBucket, renderBlock } from "../../content/pipeline/render-latex";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { registerRenderTools } from "./tools/render.js";
@@ -100,18 +110,43 @@ function parseFeedbackTs(content: string): unknown[] {
 }
 
 /** Serialize feedback items to TypeScript source. */
-function serializeFeedbackTs(items: unknown[]): string {
+function serializeFeedbackTs(items: FeedbackItem[]): string {
   const json = JSON.stringify(items, null, 2);
   return `import type { FeedbackItem } from "../../schemas/types";\n\nexport default ${json} satisfies FeedbackItem[];\n`;
 }
 
-function readFeedback(paperId: string, rootName: string): unknown[] {
+/**
+ * Read one feedback file's items.
+ *
+ * The file is written only by `writeFeedback`, which serializes with
+ * `satisfies FeedbackItem[]` — so `FeedbackItem` is the contract, and an entry
+ * that fails it is a corruption rather than a supported shape. It is still
+ * RETURNED: every write path here is read-modify-write over the whole file
+ * (`/api/feedback/{create,update,delete}` read all items, touch one, and hand
+ * the array straight back to `writeFeedback`), so silently dropping a
+ * malformed entry at read time would delete somebody's feedback from `main` on
+ * the next unrelated edit. Non-conforming entries are logged instead, which is
+ * the part that was missing: this used to return `unknown[]` and every caller
+ * cast it to `any[]`, so a corrupt entry produced neither a type error nor a
+ * log line — just `undefined` flowing into a status filter.
+ */
+function readFeedback(paperId: string, rootName: string): FeedbackItem[] {
   const p = feedbackPath(paperId, rootName);
   if (!existsSync(p)) return [];
-  try { return parseFeedbackTs(readFileSync(p, "utf-8")); } catch { return []; }
+  let items: unknown[];
+  try { items = parseFeedbackTs(readFileSync(p, "utf-8")); } catch { return []; }
+  return items.map((item, i) => {
+    const parsed = FeedbackItemSchema.safeParse(item);
+    if (!parsed.success) {
+      log("feedback", `malformed item retained: ${paperId}/${rootName}[${i}]`,
+        parsed.error.issues.map((iss) => `${iss.path.join(".") || "<root>"}: ${iss.message}`).join("; "));
+    }
+    // Retained regardless — see the note above on read-modify-write.
+    return item as FeedbackItem;
+  });
 }
 
-function writeFeedback(paperId: string, rootName: string, todos: unknown[]): void {
+function writeFeedback(paperId: string, rootName: string, todos: FeedbackItem[]): void {
   const ts = serializeFeedbackTs(todos);
 
   // Write to main repo feedback/ (for immediate reads)
@@ -214,8 +249,8 @@ function commitFeedbackToMain(paperId: string, rootName: string, content: string
 }
 
 /** List all feedback items across all papers, optionally filtered by status. */
-function listAllFeedback(status?: string): { paperId: string; rootName: string; todo: any }[] {
-  const results: { paperId: string; rootName: string; todo: any }[] = [];
+function listAllFeedback(status?: string): { paperId: string; rootName: string; todo: FeedbackItem }[] {
+  const results: { paperId: string; rootName: string; todo: FeedbackItem }[] = [];
   if (!existsSync(FEEDBACK_DIR)) return results;
   for (const paperId of readdirSync(FEEDBACK_DIR)) {
     const paperFbDir = join(FEEDBACK_DIR, paperId);
@@ -224,7 +259,7 @@ function listAllFeedback(status?: string): { paperId: string; rootName: string; 
         if (!file.endsWith(".ts")) continue;
         const rootName = file.replace(/\.ts$/, "");
         const todos = readFeedback(paperId, rootName);
-        for (const t of todos as any[]) {
+        for (const t of todos) {
           if (!status || t.status === status) {
             results.push({ paperId, rootName, todo: t });
           }
@@ -238,25 +273,11 @@ function listAllFeedback(status?: string): { paperId: string; rootName: string; 
 // ── Content resolution (dynamic, no static JSON) ────────────────
 
 const CONTENT_DIR = resolve(REPO_ROOT, "content");
+import { leanPackageByName } from "../../schemas/lean-packages.js";
 import {
-  leanPackageByName,
-  parseLeanRef,
-  type ParsedLeanRef,
-} from "../../schemas/lean-packages.js";
-
-/**
- * Parse a block's `lean.ref` URI; returns `undefined` on missing or
- * malformed refs (so callers degrade to sibling-only resolution).
- */
-function tryParseLeanRef(blk: any): ParsedLeanRef | undefined {
-  const ref = blk?.lean?.ref;
-  if (typeof ref !== "string" || ref.length === 0) return undefined;
-  try {
-    return parseLeanRef(ref);
-  } catch {
-    return undefined;
-  }
-}
+  blockCaption, blockExamples, blockLean, blockProofs, blockTex,
+  isSectionRef, sectionBlockNames, tryParseLeanRef,
+} from "../manifest-entries.js";
 
 /**
  * Resolve the Lean source for a block across branch-backed storage.
@@ -264,7 +285,7 @@ function tryParseLeanRef(blk: any): ParsedLeanRef | undefined {
  * but operates against the MCP server's git helpers.
  */
 function resolveLeanSource(
-  blk: any,
+  blk: Block,
   chRel: string,
   rootName: string,
   // `string | undefined`, matching `readFileBranch` (which this forwards to)
@@ -272,7 +293,7 @@ function resolveLeanSource(
   // Declaring it `string` was simply narrower than every party involved.
   branch: string | undefined,
 ): string | undefined {
-  if (!blk?.lean) return undefined;
+  if (!bLean(blk)) return undefined;
   const parsed = tryParseLeanRef(blk);
 
   // 1. sibling .lean file
@@ -333,11 +354,12 @@ interface ResolvedRenderedAsset {
  * every `blockStatus(blk)` read in this file was `undefined`. It is derived from the
  * block's `lean` field here, via the one existing mapper.
  */
-const bLean = (b: Block) => ("lean" in b ? b.lean : undefined);
-const bProofs = (b: Block) => ("proofs" in b ? b.proofs : undefined);
-const bExamples = (b: Block) => ("examples" in b ? b.examples : undefined);
-const bTex = (b: Block) => ("tex" in b ? b.tex : undefined);
-const bCaption = (b: Block) => ("caption" in b ? b.caption : undefined);
+// Shared with `adapters/paper/resolver.ts`, which needs the same five.
+const bLean = blockLean;
+const bProofs = blockProofs;
+const bExamples = blockExamples;
+const bTex = blockTex;
+const bCaption = blockCaption;
 const bSimulator = (b: Block) => ("simulator" in b ? b.simulator : undefined);
 const bHtml = (b: Block) => ("html" in b ? b.html : undefined);
 const bViews = (b: Block) => ("views" in b ? b.views : undefined);
@@ -379,7 +401,7 @@ interface ResolvedBlock {
   tags?: string[];
   rendered?: ResolvedRenderedAsset[];
   md: string;
-  todos?: unknown[];
+  todos?: FeedbackItem[];
 }
 
 interface ResolvedSection {
@@ -403,7 +425,7 @@ interface ResolvedChapter {
    *  lookup — declared here for the first time. */
   dir?: string;
   sections: ResolvedSection[];
-  todos?: unknown[];
+  todos?: FeedbackItem[];
 }
 
 interface ResolvedPaper {
@@ -413,7 +435,7 @@ interface ResolvedPaper {
   affiliations?: string[];
   date?: string;
   chapters: ResolvedChapter[];
-  todos?: unknown[];
+  todos?: FeedbackItem[];
   /** Flattened O(1) lookup: rootName → block. Not serialized to API responses. */
   blocksByName?: Map<string, ResolvedBlock>;
 }
@@ -428,32 +450,13 @@ interface FolioEntry {
   stats: { chapters: number; blocks: number; proved: number; todos: number };
 }
 
-/**
- * Flatten a raw section manifest into the ordered list of block root-names it
- * contributes: the section's own `blocks`, then each subsection's `blocks` in
- * declaration order.
- *
- * The viewer / MCP resolution layer has no subsection nesting, so subsection
- * content is surfaced inline under the parent section, in the same order the
- * LaTeX renderer emits it (parent blocks first, then each `\subsection` with
- * its blocks). Without this, blocks living only inside `subsections[]` never
- * reach any resolver consumer and the section renders empty in the viewer.
- */
-function sectionBlockNames(sec: any): string[] {
-  const own: string[] = Array.isArray(sec?.blocks) ? sec.blocks : [];
-  const subs: string[] = Array.isArray(sec?.subsections)
-    ? sec.subsections.flatMap((s: any) => (s && Array.isArray(s.blocks) ? s.blocks : []))
-    : [];
-  return subs.length ? [...own, ...subs] : own;
-}
-
 async function resolveFolio(branch?: string): Promise<{ title: string; papers: FolioEntry[]; branch: string }> {
   const br = branch;
   const folioRel = "content/folio.ts";
-  let folioData: { title: string; papers: Array<{ dir: string; title?: string; description?: string; tags?: string[] }> };
+  let folioData: Folio;
 
   if (fileExistsBranch(br, folioRel)) {
-    folioData = (await importTsBranch(br, folioRel)) as any;
+    folioData = await importTsBranch<Folio>(br, folioRel);
   } else {
     // Auto-discover: scan content/ for directories with matching .ts manifests
     const dirs = listDirBranch(br, "content").filter(d => {
@@ -473,15 +476,20 @@ async function resolveFolio(branch?: string): Promise<{ title: string; papers: F
         const chRel = `content/${ref.dir}/${chRef.dir}/${chRef.dir}.ts`;
         if (!fileExistsBranch(br, chRel)) continue;
         chapCount++;
-        const ch = (await importTsBranch(br, chRel)) as any;
+        const ch = await importTsBranch<Chapter>(br, chRel);
         for (const sec of ch.sections || []) {
-          if (!("blocks" in sec)) continue;
+          // Was `!("blocks" in sec)`, which also skipped inline sections that
+          // keep all their blocks in `subsections[]` — so `sectionBlockNames`,
+          // whose entire job is to reach those, never saw one here and the
+          // folio landing page undercounted them. `resolvePaper` below already
+          // used the reference test; these now agree.
+          if (isSectionRef(sec)) continue;
           for (const rootName of sectionBlockNames(sec)) {
             const blkRel = `content/${ref.dir}/${chRef.dir}/${rootName}.ts`;
             if (!fileExistsBranch(br, blkRel)) continue;
             blockCount++;
             try {
-              const blk = (await importTsBranch(br, blkRel)) as any;
+              const blk = await importTsBranch<Block>(br, blkRel);
               // `blockStatus(blk)` does not exist. `FormalizationStatus` is
               // documented in the schema as "derived at build time from .lean
               // file content. NOT stored in content block .ts manifests", so
@@ -489,7 +497,7 @@ async function resolveFolio(branch?: string): Promise<{ title: string; papers: F
               // the signal, mapped by the one existing mapper.
               if (leanStatusBucket(bLean(blk)) === "compiled") provedCount++;
               const fb = readFeedback(ref.dir, rootName);
-              if (fb.length) todoCount += fb.filter((t: any) => t.status !== "resolved" && t.status !== "wontfix").length;
+              if (fb.length) todoCount += fb.filter((t) => t.status !== "resolved" && t.status !== "wontfix").length;
             } catch {}
           }
         }
@@ -542,8 +550,8 @@ async function resolvePaper(id: string, branch?: string): Promise<(ResolvedPaper
 
     const sections: ResolvedSection[] = [];
     for (const sec of ch.sections || []) {
-      if ("name" in sec && !("blocks" in sec)) continue;
-      const section = sec as any;
+      if (isSectionRef(sec)) continue;
+      const section = sec;
       const resolveBlocksList = async (blockNames: string[]) => {
         const res: ResolvedBlock[] = [];
         for (const rootName of blockNames) {
@@ -556,7 +564,7 @@ async function resolvePaper(id: string, branch?: string): Promise<(ResolvedPaper
             const blockTodos = feedback.length ? [...feedback] : undefined;
             const leanSource = resolveLeanSource(blk, chRel, rootName, br);
             const rendered = blk.rendered?.map(
-              (r: any) => ({ ...r, url: `/api/content-asset/${id}/${chRef.dir}/${r.url}` })
+              (r: RenderedAsset) => ({ ...r, url: `/api/content-asset/${id}/${chRef.dir}/${r.url}` })
             );
             const figFile = blk.kind === "diagram" && blk.meta?.file as string | undefined;
             const figRendered = figFile ? [{
@@ -583,9 +591,12 @@ async function resolvePaper(id: string, branch?: string): Promise<(ResolvedPaper
         subsections = [];
         for (const sub of section.subsections) {
           if (!sub) continue;
-          const subBlockNames = Array.isArray(sub.blocks) ? sub.blocks : [];
-          const subBlocks = await resolveBlocksList(subBlockNames);
-          subsections.push({ title: sub.title, label: sub.label, blocks: subBlocks });
+          // A bare `SectionRef` subsection is not resolvable at this level —
+          // nothing here reads `name`/`uri` — so it contributes no blocks,
+          // exactly as before when `sub.blocks` was simply absent.
+          const inline = isSectionRef(sub) ? undefined : sub;
+          const subBlocks = await resolveBlocksList(inline?.blocks ?? []);
+          subsections.push({ title: inline?.title ?? "", label: inline?.label, blocks: subBlocks });
         }
       }
 
@@ -638,10 +649,14 @@ interface CacheEntry<T> {
   ts: number;
 }
 
-const paperOutlineCache = new Map<string, CacheEntry<any>>();
-const chapterCache = new Map<string, CacheEntry<any>>();
+// Each cache holds exactly one shape; declaring that is what lets `cacheGet`
+// return it. While these were `CacheEntry<any>` the reader at the chapter
+// cache had to launder its result through `as unknown as ChapterDetail`, and
+// the writer through `as any` — two casts standing in for one type argument.
+const paperOutlineCache = new Map<string, CacheEntry<PaperOutline>>();
+const chapterCache = new Map<string, CacheEntry<ChapterDetail>>();
 const sectionCache = new Map<string, CacheEntry<ResolvedSection>>();
-const fullPaperCache = new Map<string, CacheEntry<any>>();
+const fullPaperCache = new Map<string, CacheEntry<ResolvedPaper & { branch: string }>>();
 
 function cacheGet<T>(cache: Map<string, CacheEntry<T>>, key: string): T | null {
   const entry = cache.get(key);
@@ -722,9 +737,8 @@ async function resolvePaperOutline(id: string, branch?: string): Promise<PaperOu
 
     const sections: ChapterOutline["sections"] = [];
     for (const sec of ch.sections || []) {
-      if ("name" in sec && !("blocks" in sec)) continue;
-      const section = sec as { title: string; label?: string; blocks: string[] };
-      sections.push({ title: section.title, label: section.label, blockCount: sectionBlockNames(section).length });
+      if (isSectionRef(sec)) continue;
+      sections.push({ title: sec.title, label: sec.label, blockCount: sectionBlockNames(sec).length });
     }
 
     chapters.push({ number: chapterNumber, tabLabel: ch.tabLabel, title: ch.title, label: ch.label, dir: chRef.dir, sections });
@@ -761,14 +775,14 @@ interface ChapterDetail {
   label?: string;
   dir: string;
   sections: SectionStub[];
-  todos?: unknown[];
+  todos?: FeedbackItem[];
 }
 
 async function resolveChapterDetail(
   paperId: string, chapterDir: string, branch?: string
 ): Promise<ChapterDetail | null> {
   const cacheKey = `${paperId}:${branch || "HEAD"}:ch:${chapterDir}`;
-  const cached = cacheGet(chapterCache, cacheKey) as unknown as ChapterDetail | null;
+  const cached = cacheGet(chapterCache, cacheKey);
   if (cached) return cached;
 
   const br = branch;
@@ -798,7 +812,7 @@ async function resolveChapterDetail(
           status: blockStatus(blk),
           // Bound once: TS narrows a const, not repeated calls.
           lean: blkLean ? { ref: blkLean.ref, validation: blkLean.validation, sorryFree: blkLean.sorryFree } : undefined,
-          todoCount: feedback.filter((t: any) => t.status === "open").length,
+          todoCount: feedback.filter((t) => t.status === "open").length,
         });
       } catch {
         blockStubs.push({ rootName, kind: "error", todoCount: 0 });
@@ -832,7 +846,7 @@ async function resolveChapterDetail(
     todos: chTodos.length ? chTodos : undefined,
   };
 
-  cacheSet(chapterCache, cacheKey, result as any);
+  cacheSet(chapterCache, cacheKey, result);
   return result;
 }
 
@@ -854,11 +868,11 @@ async function resolveSection(
 
   // Filter to real sections (skip name-only refs)
   const realSections = (ch.sections || []).filter(
-    (s: any) => !("name" in s && !("blocks" in s))
+    (s): s is Section => !isSectionRef(s)
   );
   if (sectionIndex < 0 || sectionIndex >= realSections.length) return null;
 
-  const sec = realSections[sectionIndex] as { title: string; label?: string; blocks: string[] };
+  const sec = realSections[sectionIndex];
   const blocks: ResolvedBlock[] = [];
 
   for (const rootName of sectionBlockNames(sec)) {
@@ -1044,7 +1058,7 @@ interface TriageResult {
 }
 
 async function triageFeedback(
-  todo: any,
+  todo: FeedbackItem,
   blockContent: string,
   blockKind: string,
   paperId: string,
@@ -1121,7 +1135,7 @@ interface BlockDiff {
   mdDiff?: { base: string; head: string };
   leanDiff?: { base: string; head: string };
   statusDiff?: { base: string; head: string };
-  todos?: unknown[];
+  todos?: FeedbackItem[];
 }
 
 interface PaperDiff {
@@ -1130,6 +1144,10 @@ interface PaperDiff {
   paperId: string;
   blocks: BlockDiff[];
   summary: { added: number; removed: number; changed: number; unchanged: number };
+  /** Fork point `base`/`head` were actually compared at, when one was found.
+   *  The `/api/diff` handler has always attached this; it did so through
+   *  `(diff as any).mergeBase = mb`, so it never appeared here. */
+  mergeBase?: string;
 }
 
 function computePaperDiff(
@@ -1428,7 +1446,7 @@ async function handleViewerRequest(url: URL): Promise<Response | null> {
           try {
             const secData = await resolveSection(id, chDir, si, branch);
             if (!secData || !secData.blocks) continue;
-            const found = secData.blocks.find((b: any) => b.label === label);
+            const found = secData.blocks.find((b) => b.label === label);
             if (found) return Response.json(found, { headers: { "Cache-Control": "max-age=300", "Access-Control-Allow-Origin": "*" } });
           } catch (e) { log('warn', `GET /api/paper/block resolveSection ${chDir}[${si}]: ${e}`); continue; }
         }
@@ -1505,7 +1523,7 @@ async function handleViewerRequest(url: URL): Promise<Response | null> {
         resolvePaper(id, head),
       ]);
       const diff = computePaperDiff(basePaper, headPaper, base, head);
-      if (mb) (diff as any).mergeBase = mb;
+      if (mb) diff.mergeBase = mb;
       return Response.json(diff, { headers: { "Cache-Control": "no-cache", "Access-Control-Allow-Origin": "*" } });
     } catch (e) {
       return Response.json({ error: String(e) }, { status: 500 });
@@ -1921,34 +1939,37 @@ async function handleViewerRequest(url: URL): Promise<Response | null> {
         preamble = docIdx > 0 ? mainTex.slice(0, docIdx) : "";
       }
 
-      // Read the rendered LaTeX for blocks from chapters/*.tex
-      // We need to extract block LaTeX from the rendered chapters
-      // Alternative: render blocks directly using the pipeline
-      const { renderBlock } = await import(join(REPO_ROOT, "content/pipeline/render-latex.ts"));
+      // Which chapter owns each block — the one thing the nested search below
+      // used to walk `paper.chapters` for and then throw away.
+      const chapterDirOf = new Map<string, string>();
+      for (const ch of paper.chapters) {
+        if (!ch.dir) continue;
+        for (const sec of ch.sections) {
+          for (const sb of sec.blocks) chapterDirOf.set(sb.rootName, ch.dir);
+        }
+      }
 
-      // Render each block to LaTeX
+      // Render each block to LaTeX.
+      //
+      // This used to re-scan `paper.chapters` for a block matching `b` and
+      // render that — but `blockIndex`, and so `chainBlocks`, was built by
+      // walking those same `sec.blocks` arrays, so the search always handed
+      // back the object already in hand. It was rendering a `ResolvedBlock`:
+      // the viewer's projection, which carries `kind`/`label`/`tex`/`caption`
+      // and drops everything kind-specific `renderBlock` switches on
+      // (`simulator`, `html`, `views`, `of`, `interprets`, `meta`). Those
+      // blocks emitted their generic shell and lost their body, silently,
+      // because `as any` let a `ResolvedBlock` stand in for a `Block`. Load
+      // the block's own manifest, which is what `renderBlock` is typed for.
       const blockTexParts: string[] = [];
       for (const b of chainBlocks) {
+        const chDir = chapterDirOf.get(b.rootName);
+        if (!chDir) continue;
         try {
-          // Load the actual typed block for rendering
-              // Find the chapter dir for this block
-          let blockObj: any = null;
-          const mdContent = b.md || "";
-          for (const ch of paper.chapters) {
-            for (const sec of ch.sections) {
-              for (const sb of sec.blocks) {
-                if (sb.label === b.label || sb.rootName === b.rootName) {
-                  blockObj = sb;
-                  break;
-                }
-              }
-              if (blockObj) break;
-            }
-            if (blockObj) break;
-          }
-          if (blockObj) {
-            blockTexParts.push(renderBlock(blockObj as any, mdContent));
-          }
+          const blockObj = await importTsBranch<Block>(
+            undefined, `content/${paperId}/${chDir}/${b.rootName}.ts`,
+          );
+          blockTexParts.push(renderBlock(blockObj, b.md || ""));
         } catch (e) {
           blockTexParts.push(`% Error rendering ${b.label}: ${String(e)}`);
         }
@@ -2160,12 +2181,21 @@ async function handlePostRequest(url: URL, req: Request): Promise<Response | nul
         summary: string; comment: string; priority: string; assignee: string;
       };
 
-      const todo = {
+      // `body.priority` is an unvalidated wire string; it used to be written
+      // through verbatim because the array it joined was `any[]`.
+      const priority = parseTodoPriority(body.priority || undefined);
+      if (priority === INVALID_ENUM) {
+        return Response.json({
+          error: `Invalid priority: must be one of ${TODO_PRIORITIES.join("|")}`,
+        }, { status: 400 });
+      }
+
+      const todo: FeedbackItem = {
         id: makeTodoId(),
         summary: body.summary,
         comment: body.comment,
         status: "open",
-        priority: body.priority || "medium",
+        priority: priority ?? "medium",
         origin: "human",
         author: getUserName(req),
         authorEmail: getUserEmail(req),
@@ -2384,7 +2414,7 @@ async function handlePostRequest(url: URL, req: Request): Promise<Response | nul
                     const bucket = leanStatusBucket(blk.lean);
                     if (bucket === "stubbed") stats.hasSorry++;
                     if (bucket === "compiled") stats.proved++;
-                    stats.openTodos += (blk.todos || []).filter((t: any) => t.status === "open").length;
+                    stats.openTodos += (blk.todos || []).filter((t) => t.status === "open").length;
                   }
                 }
               }
@@ -2435,7 +2465,7 @@ async function handlePostRequest(url: URL, req: Request): Promise<Response | nul
               const chNum = input.chapterNumber as number;
               const paper = pid ? await resolvePaper(pid) : null;
               if (!paper) return JSON.stringify({ error: "Paper not found" });
-              const ch = paper.chapters.find((c: any) => c.number === chNum);
+              const ch = paper.chapters.find((c) => c.number === chNum);
               if (!ch) return JSON.stringify({ error: `Chapter ${chNum} not found` });
               const blocks: unknown[] = [];
               for (const sec of ch.sections || []) {
@@ -2590,7 +2620,7 @@ These become clickable buttons so users don't have to type. Make them specific t
           if (ctx.blockLabel) {
             const rootName = ctx.blockLabel.replace(/^(def|thm|lem|prop|cor|rem|ex|conj):/, "");
             const blockTodos = readFeedback(ctx.paperId, rootName);
-            const openTodos = (blockTodos as any[]).filter((t: any) => t.status === "open" || t.status === "in_progress");
+            const openTodos = blockTodos.filter((t) => t.status === "open" || t.status === "in_progress");
             if (openTodos.length) {
               systemPrompt += `\n\nOpen todos/feedback for this block (${ctx.blockLabel}):\n${JSON.stringify(openTodos, null, 2)}`;
             }
@@ -2633,11 +2663,19 @@ These become clickable buttons so users don't have to type. Make them specific t
                 messages: apiMessages,
               });
 
-              const toolUses = response.content.filter(b => b.type === "tool_use");
+              // Predicate form, not a bare boolean: `Array.filter` only narrows
+              // the element type when the callback is a type guard, so the two
+              // `.map`s below had to re-open each block with `as any` to reach
+              // `.text` / `.name` — fields the SDK already declares.
+              const toolUses = response.content.filter(
+                (b): b is Anthropic.ToolUseBlock => b.type === "tool_use",
+              );
               if (toolUses.length === 0) {
                 // Final response — send text in chunks
-                const textBlocks = response.content.filter(b => b.type === "text");
-                const fullText = textBlocks.map(b => (b as any).text).join("");
+                const textBlocks = response.content.filter(
+                  (b): b is Anthropic.TextBlock => b.type === "text",
+                );
+                const fullText = textBlocks.map(b => b.text).join("");
                 const chunkSize = 20;
                 for (let i = 0; i < fullText.length; i += chunkSize) {
                   send({ text: fullText.slice(i, i + chunkSize) });
@@ -2650,7 +2688,7 @@ These become clickable buttons so users don't have to type. Make them specific t
               }
 
               // Tool calls — send progress with tool names
-              const toolNames = toolUses.map(t => (t as any).name);
+              const toolNames = toolUses.map(t => t.name);
               logDebug("chat:tools", `round ${toolRounds + 1}: ${toolUses.length} tool calls`, toolNames.join(", "));
               const friendlyNames: Record<string, string> = {
                 get_paper_status: "checking paper status",
@@ -3037,7 +3075,7 @@ These become clickable buttons so users don't have to type. Make them specific t
     try {
       const body = await req.json() as { paperId: string; rootName: string; todoId: string };
       const todos = readFeedback(body.paperId, body.rootName);
-      const todo = (todos as any[]).find(t => t.id === body.todoId);
+      const todo = todos.find(t => t.id === body.todoId);
       if (!todo) return Response.json({ error: "Todo not found" }, { status: 404 });
 
       // Read the block content for context (O(1) via blocksByName map)
@@ -3060,11 +3098,24 @@ These become clickable buttons so users don't have to type. Make them specific t
         paperId: string; rootName: string; todoId: string;
         priority?: string; status?: string;
       };
-      const todos = readFeedback(body.paperId, body.rootName) as any[];
-      const idx = todos.findIndex((t: any) => t.id === body.todoId);
+      // `priority` and `status` arrive off the wire as bare strings. Typing
+      // the array surfaced that neither was ever checked against its enum, so
+      // `{"status":"banana"}` was written to `main` verbatim and then read
+      // back as a status no filter in this file matches — the item silently
+      // vanished from every "open"/"resolved" view.
+      const priority = parseTodoPriority(body.priority);
+      const status = parseTodoStatus(body.status);
+      if (priority === INVALID_ENUM || status === INVALID_ENUM) {
+        return Response.json({
+          error: `Invalid update: priority must be one of ${TODO_PRIORITIES.join("|")}, ` +
+            `status one of ${TODO_STATUSES.join("|")}`,
+        }, { status: 400 });
+      }
+      const todos = readFeedback(body.paperId, body.rootName);
+      const idx = todos.findIndex((t) => t.id === body.todoId);
       if (idx < 0) return Response.json({ error: "Todo not found" }, { status: 404 });
-      if (body.priority !== undefined) todos[idx].priority = body.priority;
-      if (body.status !== undefined) todos[idx].status = body.status;
+      if (priority !== undefined) todos[idx].priority = priority;
+      if (status !== undefined) todos[idx].status = status;
       writeFeedback(body.paperId, body.rootName, todos);
       return Response.json({ ok: true, todo: todos[idx] });
     } catch (e) {
@@ -3081,8 +3132,7 @@ These become clickable buttons so users don't have to type. Make them specific t
       const body = await req.json() as {
         paperId: string; rootName: string; todoId: string;
       };
-      interface FeedbackTodo { id: string; summary: string; comment?: string; status: string; priority?: string; author?: string; assignee?: string; createdAt?: string; }
-      const todos = readFeedback(body.paperId, body.rootName) as FeedbackTodo[];
+      const todos = readFeedback(body.paperId, body.rootName);
       const idx = todos.findIndex((t) => t.id === body.todoId);
       if (idx < 0) return Response.json({ error: "Todo not found" }, { status: 404 });
       todos.splice(idx, 1);

--- a/adapters/mcp-server/tools/preferences.ts
+++ b/adapters/mcp-server/tools/preferences.ts
@@ -98,7 +98,12 @@ export function registerPreferenceTools(server: McpServer): void {
       const changed: string[] = [];
       for (const [key, value] of Object.entries(updates)) {
         if (value !== undefined && key in prefs) {
-          (prefs as any)[key] = value;
+          // `Object.entries` decorrelates key from value, so TS cannot
+          // check this assignment however it is written. Narrowing the
+          // target to `Record<string, unknown>` keeps the write dynamic
+          // without reopening the whole object: the `key in prefs` guard
+          // above is what makes it sound.
+          (prefs as Record<string, unknown>)[key] = value;
           changed.push(`${key} = ${JSON.stringify(value)}`);
         }
       }

--- a/adapters/mcp-server/tools/preview.ts
+++ b/adapters/mcp-server/tools/preview.ts
@@ -8,7 +8,7 @@
  */
 
 import { z } from "zod";
-import { execSync, spawnSync } from "child_process";
+import { execSync, spawn } from "child_process";
 import { existsSync, readdirSync } from "fs";
 import { join } from "path";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -113,7 +113,13 @@ export function registerPreviewTools(server: McpServer): void {
         };
       }
 
-      spawnSync(openCmd, [fullPath], { stdio: "pipe", detached: true });
+      // `spawn`, not `spawnSync`: `detached` is not a `spawnSync` option at
+      // all (hence the overload failure), and `spawnSync` BLOCKS until the
+      // child exits — so opening a viewer would have held the tool call open
+      // for as long as the user kept the window up. `unref` lets this process
+      // exit without waiting on it, which is what "open it and return" means.
+      const child = spawn(openCmd, [fullPath], { stdio: "ignore", detached: true });
+      child.unref();
 
       return {
         content: [{

--- a/adapters/paper/index.ts
+++ b/adapters/paper/index.ts
@@ -10,6 +10,7 @@ import { existsSync, readFileSync, writeFileSync, readdirSync, mkdirSync } from 
 import { join, resolve, extname } from "path";
 import { execSync, spawnSync } from "child_process";
 
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerRenderTools } from "./tools/render.js";
 import { registerValidateTools } from "./tools/validate.js";
 import { registerLeanTools } from "./tools/lean.js";
@@ -431,7 +432,7 @@ Respond in JSON: {"assessment": "...", "actionable": boolean, "proposedEdit": {"
                 stats.totalBlocks++;
                 if (blk.kind === "definition") stats.definitions++;
                 if (blk.kind === "theorem" || blk.kind === "lemma" || blk.kind === "proposition") stats.theorems++;
-                stats.openTodos += (blk.todos || []).filter((t: any) => t.status === "open").length;
+                stats.openTodos += (blk.todos || []).filter((t) => t.status === "open").length;
               }
           return JSON.stringify({ title: paper.title, ...stats });
         }
@@ -471,7 +472,7 @@ Respond in JSON: {"assessment": "...", "actionable": boolean, "proposedEdit": {"
           const chNum = input.chapterNumber as number;
           const paper = pid ? await this.getDocument(pid) : null;
           if (!paper) return JSON.stringify({ error: "Document not found" });
-          const ch = paper.chapters.find((c: any) => c.number === chNum);
+          const ch = paper.chapters.find((c) => c.number === chNum);
           if (!ch) return JSON.stringify({ error: `Chapter ${chNum} not found` });
           const blocks: unknown[] = [];
           for (const sec of ch.sections || [])
@@ -660,7 +661,9 @@ End every response with suggested follow-ups:
             return {
               id: d.name,
               title: intake?.title ?? d.name,
-              stage: (intake?.pipeline as any)?.stage ?? "unknown",
+              // `intake` is parsed JSON, so `pipeline` is `unknown`; read the
+              // one field this needs rather than reopening the whole object.
+              stage: (intake?.pipeline as { stage?: unknown } | undefined)?.stage ?? "unknown",
               classification: intake?.classification ?? null,
               blockCount: intake?.blockCount ?? 0,
               files: readdirSync(join(uploadsDir, d.name)).filter((f) => f !== "intake.json"),
@@ -1020,7 +1023,7 @@ End every response with suggested follow-ups:
 
   // ── MCP tool registration ──────────────────────────────────────
 
-  registerMcpTools(server: any): void {
+  registerMcpTools(server: McpServer): void {
     // Paper-specific MCP tools
     registerRenderTools(server);
     registerValidateTools(server);

--- a/adapters/paper/resolver.ts
+++ b/adapters/paper/resolver.ts
@@ -22,46 +22,13 @@ import type {
   ChapterDetail,
   SectionStub,
 } from "../../src/types.js";
+import { leanPackageByName } from "../../schemas/lean-packages.js";
+import type { Block, Chapter, Folio, Paper, Section } from "../../schemas/types.js";
 import {
-  leanPackageByName,
-  parseLeanRef,
-  type ParsedLeanRef,
-} from "../../schemas/lean-packages.js";
-
-/**
- * Parse a block's `lean.ref` URI to its components.  Returns
- * `undefined` when the block has no lean ref, or when parsing fails
- * (malformed content — logged but non-fatal).
- */
-function tryParseLeanRef(blk: any): ParsedLeanRef | undefined {
-  const ref = blk?.lean?.ref;
-  if (typeof ref !== "string" || ref.length === 0) return undefined;
-  try {
-    return parseLeanRef(ref);
-  } catch {
-    return undefined;
-  }
-}
-
-/**
- * Flatten a raw section manifest into the ordered list of block root-names
- * it contributes: the section's own `blocks`, followed by each subsection's
- * `blocks` in declaration order.
- *
- * The viewer / MCP resolution layer has no subsection nesting, so subsection
- * content is surfaced inline under the parent section. The order mirrors the
- * LaTeX renderer (`render-latex.ts`: parent blocks first, then each
- * `\subsection` with its blocks), keeping the viewer and PDF block order in
- * sync. Without this, blocks that live only inside `subsections[]` never reach
- * any resolver consumer and the section renders empty in the viewer.
- */
-function sectionBlockNames(sec: any): string[] {
-  const own: string[] = Array.isArray(sec?.blocks) ? sec.blocks : [];
-  const subs: string[] = Array.isArray(sec?.subsections)
-    ? sec.subsections.flatMap((s: any) => (s && Array.isArray(s.blocks) ? s.blocks : []))
-    : [];
-  return subs.length ? [...own, ...subs] : own;
-}
+  blockCaption, blockExamples, blockLean, blockProofs, blockTex,
+  isSectionRef, sectionBlockNames, tryParseLeanRef,
+} from "../manifest-entries.js";
+import { leanStatusBucket } from "../../content/pipeline/render-latex.js";
 
 export class PaperResolver {
   private outlineCache = new TtlCache<ContentOutline>();
@@ -98,7 +65,7 @@ export class PaperResolver {
     let folioData: { title: string; papers: Array<{ dir: string; title?: string; description?: string; tags?: string[] }> };
 
     if (this.gitHelper.fileExistsBranch(br, folioRel)) {
-      folioData = (await this.gitHelper.importTsBranch(br, folioRel)) as any;
+      folioData = await this.gitHelper.importTsBranch<Folio>(br, folioRel);
     } else {
       const dirs = this.gitHelper.listDirBranch(br, "content").filter((d) => {
         if (d === "schema" || d === "pipeline" || d === "node_modules") return false;
@@ -110,25 +77,34 @@ export class PaperResolver {
     const items: FolioItem[] = [];
     for (const ref of folioData.papers) {
       try {
-        const paperMod = (await this.gitHelper.importTsBranch(br, `content/${ref.dir}/${ref.dir}.ts`)) as any;
+        const paperMod = await this.gitHelper.importTsBranch<Paper>(br, `content/${ref.dir}/${ref.dir}.ts`);
         let blockCount = 0, provedCount = 0, todoCount = 0, chapCount = 0;
 
         for (const chRef of paperMod.chapters || []) {
           const chRel = `content/${ref.dir}/${chRef.dir}/${chRef.dir}.ts`;
           if (!this.gitHelper.fileExistsBranch(br, chRel)) continue;
           chapCount++;
-          const ch = (await this.gitHelper.importTsBranch(br, chRel)) as any;
+          const ch = await this.gitHelper.importTsBranch<Chapter>(br, chRel);
           for (const sec of ch.sections || []) {
-            if (!("blocks" in sec)) continue;
+            // Was `!("blocks" in sec)`, which also skipped inline sections
+            // whose blocks all live in `subsections[]` — the very case
+            // `sectionBlockNames` exists to flatten. Same fix as the MCP
+            // resolver; both now use the one reference test.
+            if (isSectionRef(sec)) continue;
             for (const rootName of sectionBlockNames(sec)) {
               const blkRel = `content/${ref.dir}/${chRef.dir}/${rootName}.ts`;
               if (!this.gitHelper.fileExistsBranch(br, blkRel)) continue;
               blockCount++;
               try {
-                const blk = (await this.gitHelper.importTsBranch(br, blkRel)) as any;
-                if (blk.status === "proved" || blk.status === "mathlib_ok") provedCount++;
+                const blk = await this.gitHelper.importTsBranch<Block>(br, blkRel);
+                // Was `blk.status === "proved" || "mathlib_ok"`. There is no
+                // block-level `status`: the schema derives
+                // `FormalizationStatus` at build time and does not store it
+                // in manifests, so this counter was always 0. The block's
+                // own `lean` field is the signal.
+                if (leanStatusBucket(blockLean(blk)) === "compiled") provedCount++;
                 const fb = this.feedbackStore.read(ref.dir, rootName);
-                if (fb.length) todoCount += fb.filter((t: any) => t.status !== "resolved" && t.status !== "wontfix").length;
+                if (fb.length) todoCount += fb.filter((t) => t.status !== "resolved" && t.status !== "wontfix").length;
               } catch {}
             }
           }
@@ -169,7 +145,7 @@ export class PaperResolver {
     const paperRel = `content/${id}/${id}.ts`;
     if (!this.gitHelper.fileExistsBranch(br, paperRel)) return null;
 
-    const paperMod = (await this.gitHelper.importTsBranch(br, paperRel)) as any;
+    const paperMod = await this.gitHelper.importTsBranch<Paper>(br, paperRel);
     const chapters: OutlineChapter[] = [];
 
     // Auto-number chapters from manifest order: skip unnumbered ones (tabLabel set)
@@ -177,14 +153,13 @@ export class PaperResolver {
     for (const chRef of paperMod.chapters || []) {
       const chTsRel = `content/${id}/${chRef.dir}/${chRef.dir}.ts`;
       if (!this.gitHelper.fileExistsBranch(br, chTsRel)) continue;
-      const ch = (await this.gitHelper.importTsBranch(br, chTsRel)) as any;
+      const ch = await this.gitHelper.importTsBranch<Chapter>(br, chTsRel);
       const chapterNumber = ch.tabLabel != null ? undefined : autoNum++;
 
       const sections: OutlineChapter["sections"] = [];
       for (const sec of ch.sections || []) {
-        if ("name" in sec && !("blocks" in sec)) continue;
-        const section = sec as { title: string; label?: string; blocks: string[] };
-        sections.push({ title: section.title, label: section.label, blockCount: sectionBlockNames(section).length });
+        if (isSectionRef(sec)) continue;
+        sections.push({ title: sec.title, label: sec.label, blockCount: sectionBlockNames(sec).length });
       }
 
       chapters.push({ number: chapterNumber, tabLabel: ch.tabLabel, title: ch.title, label: ch.label, dir: chRef.dir, sections });
@@ -216,27 +191,30 @@ export class PaperResolver {
     const chTsRel = `${chRel}/${chapterDir}.ts`;
     if (!this.gitHelper.fileExistsBranch(br, chTsRel)) return null;
 
-    const ch = (await this.gitHelper.importTsBranch(br, chTsRel)) as any;
+    const ch = await this.gitHelper.importTsBranch<Chapter>(br, chTsRel);
     const sections: SectionStub[] = [];
 
     for (const sec of ch.sections || []) {
-      if ("name" in sec && !("blocks" in sec)) continue;
-      const section = sec as { title: string; label?: string; blocks: string[] };
+      if (isSectionRef(sec)) continue;
+      const section = sec;
 
       const blockStubs: SectionStub["blockStubs"] = [];
       for (const rootName of sectionBlockNames(section)) {
         const blkTsRel = `${chRel}/${rootName}.ts`;
         try {
-          const blk = (await this.gitHelper.importTsBranch(br, blkTsRel)) as any;
+          const blk = await this.gitHelper.importTsBranch<Block>(br, blkTsRel);
           const feedback = this.feedbackStore.read(paperId, rootName);
+          const blkLean = blockLean(blk);
           blockStubs.push({
             rootName,
             kind: blk.kind,
             label: blk.label,
             title: blk.title,
-            status: blk.status,
-            lean: blk.lean ? { ref: blk.lean.ref, validation: blk.lean.validation } : undefined,
-            todoCount: feedback.filter((t: any) => t.status === "open").length,
+            // `blk.status` again — derived, never stored. Bound once so TS
+            // narrows the const rather than each repeated call.
+            status: leanStatusBucket(blkLean),
+            lean: blkLean ? { ref: blkLean.ref, validation: blkLean.validation } : undefined,
+            todoCount: feedback.filter((t) => t.status === "open").length,
           });
         } catch {
           blockStubs.push({ rootName, kind: "error", todoCount: 0 });
@@ -281,11 +259,11 @@ export class PaperResolver {
     const chTsRel = `${chRel}/${chapterDir}.ts`;
     if (!this.gitHelper.fileExistsBranch(br, chTsRel)) return null;
 
-    const ch = (await this.gitHelper.importTsBranch(br, chTsRel)) as any;
-    const realSections = (ch.sections || []).filter((s: any) => !("name" in s && !("blocks" in s)));
+    const ch = await this.gitHelper.importTsBranch<Chapter>(br, chTsRel);
+    const realSections = (ch.sections || []).filter((s): s is Section => !isSectionRef(s));
     if (sectionIndex < 0 || sectionIndex >= realSections.length) return null;
 
-    const sec = realSections[sectionIndex] as any;
+    const sec = realSections[sectionIndex];
     const ownBlockNames = Array.isArray(sec.blocks) ? sec.blocks : [];
     const blocks = await this.resolveBlocks(paperId, chRel, ownBlockNames, br);
 
@@ -294,9 +272,11 @@ export class PaperResolver {
       subsections = [];
       for (const sub of sec.subsections) {
         if (!sub) continue;
-        const subBlockNames = Array.isArray(sub.blocks) ? sub.blocks : [];
-        const subBlocks = await this.resolveBlocks(paperId, chRel, subBlockNames, br);
-        subsections.push({ title: sub.title, label: sub.label, blocks: subBlocks });
+        // A bare `SectionRef` subsection is not resolvable at this level, so
+        // it contributes no blocks — as before, when `sub.blocks` was absent.
+        const inline = isSectionRef(sub) ? undefined : sub;
+        const subBlocks = await this.resolveBlocks(paperId, chRel, inline?.blocks ?? [], br);
+        subsections.push({ title: inline?.title ?? "", label: inline?.label, blocks: subBlocks });
       }
     }
 
@@ -316,7 +296,7 @@ export class PaperResolver {
     const paperRel = `content/${id}/${id}.ts`;
     if (!this.gitHelper.fileExistsBranch(br, paperRel)) return null;
 
-    const paperMod = (await this.gitHelper.importTsBranch(br, paperRel)) as any;
+    const paperMod = await this.gitHelper.importTsBranch<Paper>(br, paperRel);
     const chapters: ResolvedChapter[] = [];
 
     // Auto-number chapters from manifest order
@@ -325,13 +305,13 @@ export class PaperResolver {
       const chRel = `content/${id}/${chRef.dir}`;
       const chTsRel = `${chRel}/${chRef.dir}.ts`;
       if (!this.gitHelper.fileExistsBranch(br, chTsRel)) continue;
-      const ch = (await this.gitHelper.importTsBranch(br, chTsRel)) as any;
+      const ch = await this.gitHelper.importTsBranch<Chapter>(br, chTsRel);
       const chapterNumber = ch.tabLabel != null ? undefined : autoNum++;
 
       const sections: ResolvedSection[] = [];
       for (const sec of ch.sections || []) {
-        if ("name" in sec && !("blocks" in sec)) continue;
-        const section = sec as any;
+        if (isSectionRef(sec)) continue;
+        const section = sec;
         const ownBlockNames = Array.isArray(section.blocks) ? section.blocks : [];
         const blocks = await this.resolveBlocks(id, chRel, ownBlockNames, br);
 
@@ -340,9 +320,9 @@ export class PaperResolver {
           subsections = [];
           for (const sub of section.subsections) {
             if (!sub) continue;
-            const subBlockNames = Array.isArray(sub.blocks) ? sub.blocks : [];
-            const subBlocks = await this.resolveBlocks(id, chRel, subBlockNames, br);
-            subsections.push({ title: sub.title, label: sub.label, blocks: subBlocks });
+            const inline = isSectionRef(sub) ? undefined : sub;
+            const subBlocks = await this.resolveBlocks(id, chRel, inline?.blocks ?? [], br);
+            subsections.push({ title: inline?.title ?? "", label: inline?.label, blocks: subBlocks });
           }
         }
 
@@ -405,7 +385,7 @@ export class PaperResolver {
       const blkTsRel = `${chRel}/${rootName}.ts`;
       const blkMdRel = `${chRel}/${rootName}.md`;
       try {
-        const blk = (await this.gitHelper.importTsBranch(br, blkTsRel)) as any;
+        const blk = await this.gitHelper.importTsBranch<Block>(br, blkTsRel);
         const md = this.gitHelper.readFileBranch(br, blkMdRel) || "";
 
         const feedback = this.feedbackStore.read(paperId, rootName);
@@ -417,7 +397,8 @@ export class PaperResolver {
         //      (<lakeRoot>/<Decl/Path>.lean)
         //   3. grep the package's Lean source dir for the bare name
         let leanSource: string | undefined;
-        if (blk.lean) {
+        const blkLean = blockLean(blk);
+        if (blkLean) {
           const parsed = tryParseLeanRef(blk);
           leanSource = this.gitHelper.readFileBranch(br, `${chRel}/${rootName}.lean`) ?? undefined;
           if (!leanSource && parsed) {
@@ -462,12 +443,13 @@ export class PaperResolver {
           label: blk.label,
           title: blk.title,
           uses: blk.uses,
-          examples: blk.examples,
-          proofs: blk.proofs,
-          lean: blk.lean ? { ...blk.lean, source: leanSource } : undefined,
-          status: blk.status,
-          tex: blk.tex,
-          caption: blk.caption,
+          examples: blockExamples(blk),
+          proofs: blockProofs(blk),
+          lean: blkLean ? { ...blkLean, ref: blkLean.ref, source: leanSource } : undefined,
+          // Derived from `lean`, never stored on the manifest — see `blockLean`.
+          status: leanStatusBucket(blkLean),
+          tex: blockTex(blk),
+          caption: blockCaption(blk),
           tags: blk.tags,
           rendered,
           md,

--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,7 @@
         "bun-types": "latest",
         "csl-json": "^0.1.0",
         "eslint": "^10.8.0",
+        "fast-xml-parser": "^5.10.1",
         "typescript-eslint": "^8.66.0",
       },
     },
@@ -62,6 +63,8 @@
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
+    "@nodable/entities": ["@nodable/entities@3.0.0", "", {}, "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw=="],
 
     "@playwright/test": ["@playwright/test@1.61.1", "", { "dependencies": { "playwright": "1.61.1" }, "bin": { "playwright": "cli.js" } }, "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig=="],
 
@@ -152,6 +155,8 @@
     "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "anynum": ["anynum@1.0.1", "", {}, "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A=="],
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
@@ -269,6 +274,10 @@
 
     "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
 
+    "fast-xml-builder": ["fast-xml-builder@1.3.0", "", { "dependencies": { "path-expression-matcher": "^1.6.2", "xml-naming": "^0.3.0" } }, "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.10.1", "", { "dependencies": { "@nodable/entities": "^3.0.0", "fast-xml-builder": "^1.2.0", "is-unsafe": "^2.0.0", "path-expression-matcher": "^1.6.2", "strnum": "^2.4.1", "xml-naming": "^0.3.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
@@ -338,6 +347,8 @@
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "is-unsafe": ["is-unsafe@2.0.0", "", {}, "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
@@ -473,6 +484,8 @@
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
+    "path-expression-matcher": ["path-expression-matcher@1.6.2", "", {}, "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ=="],
+
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
@@ -543,6 +556,8 @@
 
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
+    "strnum": ["strnum@2.4.1", "", { "dependencies": { "anynum": "^1.0.1" } }, "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg=="],
+
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
@@ -592,6 +607,8 @@
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "xml-naming": ["xml-naming@0.3.0", "", {}, "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
       "devDependencies": {
         "@playwright/test": "^1.60.0",
         "bun-types": "latest",
+        "csl-json": "^0.1.0",
         "eslint": "^10.8.0",
         "typescript-eslint": "^8.66.0",
       },
@@ -199,6 +200,8 @@
     "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "csl-json": ["csl-json@0.1.0", "", {}, "sha512-KMvcQ07H0kMpzl2aO1mgyp+F+LVk+z+QMpN01noMUv0Uu4mqg4KyJjeM2u2716qU9ZgPq1Kr30DXqhT4RuEg1w=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 

--- a/content/pipeline/audit-wiring.ts
+++ b/content/pipeline/audit-wiring.ts
@@ -49,7 +49,13 @@ const PROVABLE_KINDS = new Set([
 type Bucket = "wired-end-to-end" | "wired-partially" | "stub/skeleton" | "math-only";
 
 interface BlockAudit {
-  label: string;
+  /** Optional, because `label` is optional on several block kinds. It was
+   *  typed `string` while `block.label` is `string | undefined`, so an
+   *  unlabelled block keyed `blocksByLabel` under `undefined` — and every
+   *  unlabelled block collided on that one key, silently discarding all but
+   *  the last. `allLabels` is derived from those keys, so the `uses[]`
+   *  resolution below inherited the damage. */
+  label?: string;
   kind: string;
   chapter: string;
   blockName: string;
@@ -187,7 +193,10 @@ async function auditPaper(): Promise<AuditReport> {
         citedWitnesses,
         usesUnresolved: [],
       };
-      blocksByLabel.set(block.label, audit);
+      // Only labelled blocks enter the label index: an unlabelled block
+      // cannot be the target of a `uses[]` edge, so it has no place in
+      // `allLabels`. It is still audited — it just isn't addressable.
+      if (block.label) blocksByLabel.set(block.label, audit);
       blocks.push(audit);
     }
   }
@@ -200,8 +209,16 @@ async function auditPaper(): Promise<AuditReport> {
     try {
       block = (await import(tsPath)).default;
     } catch {}
-    if (block && block.uses) {
-      for (const u of block.uses) {
+    // `uses` is on `BlockBase`, which every block kind extends EXCEPT
+    // `EquationBlock` — the one standalone interface in the union. Reading it
+    // off the bare union is a type error, and an equation genuinely has no
+    // editorial dependencies to resolve, so an absent `uses` is correct here
+    // rather than something to work around. (Whether `EquationBlock` SHOULD
+    // carry the editorial relation is a schema question, recorded in bean
+    // `folio-assistant-tsca` rather than decided here.)
+    const blockUses = block && "uses" in block ? block.uses : undefined;
+    if (blockUses) {
+      for (const u of blockUses) {
         // Skip qualified cross-paper references (paper-dir:label or https://).
         if (u.includes(":") && !u.startsWith("def:") && !u.startsWith("prop:") &&
             !u.startsWith("thm:") && !u.startsWith("lem:") && !u.startsWith("cor:") &&

--- a/content/pipeline/bib-qa.ts
+++ b/content/pipeline/bib-qa.ts
@@ -22,7 +22,7 @@
 
 import { readFileSync, existsSync, readdirSync, writeFileSync } from "fs";
 import { resolve, join, extname } from "path";
-import { references } from "../../schemas/references";
+import { references } from "./references-registry-di";
 import { findContentRepoRoot } from "./repo-root";
 import type { Data as CSLData, Person as CSLPerson } from "csl-json";
 

--- a/content/pipeline/block-density-audit.py
+++ b/content/pipeline/block-density-audit.py
@@ -17,7 +17,7 @@ import os
 import re
 import sys
 from pathlib import Path
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 # ── Constants ─────────────────────────────────────────────────────
 

--- a/content/pipeline/build-glossary.ts
+++ b/content/pipeline/build-glossary.ts
@@ -117,11 +117,13 @@ export async function buildGlossary(paperDir: string): Promise<GlossaryIndex> {
       try {
         const mod = await import(tsPath);
         const block: Block = mod.default;
-        const defines = (block as any).defines as string[] | undefined;
+        // `defines` and `lean` are declared on some kinds and not others, so
+        // the `in` test is the real check; `label` is on all of them.
+        const defines = "defines" in block ? block.defines : undefined;
         if (!defines || defines.length === 0) continue;
 
         const { sectionTitle } = locateBlock(name, chapter);
-        const lean = (block as any).lean?.ref ?? null;
+        const lean = ("lean" in block ? block.lean?.ref : undefined) ?? null;
 
         for (const slug of defines) {
           entries.push({
@@ -129,7 +131,7 @@ export async function buildGlossary(paperDir: string): Promise<GlossaryIndex> {
             chapter: chRef.dir,
             chapterTitle: chapter.title ?? chRef.dir,
             section: sectionTitle,
-            block: (block as any).label ?? name,
+            block: block.label ?? name,
             kind: block.kind,
             lean,
           });

--- a/content/pipeline/build.ts
+++ b/content/pipeline/build.ts
@@ -19,6 +19,7 @@ import { renderChapter, validateLatexAst } from "./render-latex";
 import { generateMainTex } from "./generate-main-tex";
 import { runPreflight } from "./latex-preflight";
 import { resolveLeanFile, leanFileStatus } from "../../scripts/lean-coverage";
+import { findContentRepoRoot, findPapers } from "./repo-root";
 
 // ── Build ────────────────────────────────────────────────────────
 
@@ -280,15 +281,46 @@ export async function buildPaper(
 
 if (import.meta.main) {
   const args = process.argv.slice(2);
-  const defaultPaper = join(import.meta.dir, "../quantum-observable-universe/quantum-observable-universe.ts");
   // Resolve relative paths against cwd so `bun run pipeline/build.ts rel/path` works.
   // Only treat args[0] as a paper path if it's a positional argument (not a --flag);
   // otherwise fall back to the default paper. This allows invocations like
   // `bun run pipeline/build.ts --generate-main --main-out main.tex` without a path.
   const firstPositional = args[0] && !args[0].startsWith("--") ? args[0] : undefined;
-  const paperPath = resolve(firstPositional || defaultPaper);
+
+  // The default was
+  //   join(import.meta.dir, "../quantum-observable-universe/quantum-observable-universe.ts")
+  // — a specific FOLIO paper, named in PLATFORM code and resolved relative to
+  // this file, so it pointed at `<platform>/content/quantum-observable-universe`
+  // which exists in no checkout. Discover the folio's papers instead, the way
+  // `validate.ts` already does. One paper is unambiguous; several need an
+  // explicit argument; none is an error worth stating rather than a path that
+  // fails to import.
+  const contentRoot = findContentRepoRoot();
+  const paperPath = resolve(firstPositional ?? (() => {
+    const papers = findPapers(contentRoot);
+    if (papers.length === 1) return join(contentRoot, "content", papers[0], `${papers[0]}.ts`);
+    if (papers.length === 0) {
+      console.error(`No paper found under ${join(contentRoot, "content")}.`);
+      console.error("folio-assistant is the PLATFORM; papers live in a folio. Run this from the folio,");
+      console.error("or pass a paper manifest explicitly: bun run pipeline/build.ts <paper>/<paper>.ts");
+      process.exit(1);
+    }
+    console.error(`${papers.length} papers found (${papers.join(", ")}) — name one:`);
+    console.error("  bun run pipeline/build.ts content/<paper>/<paper>.ts");
+    process.exit(1);
+  })());
   const outDirIdx = args.indexOf("--out-dir");
-  const outDir = resolve(outDirIdx >= 0 ? args[outDirIdx + 1] : join(import.meta.dir, "../../chapters"));
+  // The default was `join(import.meta.dir, "../../chapters")` — this file's
+  // own location, so the PLATFORM checkout. `chapters/*.tex` is folio build
+  // output; every CI invocation passes `--out-dir ../chapters/` from inside
+  // the folio, which is why this never showed there. `server.ts` invokes
+  // this script twice WITHOUT the flag, and those runs wrote a paper's
+  // chapters into the platform repo. `findContentRepoRoot()` walks up from
+  // cwd — it must not use `import.meta.dir`, which resolves through the
+  // folio's `folio-assistant/` symlink back to the platform.
+  const outDir = resolve(
+    outDirIdx >= 0 ? args[outDirIdx + 1] : join(contentRoot, "chapters"),
+  );
 
   // Parse print mode options
   const printModeIdx = args.indexOf("--print-mode");

--- a/content/pipeline/codemod-refterm.ts
+++ b/content/pipeline/codemod-refterm.ts
@@ -42,6 +42,12 @@ import { gfmTable } from "micromark-extension-gfm-table";
 import { gfmTableFromMarkdown, gfmTableToMarkdown } from "mdast-util-gfm-table";
 import { gfmStrikethrough } from "micromark-extension-gfm-strikethrough";
 import { gfmStrikethroughFromMarkdown, gfmStrikethroughToMarkdown } from "mdast-util-gfm-strikethrough";
+import type { PhrasingContent, Text } from "mdast";
+// Ambient: registers the directive node types on the mdast unions, the same
+// way `render-latex.ts` does. Without it `textDirective` is not a
+// `PhrasingContent` and every node built below needs a cast.
+import type {} from "mdast-util-directive";
+import type {} from "mdast-util-math";
 import type { Block, Chapter, Paper, Section } from "../../schemas/types";
 import { ChapterSchema, PaperSchema } from "../../schemas/constraints";
 import { buildGlossary } from "./build-glossary";
@@ -76,19 +82,19 @@ function phraseTable(slugs: string[]): PhraseEntry[] {
  * (text + directive nodes) when at least one replacement was made;
  * returns null if nothing changed.
  */
-function rewriteTextNode(value: string, phrases: PhraseEntry[]): any[] | null {
-  let segments: any[] = [{ type: "text", value }];
+function rewriteTextNode(value: string, phrases: PhraseEntry[]): PhrasingContent[] | null {
+  let segments: PhrasingContent[] = [{ type: "text", value }];
   let changed = false;
 
   for (const { slug, phrase } of phrases) {
-    const next: any[] = [];
+    const next: PhrasingContent[] = [];
     const re = new RegExp(`\\b${escapeRegExp(phrase)}\\b`, "gi");
     for (const seg of segments) {
       if (seg.type !== "text") {
         next.push(seg);
         continue;
       }
-      const text: string = seg.value;
+      const text: string = (seg as Text).value;
       let last = 0;
       let m: RegExpExecArray | null;
       let any = false;
@@ -137,24 +143,26 @@ export function rewriteMarkdown(
 
   let mutated = false;
 
-  // unist-util-visit passes `index` as `number | undefined`, not
-  // `number | null`. The mismatch made the whole visitor unassignable.
-  visit(tree as any, (node: any, index: number | undefined, parent: any) => {
+  // The `"text"` test narrows `node` to `Text` — the manual
+  // `node.type !== "text"` bail-out this replaces did the same at runtime.
+  visit(tree, "text", (node, index, parent) => {
     if (!parent || index === undefined) return;
-    if (node.type !== "text") return;
-    // Skip text nodes that are children of any directive — they are
+    // Skip text nodes that are children of an inline directive — they are
     // already part of a wrapped term.
-    if (parent.type === "textDirective" || parent.type === "leafDirective" ||
-        parent.type === "containerDirective") {
+    //
+    // The guard used to also list `containerDirective`, `code`, `inlineCode`,
+    // `math` and `inlineMath`, as "belt-and-braces against future additions".
+    // Typing `parent` answers that: the parent of a `text` node is one of
+    // link | strong | delete | root | heading | paragraph | emphasis |
+    // linkReference | tableCell | textDirective | leafDirective, and none of
+    // the five can ever appear. `code`/`inlineCode`/`math`/`inlineMath` are
+    // literal nodes carrying `value` and no `children` at all, and a
+    // `containerDirective` holds block content, so its text is a paragraph
+    // deeper. Five conditions that could not fire, kept alive by `any`.
+    if (parent.type === "textDirective" || parent.type === "leafDirective") {
       return;
     }
-    // Skip text nodes inside code/math contexts (different types, but
-    // belt-and-braces against future additions).
-    if (parent.type === "inlineCode" || parent.type === "code" ||
-        parent.type === "inlineMath" || parent.type === "math") {
-      return;
-    }
-    const replacement = rewriteTextNode(node.value as string, phrases);
+    const replacement = rewriteTextNode(node.value, phrases);
     if (replacement) {
       parent.children.splice(index, 1, ...replacement);
       mutated = true;
@@ -164,7 +172,7 @@ export function rewriteMarkdown(
   });
 
   if (!mutated) return null;
-  return String(proc.stringify(tree as any));
+  return String(proc.stringify(tree));
 }
 
 // ── Discovery ────────────────────────────────────────────────────
@@ -216,7 +224,10 @@ async function blockSelfDefines(blockTsPath: string): Promise<Set<string>> {
   try {
     const mod = await import(blockTsPath);
     const block: Block = mod.default;
-    return new Set(((block as any).defines as string[] | undefined) ?? []);
+    // `defines` is declared on the provable/definitional kinds but not on
+    // `diagram`/`equation`/`table`, in both the TS union and the Zod schema —
+    // so the `in` test is real and the cast was not.
+    return new Set(("defines" in block ? block.defines : undefined) ?? []);
   } catch {
     return new Set();
   }

--- a/content/pipeline/codemod-refterm.ts
+++ b/content/pipeline/codemod-refterm.ts
@@ -137,8 +137,10 @@ export function rewriteMarkdown(
 
   let mutated = false;
 
-  visit(tree as any, (node: any, index: number | null, parent: any) => {
-    if (!parent || index === null) return;
+  // unist-util-visit passes `index` as `number | undefined`, not
+  // `number | null`. The mismatch made the whole visitor unassignable.
+  visit(tree as any, (node: any, index: number | undefined, parent: any) => {
+    if (!parent || index === undefined) return;
     if (node.type !== "text") return;
     // Skip text nodes that are children of any directive — they are
     // already part of a wrapped term.

--- a/content/pipeline/codemod-val.ts
+++ b/content/pipeline/codemod-val.ts
@@ -43,7 +43,7 @@ import { join, resolve, extname } from "path";
 import { remark } from "remark";
 import remarkDirective from "remark-directive";
 import remarkMath from "remark-math";
-import { visit } from "unist-util-visit";
+import { visit, SKIP } from "unist-util-visit";
 import { gfmTable } from "micromark-extension-gfm-table";
 import { gfmTableFromMarkdown, gfmTableToMarkdown } from "mdast-util-gfm-table";
 import { gfmStrikethrough } from "micromark-extension-gfm-strikethrough";
@@ -265,10 +265,10 @@ export function rewriteMarkdownFile(file: string, index: LiteralEntry[]): FileRe
   interface Patch { start: number; end: number; replacement: string; }
   const patches: Patch[] = [];
 
-  visit(tree as any, (node: any) => {
+  visit(tree, (node) => {
     // Skip subtree if we're inside a fenced ```tex block or a table.
-    if (node.type === "code" && node.lang === "tex") return "skip" as any;
-    if (node.type === "table") return "skip" as any;
+    if (node.type === "code" && node.lang === "tex") return SKIP;
+    if (node.type === "table") return SKIP;
     if (node.type !== "inlineMath" && node.type !== "math") return;
     if (!node.position?.start || !node.position?.end) return;
 

--- a/content/pipeline/content-graph-analysis.py
+++ b/content/pipeline/content-graph-analysis.py
@@ -20,13 +20,11 @@ Options:
 
 import sys
 import re
-import os
 import json
 import argparse
 import subprocess
 from collections import defaultdict
 from pathlib import Path
-from itertools import combinations
 
 # ── Paths ───────────────────────────────────────────────────────────────────
 

--- a/content/pipeline/export-bibtex.ts
+++ b/content/pipeline/export-bibtex.ts
@@ -15,7 +15,7 @@
 import { writeFileSync, readFileSync, existsSync } from "fs";
 import { resolve, join } from "path";
 import type { Data as CSLData, Person as CSLPerson } from "csl-json";
-import { references } from "../../schemas/references";
+import { references } from "./references-registry-di";
 import { findContentRepoRoot } from "./repo-root";
 
 // Content repo root (was import-relative, which pointed at

--- a/content/pipeline/export-json.ts
+++ b/content/pipeline/export-json.ts
@@ -17,7 +17,7 @@
  */
 
 import { readFileSync, writeFileSync, existsSync, mkdirSync, statSync } from "fs";
-import { join, resolve } from "path";
+import { join } from "path";
 import { createHash } from "crypto";
 import type {
   Paper,
@@ -28,12 +28,16 @@ import type {
   LeanRef,
 } from "../../schemas/types";
 import type { Data as CSLData } from "csl-json";
-import { references, referenceMap } from "../../schemas/references";
+import { references, referenceMap } from "./references-registry-di";
+import { findContentRepoRoot, findPapers, soleFolioPaper } from "./repo-root";
 import { mergeCitations } from "./citations";
 import { isWitnessed } from "../../scripts/lean-witness";
 import { leanPackageByName, parseLeanRef } from "../../schemas/lean-packages";
 
-const REPO_ROOT = resolve(import.meta.dir, "../..");
+// The FOLIO's root, not the platform's. `resolve(import.meta.dir, "../..")`
+// lands in folio-assistant, which holds no papers — and the symlinked
+// embedding resolves there even when run from the content repo.
+const REPO_ROOT = findContentRepoRoot();
 const CONTENT_ROOT = join(REPO_ROOT, "content");
 
 const args = process.argv.slice(2);
@@ -42,7 +46,20 @@ function argVal(name: string, fallback: string): string {
   return idx >= 0 && args[idx + 1] ? args[idx + 1] : fallback;
 }
 
-const PAPER_NAME = argVal("paper", "quantum-observable-universe");
+// No hardcoded paper. The platform must not privilege one folio's paper —
+// this defaulted to `quantum-observable-universe`, a qou name living in the
+// platform. `--paper` still wins; otherwise take the folio's sole paper, and
+// refuse rather than guess when there are several.
+const PAPER_NAME = argVal("paper", soleFolioPaper(REPO_ROOT) ?? "");
+if (!PAPER_NAME) {
+  const found = findPapers(REPO_ROOT);
+  console.error(
+    found.length === 0
+      ? `export-json: no paper found under ${CONTENT_ROOT} — run from a folio checkout, or pass --paper.`
+      : `export-json: this folio has ${found.length} papers (${found.join(", ")}) — pass --paper to choose one.`,
+  );
+  process.exit(2);
+}
 const OUT_DIR = argVal("out", join(REPO_ROOT, "build", "viewer"));
 const PAPER_DIR = join(CONTENT_ROOT, PAPER_NAME);
 

--- a/content/pipeline/export-json.ts
+++ b/content/pipeline/export-json.ts
@@ -259,7 +259,10 @@ async function main() {
             : undefined;
 
           // Merge explicit cites[] with auto-extracted from .md
-          const explicitCites = "cites" in block ? (block as any).cites as string[] | undefined : undefined;
+          // The `in` test is real — `cites` is absent from `diagram`,
+          // `equation` and `table` in both the TS union and the Zod schema.
+          // Only the `as any` was surplus: `in` narrows on its own.
+          const explicitCites = "cites" in block ? block.cites : undefined;
           const cites = mergeCitations(explicitCites, md);
 
           blocks.push({
@@ -278,10 +281,10 @@ async function main() {
             md,
             mdModified: mdStat ? mdStat.mtime.toISOString() : "",
             meta: "meta" in block ? block.meta : undefined,
-            html: "html" in block ? (block as any).html : undefined,
-            defaultView: "defaultView" in block ? (block as any).defaultView : undefined,
-            views: "views" in block ? (block as any).views : undefined,
-            interprets: "interprets" in block ? (block as any).interprets : undefined,
+            html: "html" in block ? block.html : undefined,
+            defaultView: "defaultView" in block ? block.defaultView : undefined,
+            views: "views" in block ? block.views : undefined,
+            interprets: "interprets" in block ? block.interprets : undefined,
           });
         } catch (e) {
           blocks.push({
@@ -324,7 +327,7 @@ async function main() {
     date: paper.date,
     chapters,
     references,
-    macros: (paper as any).macros,
+    macros: paper.macros,
     meta: paper.meta,
     _built: new Date().toISOString(),
   };

--- a/content/pipeline/glossary-candidates.ts
+++ b/content/pipeline/glossary-candidates.ts
@@ -164,9 +164,9 @@ export async function proposeCandidates(paperDir: string): Promise<CandidatesRep
       try {
         const mod = await import(tsPath);
         const block: Block = mod.default;
-        const defines = ((block as any).defines as string[] | undefined) ?? [];
-        const label = (block as any).label ?? name;
-        const title = (block as any).title ?? null;
+        const defines = ("defines" in block ? block.defines : undefined) ?? [];
+        const label = block.label ?? name;
+        const title = block.title ?? null;
         const mdContent = existsSync(mdPath) ? readFileSync(mdPath, "utf-8") : "";
 
         const { sectionTitle } = locateBlock(name, chapter);

--- a/content/pipeline/migrate-bib-verifier.ts
+++ b/content/pipeline/migrate-bib-verifier.ts
@@ -49,8 +49,15 @@ if (import.meta.main) {
     process.exit(1);
   }
 
-  const raw = JSON.parse(readFileSync(TARGET, "utf-8"));
-  const entries: any[] = raw.entries ?? [];
+  // The file is hand-edited JSON, so `verified_by` is either the legacy
+  // string or the `Verifier` union this script migrates it to.
+  interface VerificationEntry { id?: string; verified_by?: unknown }
+  const raw = JSON.parse(readFileSync(TARGET, "utf-8")) as {
+    entries?: VerificationEntry[];
+    _verified_by_caveat?: unknown;
+    _schema?: string;
+  };
+  const entries: VerificationEntry[] = raw.entries ?? [];
 
   let migrated = 0;
   let alreadyStructured = 0;
@@ -59,7 +66,7 @@ if (import.meta.main) {
   for (const e of entries) {
     const v = e.verified_by;
     if (v == null) continue;
-    if (typeof v === "object" && v.kind) {
+    if (typeof v === "object" && v !== null && "kind" in v) {
       alreadyStructured++;
       continue;
     }

--- a/content/pipeline/proof-axis-dashboard.ts
+++ b/content/pipeline/proof-axis-dashboard.ts
@@ -66,6 +66,13 @@ interface SorryInfo {
 import { walkBlocks, loadQaReport } from "./qa-utils";
 import { WATCHER_CRITERIA_BY_AXIS } from "./qa-criteria-registry";
 
+/** `evidence` as searchable text, whichever of its two shapes it is. */
+function evidenceText(ev: string | Array<{ line?: number; text?: string }> | undefined): string {
+  if (typeof ev === "string") return ev;
+  if (!Array.isArray(ev)) return "";
+  return ev.map((h) => `${h.line ?? ""}:${h.text ?? ""}`).join(" | ");
+}
+
 function main() {
   const args = parseArgs(process.argv.slice(2));
   const rootPath = resolve(REPO_ROOT, "content", args.root);
@@ -104,7 +111,13 @@ function main() {
       if (r === "fail") s.failBlocks.push(report.label);
       if (r === "warn") {
         s.warnBlocks.push(report.label);
-        const ev = latest.evidence ?? "";
+        // `QaCriterionEntry.evidence` is `string | Array<{line?, text?}>`.
+        // This was used directly as a string: `ev.includes("no declarations")`
+        // on the ARRAY form is Array.prototype.includes — exact-element
+        // membership, not substring — so it was always false and the
+        // "no declarations" mismatch silently never fired for array-form
+        // evidence. Flatten to text first.
+        const ev = evidenceText(latest.evidence);
         const notes = latest.notes ?? "";
         if (ev.includes("no declarations")) {
           const relTs = relative(rootPath, block.ts);

--- a/content/pipeline/q-usage-audit.ts
+++ b/content/pipeline/q-usage-audit.ts
@@ -341,7 +341,10 @@ interface BlockFinding {
  * the audit just stopped reading it.
  */
 export function hasHumanDispensation(
-  b: BlockTriple,
+  // Only the `.ts` path is read — the sidecar is derived from it. Taking the
+  // whole `BlockTriple` overstated the dependency and forced callers (and the
+  // regression test) to construct five fields this never looks at.
+  b: Pick<BlockTriple, "ts">,
   criterionId: string,
   currentHashes: { ts?: string; md?: string; lean?: string },
 ): boolean {

--- a/content/pipeline/qa-checkers-voice.ts
+++ b/content/pipeline/qa-checkers-voice.ts
@@ -869,7 +869,7 @@ export function checkScholarlyDefault(
   mdPath: string | undefined,
   leanPath: string | undefined,
 ): CheckerResult {
-  const { lines } = mdPath ? readSource(mdPath) : { src: "", lines: [] };
+  const lines = mdPath ? readSource(mdPath).lines : [];
   if (lines.length === 0 && !leanPath) return { result: "pass", hits: [] };
 
   const hits: CheckerHit[] = [];

--- a/content/pipeline/qa-sweep.ts
+++ b/content/pipeline/qa-sweep.ts
@@ -122,6 +122,7 @@ import {
   getCriterionExtraInputs,
 } from "./qa-criteria-registry";
 import { AUTOMATED_CHECKERS } from "./qa-checkers-voice";
+import type { CheckerResult } from "./qa-checkers-extended";
 import type {
   BlockQaReport,
   QaCriterionEntry,
@@ -180,13 +181,21 @@ interface BlockSweepResult {
   fail_minor: number;
   details: Array<{
     criterion: string;
+    // `CheckerResult["result"]` is assigned here verbatim, so this union must
+    // contain all of it. It omitted `"warn"` and plain `"n/a"` — meaning a
+    // soft finding was written into the details JSON as a value the type said
+    // could not occur, and a consumer switching exhaustively on `outcome`
+    // would not handle it. `CheckerResult` documents that `warn` is
+    // "preserved end-to-end … without being silently coerced to `pass`", and
+    // an earlier `warn` -> `pass` coercion in the extended dispatch did
+    // silently drop chapter-mismatch warnings (#1640). Referencing the type
+    // rather than restating it is what stops the two drifting again.
     outcome:
       | "fresh-skip"
-      | "pass"
-      | "fail"
       | "needs-agent"
       | "n/a-no-md"
-      | "n/a-no-lean";
+      | "n/a-no-lean"
+      | CheckerResult["result"];
     severity?: "critical" | "major" | "minor";
     hits?: number;
     first_hit?: string;

--- a/content/pipeline/references-registry-di.ts
+++ b/content/pipeline/references-registry-di.ts
@@ -1,0 +1,98 @@
+/**
+ * Dependency injection point for the bibliography.
+ *
+ * The reference database is CONTENT: in qou it is
+ * `content/schema/references.ts`, ~7900 lines of CSL-JSON entries. It belongs
+ * to the folio, the same way the values registry and the Lake package list do.
+ *
+ * Six pipeline files imported it directly as `../../schemas/references` — a
+ * path that does not exist in this repo. They did not merely fail to
+ * type-check; **every one of them threw `Cannot find module` at import**, so
+ * `validate-bib`, `bib-qa`, `export-bibtex`, `export-json`,
+ * `validate-references` and `validate-references-human-review` could not run
+ * here at all. The whole bibliography subsystem was dead code, and nothing
+ * said so, because `content/**` was outside the tsconfig program (bean
+ * `folio-assistant-tsca`) and nothing else imports these entry points.
+ *
+ * This mirrors `value-registry-di.ts` exactly, including the Proxy that lets
+ * consumers keep writing `references` as a value. Downstream runner scripts
+ * call `configureReferenceRegistry` before invoking pipeline functions — see
+ * qou's `scripts/run-validate.ts` for the established shape.
+ *
+ * @module content/pipeline/references-registry-di
+ */
+
+import type { z } from "zod";
+import type { Data as CSLData } from "csl-json";
+
+export type { CSLData };
+
+export interface ReferenceRegistryAPI {
+  /** Every entry, in declaration order. */
+  references: CSLData[];
+  /** `id` → entry. */
+  referenceMap: Map<string, CSLData>;
+  /** Zod schema the folio validates entries against at construction time. */
+  CSLEntrySchema: z.ZodType<unknown>;
+}
+
+let currentApi: ReferenceRegistryAPI | null = null;
+
+export function configureReferenceRegistry(api: ReferenceRegistryAPI): void {
+  currentApi = api;
+}
+
+export function getReferenceRegistry(): ReferenceRegistryAPI {
+  if (!currentApi) {
+    throw new Error(
+      "Reference registry not configured. " +
+        "The downstream repo must call configureReferenceRegistry() before running pipeline functions.",
+    );
+  }
+  return currentApi;
+}
+
+/**
+ * The reference list, as a value.
+ *
+ * A Proxy over an array so the six consumers keep reading `references` the way
+ * they always have — `.length`, index access, `for…of`, `.map`, `.filter` —
+ * while the actual data is resolved lazily from the injected registry. Without
+ * this every call site would have to become `getReferenceRegistry().references`
+ * and the diff would be far larger than the defect.
+ */
+export const references: CSLData[] = new Proxy([] as CSLData[], {
+  get: (_, prop) => {
+    const arr = getReferenceRegistry().references;
+    const v = Reflect.get(arr, prop);
+    return typeof v === "function" ? v.bind(arr) : v;
+  },
+  has: (_, prop) => Reflect.has(getReferenceRegistry().references, prop),
+  ownKeys: () => Reflect.ownKeys(getReferenceRegistry().references),
+  getOwnPropertyDescriptor: (_, prop) =>
+    Reflect.getOwnPropertyDescriptor(getReferenceRegistry().references, prop),
+});
+
+/** `id` → entry, resolved from the injected registry. */
+export const referenceMap: Map<string, CSLData> = new Proxy(new Map(), {
+  get: (_, prop) => {
+    const map = getReferenceRegistry().referenceMap;
+    const v = Reflect.get(map, prop);
+    return typeof v === "function" ? v.bind(map) : v;
+  },
+}) as Map<string, CSLData>;
+
+/** The folio's entry schema, resolved from the injected registry. */
+export const CSLEntrySchema: z.ZodType<unknown> = new Proxy(
+  {} as z.ZodType<unknown>,
+  {
+    get: (_, prop) => {
+      const schema = getReferenceRegistry().CSLEntrySchema as unknown as Record<
+        string | symbol,
+        unknown
+      >;
+      const v = schema[prop];
+      return typeof v === "function" ? (v as (...a: unknown[]) => unknown).bind(schema) : v;
+    },
+  },
+);

--- a/content/pipeline/render-latex.ts
+++ b/content/pipeline/render-latex.ts
@@ -167,7 +167,7 @@ function transliterateForVerbatim(text: string): string {
  * unknown/absent validation on a block that *does* carry a Lean ref defaults
  * to "drafted" (it is stated, just not yet checked).
  */
-function leanStatusBucket(
+export function leanStatusBucket(
   lean: { sorryFree?: boolean; validation?: string } | undefined,
 ): "stubbed" | "drafted" | "compiled" {
   if (!lean) return "stubbed";

--- a/content/pipeline/validate-bib.ts
+++ b/content/pipeline/validate-bib.ts
@@ -86,6 +86,12 @@ const CONTENT_ROOT = path.join(REPO_ROOT, "content");
  * and `Math.abs(NaN) > 1` is false, so a malformed year would read as a MATCH
  * rather than a mismatch.
  */
+/** An unknown thrown value as a message. `catch (e)` is `unknown` under
+ *  `strict`; these sites read `e.message ?? e`, which needs the narrowing. */
+function errMsg(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
 function cslYear(parts: unknown): number | undefined {
   // `unknown` rather than csl-json's `Date['date-parts']`: that is a
   // fixed-arity tuple of optional LooseNumbers, and the Crossref response
@@ -130,8 +136,8 @@ async function modeDoi(): Promise<CheckResult[]> {
       } else {
         out.push({ entry: r.id, severity: "warn", note: `HTTP ${resp.status} for ${url}` });
       }
-    } catch (e: any) {
-      out.push({ entry: r.id, severity: "warn", note: `fetch failed: ${e.message ?? e}` });
+    } catch (e) {
+      out.push({ entry: r.id, severity: "warn", note: `fetch failed: ${errMsg(e)}` });
     }
     if (i % 25 === 0) console.log(`  …${i}/${withDoi.length}`);
   }
@@ -284,8 +290,8 @@ async function modeCrossref(): Promise<CheckResult[]> {
       } else {
         out.push({ entry: r.id, severity: "ok", note: "Crossref matches" });
       }
-    } catch (e: any) {
-      out.push({ entry: r.id, severity: "warn", note: `crossref fetch failed: ${e.message ?? e}` });
+    } catch (e) {
+      out.push({ entry: r.id, severity: "warn", note: `crossref fetch failed: ${errMsg(e)}` });
     }
     if (i % 25 === 0) console.log(`  …${i}/${withDoi.length}`);
   }
@@ -307,8 +313,8 @@ async function modeArxiv(): Promise<CheckResult[]> {
       } else {
         out.push({ entry: r.id, severity: "warn", note: `arxiv HTTP ${resp.status}` });
       }
-    } catch (e: any) {
-      out.push({ entry: r.id, severity: "warn", note: `arxiv fetch failed: ${e.message ?? e}` });
+    } catch (e) {
+      out.push({ entry: r.id, severity: "warn", note: `arxiv fetch failed: ${errMsg(e)}` });
     }
   }
   return out;

--- a/content/pipeline/validate-bib.ts
+++ b/content/pipeline/validate-bib.ts
@@ -46,7 +46,8 @@
  * source of truth; this script verifies external correctness of every
  * entry beyond schema-shape validation.
  */
-import { references } from "../../schemas/references";
+import { references } from "./references-registry-di";
+import { findContentRepoRoot } from "./repo-root";
 import * as fs from "fs";
 import * as path from "path";
 import { glob } from "fs/promises";
@@ -68,8 +69,36 @@ if (MODES.size === 0) {
   process.exit(2);
 }
 
-const CONTENT_ROOT = path.resolve(__dirname, "..");
-const REPO_ROOT = path.resolve(CONTENT_ROOT, "..");
+// Both roots are the FOLIO's, not the platform's. `path.resolve(__dirname,
+// "..")` lands in `<folio-assistant>/content/`, which holds only `pipeline/` —
+// so the `**/*.lean` glob below had nothing to walk. Never noticed, because
+// this file threw `Cannot find module` at import and could not run at all.
+const REPO_ROOT = findContentRepoRoot();
+const CONTENT_ROOT = path.join(REPO_ROOT, "content");
+
+/**
+ * The year from a CSL `issued` date, as a number.
+ *
+ * CSL-JSON types `date-parts` entries as `LooseNumber = string | number` and
+ * the spec permits `"date-parts": [["2020"]]`. The two comparison sites below
+ * subtracted these directly; JS coerces a numeric string, so it happened to
+ * work, but it is unsound and silently yields `NaN` for anything non-numeric —
+ * and `Math.abs(NaN) > 1` is false, so a malformed year would read as a MATCH
+ * rather than a mismatch.
+ */
+function cslYear(parts: unknown): number | undefined {
+  // `unknown` rather than csl-json's `Date['date-parts']`: that is a
+  // fixed-arity tuple of optional LooseNumbers, and the Crossref response
+  // objects below carry their own near-identical shape. Narrowing here takes
+  // both without a cast at either call site.
+  if (!Array.isArray(parts)) return undefined;
+  const first = parts[0];
+  if (!Array.isArray(first)) return undefined;
+  const raw: unknown = first[0];
+  if (typeof raw !== "number" && typeof raw !== "string") return undefined;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : undefined;
+}
 
 async function modeDoi(): Promise<CheckResult[]> {
   const out: CheckResult[] = [];
@@ -144,7 +173,7 @@ async function modeCrossCheck(): Promise<CheckResult[]> {
       const authorFamilies: string[] = (entry.author ?? [])
         .map((a: any) => (a.family ?? a.literal ?? "").toLowerCase())
         .filter((s: string) => s.length >= 3);
-      const entryYear = entry.issued?.["date-parts"]?.[0]?.[0];
+      const entryYear = cslYear(entry.issued?.["date-parts"]);
       checked++;
       // Strip URLs, DOIs, and punctuation; count remaining alphabetic words
       const descStripped = desc
@@ -234,12 +263,12 @@ async function modeCrossref(): Promise<CheckResult[]> {
       const msg = data.message ?? data;
       const cTitle = (msg.title?.[0] ?? "").toLowerCase();
       const cAuthor = (msg.author?.[0]?.family ?? "").toLowerCase();
-      const cYear = msg["published-print"]?.["date-parts"]?.[0]?.[0]
-                  ?? msg["published-online"]?.["date-parts"]?.[0]?.[0]
-                  ?? msg["created"]?.["date-parts"]?.[0]?.[0];
+      const cYear = cslYear(msg["published-print"]?.["date-parts"])
+                  ?? cslYear(msg["published-online"]?.["date-parts"])
+                  ?? cslYear(msg["created"]?.["date-parts"]);
       const eTitle = ((r as any).title ?? "").toLowerCase();
       const eAuthor = (r.author?.[0]?.family ?? "").toLowerCase();
-      const eYear = r.issued?.["date-parts"]?.[0]?.[0];
+      const eYear = cslYear(r.issued?.["date-parts"]);
       const issues: string[] = [];
       if (eTitle && cTitle && !cTitle.includes(eTitle.slice(0, 20)) && !eTitle.includes(cTitle.slice(0, 20))) {
         issues.push(`title mismatch: entry "${eTitle.slice(0, 60)}" vs Crossref "${cTitle.slice(0, 60)}"`);

--- a/content/pipeline/validate-bib.ts
+++ b/content/pipeline/validate-bib.ts
@@ -176,9 +176,12 @@ async function modeCrossCheck(): Promise<CheckResult[]> {
       //      lowercased description.
       // This skips URL-only / DOI-only / topic-hint-only descriptions
       // (which v2's "always check" misclassified as FPs).
+      // `Person` is `{family} | {literal}`, but `PersonPartial` makes both
+      // optional on either arm, so the `??` chain is the right read — it was
+      // only the `any` that was surplus.
       const authorFamilies: string[] = (entry.author ?? [])
-        .map((a: any) => (a.family ?? a.literal ?? "").toLowerCase())
-        .filter((s: string) => s.length >= 3);
+        .map((a) => (a.family ?? a.literal ?? "").toLowerCase())
+        .filter((s) => s.length >= 3);
       const entryYear = cslYear(entry.issued?.["date-parts"]);
       checked++;
       // Strip URLs, DOIs, and punctuation; count remaining alphabetic words
@@ -198,7 +201,7 @@ async function modeCrossCheck(): Promise<CheckResult[]> {
       // cite the work by title rather than surname (e.g.
       // `[kauffman1991] Knots and Physics, World Scientific`); these are
       // genuine matches that v3 incorrectly flagged.
-      const entryTitle: string = ((entry as any).title ?? "").toLowerCase();
+      const entryTitle: string = (entry.title ?? "").toLowerCase();
       const stopwords = new Set([
         "a", "an", "the", "of", "and", "or", "in", "on", "for", "to", "from",
         "with", "by", "at", "as", "is", "are", "be",
@@ -265,14 +268,24 @@ async function modeCrossref(): Promise<CheckResult[]> {
         out.push({ entry: r.id, severity: "warn", note: `crossref ${resp.status} for ${r.DOI}` });
         continue;
       }
-      const data: any = await resp.json();
-      const msg = data.message ?? data;
+      // The fields this reads off a Crossref `/works/<DOI>` response.
+      // Everything else in the payload is ignored, and naming these is what
+      // keeps a typo in one of them from silently comparing "" to "".
+      interface CrossrefWork {
+        title?: string[];
+        author?: Array<{ family?: string }>;
+        "published-print"?: { "date-parts"?: unknown };
+        "published-online"?: { "date-parts"?: unknown };
+        created?: { "date-parts"?: unknown };
+      }
+      const data = await resp.json() as CrossrefWork & { message?: CrossrefWork };
+      const msg: CrossrefWork = data.message ?? data;
       const cTitle = (msg.title?.[0] ?? "").toLowerCase();
       const cAuthor = (msg.author?.[0]?.family ?? "").toLowerCase();
       const cYear = cslYear(msg["published-print"]?.["date-parts"])
                   ?? cslYear(msg["published-online"]?.["date-parts"])
                   ?? cslYear(msg["created"]?.["date-parts"]);
-      const eTitle = ((r as any).title ?? "").toLowerCase();
+      const eTitle = (r.title ?? "").toLowerCase();
       const eAuthor = (r.author?.[0]?.family ?? "").toLowerCase();
       const eYear = cslYear(r.issued?.["date-parts"]);
       const issues: string[] = [];
@@ -300,13 +313,13 @@ async function modeCrossref(): Promise<CheckResult[]> {
 
 async function modeArxiv(): Promise<CheckResult[]> {
   const out: CheckResult[] = [];
-  const withArxiv = references.filter((r) => (r as any).URL && /arxiv\.org/i.test((r as any).URL));
+  const withArxiv = references.filter((r) => r.URL && /arxiv\.org/i.test(r.URL));
   console.log(`\n[arxiv] checking ${withArxiv.length} arxiv-URL entries...`);
   for (const r of withArxiv) {
     try {
       const ctrl = new AbortController();
       const timer = setTimeout(() => ctrl.abort(), 5000);
-      const resp = await fetch((r as any).URL, { method: "HEAD", redirect: "follow", signal: ctrl.signal });
+      const resp = await fetch(r.URL!, { method: "HEAD", redirect: "follow", signal: ctrl.signal });
       clearTimeout(timer);
       if (resp.status === 200 || resp.status === 301 || resp.status === 302) {
         out.push({ entry: r.id, severity: "ok", note: `arxiv ${resp.status} OK` });

--- a/content/pipeline/validate-defterm.ts
+++ b/content/pipeline/validate-defterm.ts
@@ -10,15 +10,19 @@
  * @module content/pipeline/validate-defterm
  */
 import { visit } from "unist-util-visit";
+import type { TextDirective } from "mdast-util-directive";
+// Ambient: registers the directive node types on the mdast unions.
+import type {} from "mdast-util-directive";
+import type {} from "mdast-util-math";
 import type { Block, ValidationIssue } from "../../schemas/types";
 import { parseMdCached } from "./render-latex";
 
 /** Resolve the slug for a defterm/refterm node. */
-function nodeSlug(node: any): { slug: string; label: string } {
-  const label = ((node.children ?? [])
-    .map((c: any) => (typeof c.value === "string" ? c.value : ""))
+function nodeSlug(node: TextDirective): { slug: string; label: string } {
+  const label = (node.children ?? [])
+    .map((c) => ("value" in c && typeof c.value === "string" ? c.value : ""))
     .join("")
-    .trim()) as string;
+    .trim();
   const explicit = node.attributes && (node.attributes.id || node.attributes["#"]);
   const slug = (explicit ? String(explicit) : label).trim();
   return { slug, label };
@@ -45,7 +49,7 @@ function collectBlockUsage(md: string): BlockTermUsage {
   const refs = new Map<string, { label: string }>();
   const textParts: string[] = [];
 
-  visit(tree as any, (node: any, _index, parent: any) => {
+  visit(tree, (node, _index, parent) => {
     if (node.type === "textDirective") {
       if (node.name === "defterm") {
         const { slug, label } = nodeSlug(node);
@@ -55,9 +59,10 @@ function collectBlockUsage(md: string): BlockTermUsage {
         if (slug && !refs.has(slug)) refs.set(slug, { label });
       }
     } else if (node.type === "text" && parent && parent.type !== "textDirective") {
-      // Skip text nodes inside directives (already counted as label) and
-      // inside math/code (different node types).
-      textParts.push(node.value as string);
+      // Skip text nodes inside directives (already counted as label). Math
+      // and code need no test: they are mdast literal nodes with no `text`
+      // children to reach.
+      textParts.push(node.value);
     }
   });
 
@@ -72,7 +77,9 @@ export function buildGlossaryIndex(
 ): Map<string, string[]> {
   const index = new Map<string, string[]>();
   for (const { name, block } of blocks) {
-    const defines = (block as any).defines as string[] | undefined;
+    // `defines` is absent from `diagram`/`equation`/`table` in both the TS
+    // union and the Zod schema, so the `in` test is real — the cast was not.
+    const defines = "defines" in block ? block.defines : undefined;
     if (!defines) continue;
     for (const slug of defines) {
       const list = index.get(slug) ?? [];
@@ -140,7 +147,7 @@ export function validateDefterms(
   // ── Rule: defterm-declared, defterm-marked ──
   for (const [name, { block }] of blocks) {
     const usage = usageByBlock.get(name)!;
-    const defines = ((block as any).defines as string[] | undefined) ?? [];
+    const defines = ("defines" in block ? block.defines : undefined) ?? [];
     const declaredSet = new Set(defines);
 
     // defterm-declared (error): every :defterm[X] must appear in defines[]

--- a/content/pipeline/validate-references-human-review.ts
+++ b/content/pipeline/validate-references-human-review.ts
@@ -23,10 +23,11 @@
  */
 
 import { readFileSync, existsSync } from "fs";
-import { resolve } from "path";
+import { join } from "path";
 import { createHash } from "crypto";
-import { references } from "../../schemas/references";
+import { references } from "./references-registry-di";
 import type { Data as CSLData } from "csl-json";
+import { findContentRepoRoot } from "./repo-root";
 
 const STATUS_ENUM = [
   "unreviewed",
@@ -51,7 +52,12 @@ interface ReviewSidecar {
   reviews: Record<string, ReviewEntry>;
 }
 
-const SIDECAR_PATH = resolve(import.meta.dir, "../../schemas/references.review.json");
+// The review sidecar sits BESIDE the bibliography it annotates, which is
+// folio content (`content/schema/references.review.json`). Computing it from
+// `import.meta.dir` pointed at `<folio-assistant>/schemas/` — a path that does
+// not exist, and one the folio's symlinked embedding resolves to even when the
+// pipeline is run from the content repo.
+const SIDECAR_PATH = join(findContentRepoRoot(), "content", "schema", "references.review.json");
 
 /** Recursively key-sorted JSON, so the hash is independent of source key order.
  *  Mimics `JSON.stringify` semantics for the non-JSON values that can appear in a

--- a/content/pipeline/validate-references.ts
+++ b/content/pipeline/validate-references.ts
@@ -21,7 +21,7 @@
 
 import { readFileSync, existsSync, readdirSync } from "fs";
 import { resolve, join } from "path";
-import { references, referenceMap, CSLEntrySchema } from "../../schemas/references";
+import { references, referenceMap, CSLEntrySchema } from "./references-registry-di";
 
 const REPO_ROOT = resolve(import.meta.dir, "../..");
 const args = process.argv.slice(2);

--- a/content/pipeline/validate-tex.ts
+++ b/content/pipeline/validate-tex.ts
@@ -26,6 +26,24 @@ import remarkMath from "remark-math";
 import { visit } from "unist-util-visit";
 import { parse as parseLatex } from "@unified-latex/unified-latex-util-parse";
 import { printRaw } from "@unified-latex/unified-latex-util-print-raw";
+import type { Ast as LatexAstUnion, Environment } from "@unified-latex/unified-latex-types";
+
+/** One node of the unified-latex AST — the second, unrelated node family
+ *  alongside mdast in this file. Same alias as `render-latex.ts`. */
+type LatexNode = Exclude<LatexAstUnion, unknown[]>;
+
+/** Child nodes, when this node's `content` is an array. On `macro`,
+ *  `string`, `comment` and `verb` it is a plain string instead. */
+function latexChildren(node: LatexNode): LatexNode[] {
+  const c = (node as { content?: unknown }).content;
+  return Array.isArray(c) ? (c as LatexNode[]) : [];
+}
+
+/** A node's arguments, for the kinds that take them. */
+function latexArgs(node: LatexNode): LatexNode[] {
+  const a = (node as { args?: unknown }).args;
+  return Array.isArray(a) ? (a as LatexNode[]) : [];
+}
 
 // ── Types ─────────────────────────────────────────────────────────
 
@@ -72,7 +90,7 @@ function extractSnippets(filepath: string, text: string): TexSnippet[] {
 
   const tree = remark().use(remarkMath).parse(text);
 
-  visit(tree, (node: any) => {
+  visit(tree, (node) => {
     const pos = node.position?.start ?? { line: 1, column: 1 };
 
     if (node.type === "inlineMath") {
@@ -141,7 +159,7 @@ function validateSnippetAst(snippet: TexSnippet): ValidationError[] {
     texToParse = snippet.content;
   }
 
-  let ast: any;
+  let ast: ReturnType<typeof parseLatex>;
   try {
     ast = parseLatex(texToParse);
   } catch (e) {
@@ -160,13 +178,12 @@ function validateSnippetAst(snippet: TexSnippet): ValidationError[] {
   // Walk AST for structural issues
   const envStack: string[] = [];
 
-  function walkNodes(nodes: any[]): void {
+  function walkNodes(nodes: LatexNode[]): void {
     for (const node of nodes) {
       // Check environment nodes
       if (node.type === "environment") {
-        const envName = typeof node.env === "string"
-          ? node.env
-          : printRaw(node.env ?? []);
+        const env = (node as Environment).env;
+        const envName = typeof env === "string" ? env : printRaw(env ?? []);
 
         // Check for non-math environments in math context
         if (isMathContext && NON_MATH_ENVS.has(envName)) {
@@ -184,43 +201,25 @@ function validateSnippetAst(snippet: TexSnippet): ValidationError[] {
         envStack.push(envName);
 
         // Recurse into environment content
-        if (node.content && Array.isArray(node.content)) {
-          walkNodes(node.content);
-        }
+        walkNodes(latexChildren(node));
 
         envStack.pop();
       }
 
-      // Check for unmatched braces (group nodes with issues)
-      if (node.type === "group" && node.content && Array.isArray(node.content)) {
-        walkNodes(node.content);
+      // Groups (brace scopes) and the three math node kinds carry children
+      // the same way; `latexChildren` returns [] for anything else, so the
+      // per-type `Array.isArray(node.content)` tests are what it replaces.
+      if (node.type === "group" || node.type === "inlinemath" ||
+          node.type === "displaymath" || node.type === "mathenv") {
+        walkNodes(latexChildren(node));
       }
 
       // Recurse into args
-      if (node.args && Array.isArray(node.args)) {
-        for (const arg of node.args) {
-          if (arg.content && Array.isArray(arg.content)) {
-            walkNodes(arg.content);
-          }
-        }
-      }
-
-      // Check inline/display math nodes for nested issues
-      if (node.type === "inlinemath" && node.content) {
-        walkNodes(node.content);
-      }
-      if (node.type === "displaymath" && node.content) {
-        walkNodes(node.content);
-      }
-      if (node.type === "mathenv" && node.content) {
-        walkNodes(node.content);
-      }
+      for (const arg of latexArgs(node)) walkNodes(latexChildren(arg));
     }
   }
 
-  if (ast.content && Array.isArray(ast.content)) {
-    walkNodes(ast.content);
-  }
+  walkNodes(latexChildren(ast));
 
   return errors;
 }

--- a/content/pipeline/validate-value.ts
+++ b/content/pipeline/validate-value.ts
@@ -129,9 +129,10 @@ export function validateValueDirectives(
     // computation, warn so the author either attaches one or accepts
     // the implicit dependency.  This is per decision 2a (implicit
     // auto-link).
-    const blockAny = block as any;
+    // `computation` is declared on definition/theorem/algorithm/simulator/
+    // table but not on prose/diagram/equation, so the `in` test is real.
     const compWitnessRaw: string | string[] | undefined =
-      blockAny?.computation?.witness;
+      "computation" in block ? block.computation?.witness : undefined;
     const declared: string[] = compWitnessRaw === undefined
       ? []
       : Array.isArray(compWitnessRaw)

--- a/content/pipeline/validate.ts
+++ b/content/pipeline/validate.ts
@@ -41,8 +41,6 @@ function discoverManifests(dir: string): string[] {
     .map(f => basename(f, ".ts"));
 }
 
-type ManifestKind = "paper" | "chapter" | null;
-
 /**
  * Detect what kind of manifest a directory's eponymous .ts file is.
  * Returns "paper", "chapter", or null if no manifest exists.
@@ -51,15 +49,24 @@ type ManifestKind = "paper" | "chapter" | null;
  * exported object against PaperSchema and ChapterSchema. The data itself
  * determines the type — no source-text heuristics.
  */
-async function detectManifestKind(dir: string): Promise<{ kind: ManifestKind; path: string | null; data?: any }> {
+// Discriminated on `kind`: `data` is the manifest each branch just validated,
+// so callers get `Paper` or `Chapter` rather than re-asserting it.
+type ManifestDetection =
+  | { kind: "paper"; path: string; data: Paper }
+  | { kind: "chapter"; path: string; data: Chapter }
+  | { kind: null; path: null; data?: undefined };
+
+async function detectManifestKind(dir: string): Promise<ManifestDetection> {
   const dirName = basename(dir);
   const manifestPath = join(dir, `${dirName}.ts`);
   if (!existsSync(manifestPath)) return { kind: null, path: null };
   try {
     const mod = await import(manifestPath);
     const obj = mod.default;
-    if (PaperSchema.safeParse(obj).success) return { kind: "paper", path: manifestPath, data: obj };
-    if (ChapterSchema.safeParse(obj).success) return { kind: "chapter", path: manifestPath, data: obj };
+    const asPaper = PaperSchema.safeParse(obj);
+    if (asPaper.success) return { kind: "paper", path: manifestPath, data: obj as Paper };
+    const asChapter = ChapterSchema.safeParse(obj);
+    if (asChapter.success) return { kind: "chapter", path: manifestPath, data: obj as Chapter };
   } catch { /* import error — not a valid manifest */ }
   return { kind: null, path: null };
 }
@@ -501,7 +508,7 @@ export async function validateObjects(
 
     for (const rule of CONSTRAINT_RULES) {
       if (!rule.appliesTo.includes(block.kind)) continue;
-      const msg = rule.check(block as any, ctx);
+      const msg = rule.check(block, ctx);
       if (msg) {
         const isWarning = msg.startsWith("[warning]");
         issues.push({

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,13 +22,15 @@ import tseslint from "typescript-eslint";
  *           rest of it being parsed as code. bun could not load that file.
  *
  *   WARN  — gradual-typing and module-style debt that is real but is a
- *           project-wide decision, not something to fail a build over:
- *           `no-explicit-any` (190 of the 356), `no-require-imports`,
- *           `no-unsafe-function-type`, `no-this-alias`.
+ *           project-wide decision, not something to fail a build over. This
+ *           tier is now EMPTY: `no-require-imports`, `no-unsafe-function-type`
+ *           and `no-this-alias` were drained first, and `no-explicit-any` —
+ *           190 of the original 356 — followed. Every rule is an error.
  *
  * Warnings are counted, not hidden. `bun run lint` reports them; the backlog
  * is visible without being a blocker. Tighten by promoting a rule here once
- * its count reaches zero.
+ * its count reaches zero — and promote it the moment it does, so the count
+ * cannot creep back up behind a warning nobody reads.
  */
 export default tseslint.config(
   {
@@ -80,13 +82,22 @@ export default tseslint.config(
       // `this`. An arrow captures it lexically and the alias disappears.
       "@typescript-eslint/no-this-alias": "error",
 
-      // ── The remaining debt ─────────────────────────────────────
-      // `no-explicit-any`: 201 over 194 files, and the ONLY rule still on
-      // warn. Unlike the four above it is not a sweep — each `any` is a
-      // separate typing decision, and a blanket replacement with `unknown`
-      // would either not compile or push casts to every call site. It wants
-      // a plan (bean lnt1) before anyone starts.
-      "@typescript-eslint/no-explicit-any": "warn",
+      // Driven to 0 from 201 over 194 files (bean lnt1) — the last rule to
+      // come off `warn`, and the only one that was never a sweep: each `any`
+      // was a separate typing decision, and a blanket replacement with
+      // `unknown` would either not compile or push a cast to every call site.
+      //
+      // A rule is an error only once its count is zero, and this one now is,
+      // so the escape hatch closes here rather than sitting on `warn` while
+      // the count creeps back. What the drain surfaced, in short: the skill
+      // registry never validated against its own schema; three schemas had
+      // drifted from the data (a second `FeedbackItem`, a second
+      // `LifecycleStage`, `SkillDefinition` missing two fields present on
+      // 18/18 files); `blk.status` was a phantom in both resolvers;
+      // `renderBlock` was being handed a `ResolvedBlock`; feedback
+      // status/priority were written to `main` unvalidated; PACKAGES.md had
+      // always shipped empty; and five mdast guards could never fire.
+      "@typescript-eslint/no-explicit-any": "error",
     },
   },
 );

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   "devDependencies": {
     "@playwright/test": "^1.60.0",
     "bun-types": "latest",
+    "csl-json": "^0.1.0",
     "eslint": "^10.8.0",
     "typescript-eslint": "^8.66.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": false,
   "type": "module",
-  "description": "Content-agnostic assistant platform — MCP server, auth, UI, deploy. Pluggable content adapters for papers, guidelines, documentation.",
+  "description": "Content-agnostic assistant platform \u2014 MCP server, auth, UI, deploy. Pluggable content adapters for papers, guidelines, documentation.",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -45,7 +45,8 @@
     "check-deps": "bun run src/index.ts --check-deps",
     "test:e2e": "playwright test",
     "test": "bun test",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.104.2",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "bun-types": "latest",
     "csl-json": "^0.1.0",
     "eslint": "^10.8.0",
+    "fast-xml-parser": "^5.10.1",
     "typescript-eslint": "^8.66.0"
   },
   "engines": {

--- a/schemas/assistant-types.ts
+++ b/schemas/assistant-types.ts
@@ -222,6 +222,8 @@ export interface SkillValidator {
  * enabling auto-generated documentation to cross-reference skills
  * with their data models.
  */
+import type { LifecycleStage, SkillPackageManifest } from "./types.js";
+
 export interface SkillSchemaRef {
   /** Schema module (e.g., "schemas/types", "schemas/formalization-types"). */
   module: string;
@@ -287,6 +289,21 @@ export interface SkillDefinition {
   package?: string;
   /** Schema types this skill reads/writes — for doc cross-referencing. */
   schemas?: SkillSchemaRef[];
+  /**
+   * Lifecycle stages this skill participates in.
+   *
+   * Present on all 18 skill definitions on disk and on `SkillDefinitionSchema`,
+   * but missing here — so `scripts/generate-docs.ts`, which renders it, had to
+   * read it off an `any`.
+   */
+  lifecycleStages?: LifecycleStage[];
+  /**
+   * Directory holding this skill's own JSON Schema files, relative to the repo
+   * root (e.g. `schemas/skills/content-author`). Also 18/18 on disk, also on
+   * the Zod schema, also missing here. Distinct from `schemas` above, which
+   * names TypeScript modules and types rather than a directory.
+   */
+  schemaRef?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -478,8 +495,22 @@ export interface SkillRegistry {
   skills: SkillDefinition[];
   /** All workflow requirements. */
   requirements: Requirement[];
-  /** External skill package references. */
-  packages: SkillPackageRef[];
+  /**
+   * Skill packages under `skills/`, with their Docker requirements.
+   *
+   * Declared `SkillPackageRef[]` until now — the type for an *external*
+   * package synced in from another repo, requiring `repo`/`path`/`ref`. The
+   * generator has only ever put local `skills/<name>/package-manifest.json`
+   * files here, which carry none of those, so no generated registry has ever
+   * satisfied `SkillRegistrySchema`: 15 issues, all `packages.N.{repo,path,ref}
+   * Required`. Nothing noticed because the generator's own output type was
+   * `any[]` and nothing validated the result. `scripts/tests/registry.test.ts`
+   * now does.
+   *
+   * External packages are `RemotePackageRef`s under `skills/remote-packages/`;
+   * they are rendered into the docs but are not yet part of the registry.
+   */
+  packages: SkillPackageManifest[];
   /** Lifecycle hooks. */
   hooks: SessionHook[];
   /** Identity-source → actor mapping rules, evaluated by priority (highest first). */

--- a/schemas/assistant-workflow.ts
+++ b/schemas/assistant-workflow.ts
@@ -9,30 +9,29 @@
  * ## Lifecycle stages
  *
  * ```
- * ┌─────────┐     ┌──────────┐     ┌──────────┐     ┌──────┐
- * │ DEVELOP │────▶│ VALIDATE │────▶│  REVIEW  │────▶│ TEST │
- * └─────────┘     └──────────┘     └──────────┘     └──────┘
- *       ▲               │                │               │
- *       │               ▼                ▼               ▼
- *       │          ┌─────────┐     ┌─────────┐     ┌─────────┐
- *       └──────────│ REVISE  │◀────│ REVISE  │◀────│ REVISE  │
- *                  └─────────┘     └─────────┘     └─────────┘
- *                                                        │
- *                                                        ▼
- *                  ┌──────────┐     ┌──────────┐
- *                  │ FEEDBACK │◀────│ PUBLISH  │
- *                  └──────────┘     └──────────┘
- *                       │
- *                       ▼
- *                  ┌─────────┐
- *                  │ DEVELOP │  (new cycle)
- *                  └─────────┘
+ * ┌──────┐     ┌────────┐     ┌──────────┐     ┌──────────┐     ┌──────┐
+ * │ PLAN │────▶│ AUTHOR │────▶│ VALIDATE │────▶│  REVIEW  │────▶│ TEST │
+ * └──────┘     └────────┘     └──────────┘     └──────────┘     └──────┘
+ *                    ▲              │                │              │
+ *                    │              ▼                ▼              ▼
+ *                    └──────────────┴────────────────┴──────────────┘
+ *                                    (rework)                       │
+ *                                                                   ▼
+ *              ┌────────┐     ┌──────────┐     ┌──────────┐
+ *              │ RETIRE │◀────│ FEEDBACK │◀────│ PUBLISH  │
+ *              └────────┘     └──────────┘     └──────────┘
+ *                                   │
+ *                                   ▼
+ *                              ┌────────┐
+ *                              │ AUTHOR │  (new cycle)
+ *                              └────────┘
  * ```
  *
  * @module assistant-workflow
  */
 
 import type { Conformance } from "./assistant-types";
+import type { LifecycleStage } from "./types.js";
 
 // ---------------------------------------------------------------------------
 // Lifecycle stages
@@ -43,22 +42,26 @@ import type { Conformance } from "./assistant-types";
  *
  * | Stage | Description | Key activities |
  * |-------|-------------|----------------|
- * | `develop` | Create or modify content | Authoring, formalization, editing |
+ * | `plan` | Scope the work | Outlining, dependency ordering, triage |
+ * | `author` | Create or modify content | Authoring, formalization, editing |
  * | `validate` | Automated checks | Schema, AST, constraint, type checking |
  * | `review` | Human or agent review | Accuracy, style, proof correctness |
  * | `test` | Integration testing | Build, CI, regression, proof compilation |
  * | `publish` | Release to audience | PDF, HTML, gh-pages, IG Publisher |
  * | `feedback` | Collect responses | Todos, issues, comments, annotations |
- * | `revise` | Address feedback | Bug fixes, proof corrections, edits |
+ * | `retire` | Withdraw content | Deprecation, supersession, archival |
+ *
+ * Re-exported from `./types.js`, where it is `z.infer` of
+ * `LifecycleStageSchema` — not redeclared. This module used to declare its own
+ * seven-member version with `develop` and `revise` in place of `plan`,
+ * `author` and `retire`. Every stage value on disk (18 skill definitions and 5
+ * package manifests) comes from the Zod enum: `author` alone appears 18 times,
+ * `plan` 7 and `retire` 4, while `develop` and `revise` appear nowhere at all.
+ * The redeclared type was unreachable from the `schemas/` barrel, which
+ * exports `types.js` and not this module, so the two never met and the wrong
+ * one simply sat here contradicting the published schema reference.
  */
-export type LifecycleStage =
-  | "develop"
-  | "validate"
-  | "review"
-  | "test"
-  | "publish"
-  | "feedback"
-  | "revise";
+export type { LifecycleStage };
 
 /**
  * A transition between lifecycle stages.
@@ -98,14 +101,14 @@ export interface StageSkillBinding {
  * const mathWorkflow: WorkflowDefinition = {
  *   id: "authoring-math",
  *   name: "Formal Mathematics Authoring",
- *   stages: ["develop", "validate", "review", "test", "publish", "feedback"],
+ *   stages: ["author", "validate", "review", "test", "publish", "feedback"],
  *   transitions: [
- *     { from: "develop", to: "validate", trigger: "auto" },
+ *     { from: "author", to: "validate", trigger: "auto" },
  *     { from: "validate", to: "review", trigger: "auto",
  *       gates: ["REQ-CCR-1"] },
  *   ],
  *   bindings: [
- *     { stage: "develop", skills: [
+ *     { stage: "author", skills: [
  *       { skillId: "formalizer", conformance: "SHALL",
  *         role: "Generate Lean proofs" },
  *     ]},
@@ -144,23 +147,29 @@ export const mathAuthoringWorkflow: WorkflowDefinition = {
   description:
     "Content development lifecycle for formal mathematics papers: " +
     "Lean 4 formalization, LaTeX rendering, proof review, and publication.",
-  stages: ["develop", "validate", "review", "test", "publish", "feedback", "revise"],
+  // `develop` and `revise` were this workflow's own names for two stages the
+  // canonical `LifecycleStage` enum does not distinguish: both are `author`
+  // (first draft and rework alike). Merged rather than kept, because they
+  // were only expressible while this module declared a private copy of the
+  // enum. If the distinction is worth keeping, the fix is the other
+  // direction — add a member to `LifecycleStageSchema` so every consumer
+  // sees it — not a second vocabulary here.
+  stages: ["author", "validate", "review", "test", "publish", "feedback"],
   transitions: [
-    { from: "develop", to: "validate", trigger: "auto" },
+    { from: "author", to: "validate", trigger: "auto" },
     { from: "validate", to: "review", trigger: "auto", gates: ["REQ-CCR-1", "REQ-CCR-2"] },
     { from: "review", to: "test", trigger: "manual" },
     { from: "test", to: "publish", trigger: "ci", gates: ["REQ-CH-1"] },
     { from: "publish", to: "feedback", trigger: "auto" },
-    { from: "feedback", to: "revise", trigger: "manual" },
-    { from: "revise", to: "develop", trigger: "manual" },
-    // Short-circuit: validation failures go back to develop
-    { from: "validate", to: "revise", trigger: "auto" },
-    { from: "review", to: "revise", trigger: "manual" },
-    { from: "test", to: "revise", trigger: "auto" },
+    { from: "feedback", to: "author", trigger: "manual" },
+    // Short-circuit: a failed gate sends the content back to authoring
+    { from: "validate", to: "author", trigger: "auto" },
+    { from: "review", to: "author", trigger: "manual" },
+    { from: "test", to: "author", trigger: "auto" },
   ],
   bindings: [
     {
-      stage: "develop",
+      stage: "author",
       skills: [
         { skillId: "editor", conformance: "SHALL", role: "Coordinate session, triage tasks" },
         { skillId: "formalizer", conformance: "SHALL", role: "Generate/complete Lean proofs" },
@@ -168,6 +177,10 @@ export const mathAuthoringWorkflow: WorkflowDefinition = {
         { skillId: "lean-generation", conformance: "SHOULD", role: "Extract Lean stubs from LaTeX" },
         { skillId: "ontologist", conformance: "MAY", role: "Term disambiguation, glossary" },
         { skillId: "paper-importer", conformance: "MAY", role: "Import from arXiv" },
+        // Folded in from the former `revise` stage; `editor` was SHALL in
+        // both and is not repeated.
+        { skillId: "proof-simplifier", conformance: "MAY", role: "Streamline completed proofs" },
+        { skillId: "chapter-analysis", conformance: "MAY", role: "Structural review" },
       ],
     },
     {
@@ -206,14 +219,6 @@ export const mathAuthoringWorkflow: WorkflowDefinition = {
       stage: "feedback",
       skills: [
         { skillId: "todo-review", conformance: "SHALL", role: "Process feedback into TodoItems" },
-      ],
-    },
-    {
-      stage: "revise",
-      skills: [
-        { skillId: "editor", conformance: "SHALL", role: "Triage revision tasks" },
-        { skillId: "proof-simplifier", conformance: "MAY", role: "Streamline completed proofs" },
-        { skillId: "chapter-analysis", conformance: "MAY", role: "Structural review" },
       ],
     },
   ],

--- a/schemas/builders.ts
+++ b/schemas/builders.ts
@@ -17,6 +17,7 @@ import type {
   SkillPackageManifest,
   RemotePackageRef,
   DefinitionBlock,
+  LeanRef,
   TheoremBlock,
   LemmaBlock,
   PropositionBlock,
@@ -123,15 +124,20 @@ function validated<T>(schema: { parse: (v: unknown) => unknown }, data: T): T {
 
 // ── Block builders ───────────────────────────────────────────────
 
-export function definition(data: Omit<DefinitionBlock, "kind">): DefinitionBlock {
+// `DefinitionBlock.lean` is required, so `Omit<…, "kind">` could not express
+// the very case this builder exists to handle — a partially-authored
+// definition with no ref yet. The `as any` below was standing in for that.
+export function definition(
+  data: Omit<DefinitionBlock, "kind" | "lean"> & { lean?: LeanRef },
+): DefinitionBlock {
   // Provide default lean ref so partially-authored definitions
   // load instead of crashing the viewer/MCP server with Zod errors.
   // Uses the qou package by default; callers working in other papers
   // must pass an explicit `lean.ref`.
   const label = data.label || "def:unknown";
   const defaultDecl = "QOU." + label.replace(/^def:/, "").replace(/-./g, m => m[1].toUpperCase()).replace(/^./, c => c.toUpperCase());
-  if (!data.lean) (data as any).lean = { ref: `qou:${defaultDecl}` };
-  return validated(DefinitionSchema, { kind: "definition" as const, ...data });
+  const lean = data.lean ?? { ref: `qou:${defaultDecl}` };
+  return validated(DefinitionSchema, { kind: "definition" as const, ...data, lean });
 }
 
 export function theorem(data: Omit<TheoremBlock, "kind">): TheoremBlock {

--- a/schemas/constraints.ts
+++ b/schemas/constraints.ts
@@ -404,6 +404,13 @@ export const DefinitionSchema = BlockBaseSchema.extend({
 });
 
 const ProvableBaseSchema = BlockBaseSchema.extend({
+  // TS `ProvableBase` declares `lean?: LeanRef`; only `DefinitionSchema`
+  // declared it here, so a theorem / lemma / proposition / corollary /
+  // algorithm writing `lean: { ref: … }` had it SILENTLY STRIPPED at the
+  // validation boundary — the link into Lean, on exactly the kinds whose
+  // whole point is to carry one. Optional, matching TS: `DefinitionSchema`
+  // keeps its own required override.
+  lean: LeanRefSchema.optional(),
   proofs: z.array(z.string()).optional(),
   examples: z.array(z.string()).optional(),
 });
@@ -474,6 +481,10 @@ export const ConjectureSchema = BlockBaseSchema.extend({
 export const ExampleSchema = BlockBaseSchema.extend({
   kind: z.literal("example"),
   label: labelForKind("example"),
+  /** Label of the provable block this example interprets. Declared on TS
+   *  `ExampleBlock` and missing here, unlike its `algorithm` and `remark`
+   *  siblings — so it was silently stripped. `.min(1)` matches theirs. */
+  interprets: z.string().min(1).optional(),
   lean: LeanRefSchema.optional(),
 });
 
@@ -507,6 +518,11 @@ export const ComputationSchema = z.object({
 export const ProofSchema = BlockBaseSchema.extend({
   kind: z.literal("proof"),
   label: labelForKind("proof"),
+  // The canonical reverse link to the provable this proof establishes
+  // (`ProvableBase.proofs[]` is the forward one). Declared on TS
+  // `ProofBlock`, missing here — so it was silently stripped. Eight proof
+  // blocks in qou carry it.
+  of: z.string().optional(),
   lean: LeanRefSchema.optional(),
   computation: ComputationSchema.optional(),
 });
@@ -522,8 +538,10 @@ export const SimulatorSchema = BlockBaseSchema.extend({
 export const ProseSchema = z.object({
   kind: z.literal("prose"),
   label: z.string().optional(),
+  title: z.string().optional(),
   cites: z.array(z.string()).optional(),
   tags: z.array(z.string()).optional(),
+  uses: z.array(z.string()).optional(),
   companions: CompanionsSchema.optional(),
   rendered: z.array(RenderedAssetSchema).optional(),
   meta: z.record(z.string(), z.unknown()).optional(),
@@ -533,8 +551,10 @@ export const ProseSchema = z.object({
 export const EquationSchema = z.object({
   kind: z.literal("equation"),
   label: labelForKind("equation").optional(),
+  title: z.string().optional(),
   tex: z.string().optional(),
   tags: z.array(z.string()).optional(),
+  uses: z.array(z.string()).optional(),
   companions: CompanionsSchema.optional(),
   rendered: z.array(RenderedAssetSchema).optional(),
   meta: z.record(z.string(), z.unknown()).optional(),
@@ -544,9 +564,11 @@ export const EquationSchema = z.object({
 export const DiagramSchema = z.object({
   kind: z.literal("diagram"),
   label: labelForKind("diagram").optional(),
+  title: z.string().optional(),
   tex: z.string().optional(),
   caption: z.string().optional(),
   tags: z.array(z.string()).optional(),
+  uses: z.array(z.string()).optional(),
   companions: CompanionsSchema.optional(),
   rendered: z.array(RenderedAssetSchema).optional(),
   meta: z.record(z.string(), z.unknown()).optional(),
@@ -794,10 +816,16 @@ export const CONSTRAINT_RULES: ConstraintRule[] = [
     appliesTo: [
       "definition", "theorem", "lemma", "proposition", "corollary",
       "conjecture", "example", "remark", "simulator",
+      "algorithm", "proof", "prose", "equation", "diagram", "table",
     ],
     check: (block, ctx) => {
       if (!("uses" in block) || !block.uses) return null;
       const missing = block.uses.filter((u: string) => {
+        // An empty entry is never resolvable and must be reported as one —
+        // not skipped. Ten `*-table-data` blocks in qou carry `uses: [""]`
+        // beside `title: "Data table N from "`, an extraction generator that
+        // failed to substitute its source label.
+        if (u.trim() === "") return true;
         // Cross-paper qualified ref: "paper-dir:label" (contains exactly
         // one colon-delimited paper prefix before the label-kind prefix).
         // Pattern: non-label chars, colon, then a standard label.
@@ -809,8 +837,11 @@ export const CONSTRAINT_RULES: ConstraintRule[] = [
         // Same-paper ref — must exist in allLabels
         return !ctx.allLabels.has(u);
       });
+      // Quote each label: an empty entry rendered bare produced
+      // "Unresolved uses: " with nothing after it, which reads as a checker
+      // bug rather than as the content defect it is.
       return missing.length === 0 ? null
-        : `Unresolved uses: ${missing.join(", ")}`;
+        : `Unresolved uses: ${missing.map((u: string) => JSON.stringify(u)).join(", ")}`;
     },
   },
   {

--- a/schemas/constraints.ts
+++ b/schemas/constraints.ts
@@ -9,6 +9,7 @@
 import { z } from "zod";
 
 import { LEAN_REF_PATTERN, leanPackageByName, parseLeanRef } from "./lean-packages.js";
+import type { Block } from "./types.js";
 
 
 // ─── Enumerations ────────────────────────────────────────────────────────────
@@ -722,7 +723,7 @@ export interface ConstraintRule {
   /** Which block kinds this rule applies to. */
   appliesTo: string[];
   /** Check function — returns error message or null. */
-  check: (block: z.infer<typeof BlockSchema>, context: ConstraintContext) => string | null;
+  check: (block: Block, context: ConstraintContext) => string | null;
 }
 
 export interface ConstraintContext {

--- a/schemas/constraints.ts
+++ b/schemas/constraints.ts
@@ -91,6 +91,13 @@ export const SkillValidatorSchema = z.object({
   scope: ValidatorScopeSchema,
 });
 
+/** Mirrors `SkillSchemaRef` — a TS module + the type names a skill touches. */
+export const SkillSchemaRefSchema = z.object({
+  module: z.string().min(1),
+  types: z.array(z.string()),
+  access: z.enum(["read", "write", "read-write"]),
+});
+
 export const SkillDefinitionSchema = z.object({
   id: z.string().min(1),
   name: z.string().min(1),
@@ -105,6 +112,10 @@ export const SkillDefinitionSchema = z.object({
   routingPatterns: z.array(z.string()).optional(),
   tags: z.array(z.string()).optional(),
   package: z.string().optional(),
+  // `SkillDefinition.schemas` is documented and appears in the interface's own
+  // example, but had no counterpart here — so `.parse()` stripped it off any
+  // skill that used one. Same defect as `lean` on the provable blocks.
+  schemas: z.array(SkillSchemaRefSchema).optional(),
   lifecycleStages: z.array(LifecycleStageSchema).optional(),
   schemaRef: z.string().optional(),
 });
@@ -165,17 +176,6 @@ export const RoleAssignmentSchema = z.object({
   priority: z.number(),
 });
 
-export const SkillRegistrySchema = z.object({
-  schemaVersion: z.literal("1.0"),
-  repository: z.string(),
-  actors: z.array(ActorDefinitionSchema),
-  capabilities: z.array(CapabilityDefinitionSchema),
-  skills: z.array(SkillDefinitionSchema),
-  requirements: z.array(RequirementSchema),
-  packages: z.array(SkillPackageRefSchema),
-  hooks: z.array(SessionHookSchema),
-});
-
 // ─── Docker Requirements ─────────────────────────────────────────────────────
 
 export const DockerRequirementsSchema = z.object({
@@ -199,6 +199,24 @@ export const SkillPackageManifestSchema = z.object({
   requiresCapabilities: z.array(z.string()).optional(),
   lifecycleStages: z.array(LifecycleStageSchema).optional(),
   schemas: z.array(z.string()).optional(),
+});
+
+export const SkillRegistrySchema = z.object({
+  schemaVersion: z.literal("1.0"),
+  repository: z.string(),
+  actors: z.array(ActorDefinitionSchema),
+  capabilities: z.array(CapabilityDefinitionSchema),
+  skills: z.array(SkillDefinitionSchema),
+  requirements: z.array(RequirementSchema),
+  // Local `skills/<name>/package-manifest.json` files, which is what the
+  // generator has always written here — not `SkillPackageRefSchema`, whose
+  // required `repo`/`path`/`ref` made every generated registry invalid.
+  packages: z.array(SkillPackageManifestSchema),
+  hooks: z.array(SessionHookSchema),
+  // `SkillRegistry.roleAssignments` is required by the TS interface but was
+  // absent here, so the field was stripped by `.parse()` — on top of the
+  // generator never populating it in the first place.
+  roleAssignments: z.array(RoleAssignmentSchema),
 });
 
 // ─── Remote Package Reference ────────────────────────────────────────────────

--- a/schemas/lean-packages.ts
+++ b/schemas/lean-packages.ts
@@ -27,7 +27,9 @@ export function configureLeanPackages(packages: readonly LeanPackage[]) {
 
 // Export the array as a proxy so it always reads the injected state
 export const LEAN_PACKAGES: readonly LeanPackage[] = new Proxy([] as LeanPackage[], {
-  get: (target, prop) => (configuredPackages as any)[prop],
+  // `Reflect.get` reads an arbitrary key off the injected array without
+  // reopening its element type.
+  get: (_target, prop) => Reflect.get(configuredPackages, prop),
   ownKeys: () => Reflect.ownKeys(configuredPackages),
   getOwnPropertyDescriptor: (_, prop) => Reflect.getOwnPropertyDescriptor(configuredPackages, prop),
   has: (_, key) => key in configuredPackages,

--- a/schemas/types.ts
+++ b/schemas/types.ts
@@ -898,6 +898,15 @@ export interface EquationBlock {
   kind: "equation";
   /** Equation label (e.g. "eq:snake-identities"). */
   label?: string;
+  /** Optional display title. */
+  title?: string;
+  tags?: string[];
+  /** Editorial dependencies — see `BlockBase.uses`. Equation was the ONLY
+   *  member of the `Block` union carrying neither `uses` nor a base that
+   *  supplies it; its three standalone siblings (`prose`, `diagram`, `table`)
+   *  all declare it. `tags` was likewise present in the Zod schema and absent
+   *  here. */
+  uses?: string[];
   /** Inline TeX for the equation (short enough to live in .ts). */
   tex?: string;
   companions?: Companions;

--- a/scripts/audit-wiring.ts
+++ b/scripts/audit-wiring.ts
@@ -53,6 +53,24 @@ import { readFileSync, mkdirSync, writeFileSync } from "fs";
 import { resolve, dirname, relative } from "path";
 import { globSync } from "glob";
 import { execSync } from "child_process";
+import type { ComputationWitness } from "../schemas/types.ts";
+
+/**
+ * A `.witness.json` as it appears on disk.
+ *
+ * Every field is optional and read defensively: these files are produced by
+ * the folio's Python `WitnessBuilder` and can be malformed (this script
+ * counts that case), so nothing here is guaranteed. `scriptFile`,
+ * `scriptHash`, `scriptCommitSha` and `git_sha` are written by the builder
+ * but are NOT on `ComputationWitness` in `schemas/types.ts` — the two have
+ * drifted, and the drift is only visible once this stops being `any`.
+ */
+interface WitnessFile extends Partial<ComputationWitness> {
+  scriptFile?: string;
+  scriptHash?: string;
+  scriptCommitSha?: string;
+  git_sha?: string;
+}
 
 const REPO_ROOT = resolve(import.meta.dir, "..");
 
@@ -317,13 +335,13 @@ function audit(args: Args): BucketResult {
     report.totals.total++;
     dirBucket.total++;
 
-    let witness: any = null;
+    let witness: WitnessFile | null = null;
     let malformed = false;
     const rawText = (() => {
       try { return readFileSync(wf, "utf-8"); } catch { return ""; }
     })();
     try {
-      witness = JSON.parse(rawText);
+      witness = JSON.parse(rawText) as WitnessFile;
     } catch {
       malformed = true;
     }

--- a/scripts/extract-lean-blocks.py
+++ b/scripts/extract-lean-blocks.py
@@ -6,7 +6,6 @@ and writes individual .lean files alongside their .ts/.md siblings.
 """
 
 import re
-import os
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent

--- a/scripts/find-arxiv-mirrors.py
+++ b/scripts/find-arxiv-mirrors.py
@@ -30,7 +30,6 @@ Usage:
 """
 
 import argparse
-import json
 import re
 import time
 import urllib.parse
@@ -38,7 +37,6 @@ import urllib.request
 import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 REFS_TS = REPO_ROOT / "content" / "schema" / "references.ts"

--- a/scripts/fix-cross-cluster-witness-loads.py
+++ b/scripts/fix-cross-cluster-witness-loads.py
@@ -33,7 +33,6 @@ from __future__ import annotations
 
 import argparse
 import re
-import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent

--- a/scripts/fix-moved-scripts.py
+++ b/scripts/fix-moved-scripts.py
@@ -35,7 +35,6 @@ from __future__ import annotations
 
 import argparse
 import re
-import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent

--- a/scripts/fix-root-script-shim.py
+++ b/scripts/fix-root-script-shim.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 import argparse
 import re
-import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -39,7 +39,20 @@ import {
   DockerRequirementsSchema,
   SkillPackageManifestSchema,
   RemotePackageRefSchema,
+  LifecycleStageSchema,
 } from "../schemas/constraints.js";
+import type { z } from "zod";
+import type {
+  ActorDefinition, CapabilityDefinition, Requirement, SkillDefinition,
+} from "../schemas/assistant-types.ts";
+// `assistant-package.ts` also exports a `PackageManifest` — a Docker BUILD
+// manifest (`packageId`, `baseImage`, `apt`, `installers`). The files under
+// `skills/*/package-manifest.json` are the other thing of that name, matching
+// `SkillPackageManifestSchema` exactly on all nine keys.
+import type { SkillPackageManifest } from "../schemas/types.ts";
+
+/** No TS interface mirrors this one — the Zod schema is its definition. */
+type RemotePackageRef = z.infer<typeof RemotePackageRefSchema>;
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = join(__dirname, "..");
@@ -49,40 +62,71 @@ mkdirSync(outDir, { recursive: true });
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-function loadJsonDir(dir: string): { name: string; data: any }[] {
+/** One `<name>.json` per definition, parsed. Callers say what `T` is. */
+function loadJsonDir<T>(dir: string): { name: string; data: T }[] {
   if (!existsSync(dir)) return [];
   return readdirSync(dir)
     .filter(f => f.endsWith(".json"))
     .map(f => {
       try {
-        return { name: f.replace(".json", ""), data: JSON.parse(readFileSync(join(dir, f), "utf-8")) };
+        return { name: f.replace(".json", ""), data: JSON.parse(readFileSync(join(dir, f), "utf-8")) as T };
       } catch { return null; }
     })
-    .filter(Boolean) as any[];
+    .filter((x): x is { name: string; data: T } => x !== null);
 }
 
-function formatType(def: any): string {
+/**
+ * The subset of a JSON Schema node this renderer reads.
+ *
+ * Hand-declared rather than borrowed from `zod-to-json-schema`, whose
+ * `JsonSchema7Type` is a 24-arm union: every access here would need a
+ * narrowing step for a renderer that is deliberately shape-tolerant and falls
+ * through to "`object`". Naming the fields it does read is what stops a typo
+ * in one of them from silently rendering every type as "`object`".
+ */
+interface JsonSchemaNode {
+  // Other keywords pass through untouched; the index signature says so, and
+  // keeps a `zod-to-json-schema` node — whose `anyOf` arms may be bare
+  // `{format}` objects — assignable without a cast.
+  [keyword: string]: unknown;
+}
+
+/** Treat an arbitrary JSON value as a schema node; non-objects have none. */
+const node = (v: unknown): JsonSchemaNode | undefined =>
+  v !== null && typeof v === "object" ? (v as JsonSchemaNode) : undefined;
+
+/** A keyword read as a string, or `undefined` if it is absent or not one. */
+const str = (v: unknown): string | undefined => (typeof v === "string" ? v : undefined);
+
+/** A keyword read as an array, or `undefined`. */
+const arr = (v: unknown): unknown[] | undefined => (Array.isArray(v) ? v : undefined);
+
+function formatType(def: JsonSchemaNode | undefined): string {
   if (!def) return "`any`";
-  if (def.type === "array") return `${formatType(def.items || {})}[]`;
-  if (def.type) return `\`${def.type}\``;
-  if (def.enum) return def.enum.map((e: string) => `\`"${e}"\``).join(" | ");
-  if (def.anyOf) return def.anyOf.map((a: any) => formatType(a)).join(" | ");
-  if (def.oneOf) return def.oneOf.map((a: any) => formatType(a)).join(" | ");
-  if (def.const) return `\`"${def.const}"\``;
-  if (def.$ref) return `\`${def.$ref.split("/").pop()}\``;
+  if (def.type === "array") return `${formatType(node(def.items) ?? {})}[]`;
+  if (def.type) return `\`${String(def.type)}\``;
+  const enums = arr(def.enum);
+  if (enums) return enums.map((e) => `\`"${String(e)}"\``).join(" | ");
+  const anyOf = arr(def.anyOf);
+  if (anyOf) return anyOf.map((a) => formatType(node(a))).join(" | ");
+  const oneOf = arr(def.oneOf);
+  if (oneOf) return oneOf.map((a) => formatType(node(a))).join(" | ");
+  if (def.const) return `\`"${String(def.const)}"\``;
+  const ref = str(def.$ref);
+  if (ref) return `\`${ref.split("/").pop()}\``;
   return "`object`";
 }
 
-function jsonSchemaPropsTable(schema: any): string[] {
+function jsonSchemaPropsTable(schema: JsonSchemaNode | undefined): string[] {
   const lines: string[] = [];
-  const props = schema?.properties || {};
+  const props = node(schema?.properties) ?? {};
   if (Object.keys(props).length === 0) return lines;
-  const req = schema?.required || [];
+  const req = arr(schema?.required) ?? [];
   lines.push("| Property | Type | Required | Description |");
   lines.push("|----------|------|----------|-------------|");
   for (const [k, v] of Object.entries(props)) {
-    const d = v as any;
-    lines.push(`| \`${k}\` | ${formatType(d)} | ${req.includes(k) ? "Yes" : "No"} | ${d.description || ""} |`);
+    const d = node(v);
+    lines.push(`| \`${k}\` | ${formatType(d)} | ${req.includes(k) ? "Yes" : "No"} | ${str(d?.description) || ""} |`);
   }
   return lines;
 }
@@ -120,23 +164,29 @@ function getTransitiveRoles(actorId: string): Set<string> {
 
 // ─── Load all data ───────────────────────────────────────────────────────────
 
-const actors = loadJsonDir(join(rootDir, ".claude", "skills", "actors"));
-const capabilities = loadJsonDir(join(rootDir, ".claude", "skills", "capabilities"));
-const requirements = loadJsonDir(join(rootDir, ".claude", "skills", "requirements"));
-const skills = loadJsonDir(join(rootDir, ".claude", "skills", "local"));
-const remotePackages = loadJsonDir(join(rootDir, "skills", "remote-packages"));
+const actors = loadJsonDir<ActorDefinition>(join(rootDir, ".claude", "skills", "actors"));
+const capabilities = loadJsonDir<CapabilityDefinition>(join(rootDir, ".claude", "skills", "capabilities"));
+const requirements = loadJsonDir<Requirement>(join(rootDir, ".claude", "skills", "requirements"));
+const skills = loadJsonDir<SkillDefinition>(join(rootDir, ".claude", "skills", "local"));
+const remotePackages = loadJsonDir<RemotePackageRef>(join(rootDir, "skills", "remote-packages"));
 const skillSchemaDirs = existsSync(join(rootDir, "schemas", "skills"))
   ? readdirSync(join(rootDir, "schemas", "skills"), { withFileTypes: true }).filter(d => d.isDirectory()).map(d => d.name)
   : [];
-const packages = loadJsonDir(join(rootDir, "skills")).length > 0
+// Gated on `loadJsonDir(join(rootDir, "skills")).length > 0` until now — that
+// reads loose `*.json` files sitting DIRECTLY in `skills/`, and there have
+// never been any: every manifest lives one level down, in
+// `skills/<package>/package-manifest.json`. So the guard was always false,
+// `packages` was always `[]`, and PACKAGES.md shipped with an empty "Package
+// Summary" table and no per-package sections at all, for all five packages.
+const packages = existsSync(join(rootDir, "skills"))
   ? readdirSync(join(rootDir, "skills"), { withFileTypes: true })
       .filter(d => d.isDirectory())
       .map(d => {
         const mp = join(rootDir, "skills", d.name, "package-manifest.json");
-        try { return { name: d.name, data: JSON.parse(readFileSync(mp, "utf-8")) }; }
+        try { return { name: d.name, data: JSON.parse(readFileSync(mp, "utf-8")) as SkillPackageManifest }; }
         catch { return null; }
       })
-      .filter(Boolean) as any[]
+      .filter((x): x is { name: string; data: SkillPackageManifest } => x !== null)
   : [];
 
 // ─── 1. SCHEMAS.md — Core framework schemas ─────────────────────────────────
@@ -225,7 +275,7 @@ function generateSchemasMd(): string {
       L.push(`**Package:** ${skillDef.data.package || "local"}  `);
       L.push(`**Lifecycle:** ${(skillDef.data.lifecycleStages || []).join(", ")}  `);
       if (skillDef.data.mcpServices?.length) L.push(`**MCP Services:** ${skillDef.data.mcpServices.join(", ")}  `);
-      if (skillDef.data.scripts?.length) L.push(`**Scripts:** ${skillDef.data.scripts.map((s: any) => `\`${s.path}\` (${s.runtime})`).join(", ")}  `);
+      if (skillDef.data.scripts?.length) L.push(`**Scripts:** ${skillDef.data.scripts.map((s) => `\`${s.path}\` (${s.runtime})`).join(", ")}  `);
       L.push("");
     }
 
@@ -430,7 +480,9 @@ function generateCapabilitiesMd(): string {
   for (const c of capabilities) {
     const d = c.data;
     const det = d.detection;
-    let detStr = det.method;
+    // Annotated: inferred, this is the literal union of `det.method`, so
+    // every formatted branch below is a type error the `any` was hiding.
+    let detStr: string = det.method;
     if (det.method === "command") detStr = `command: \`${det.command}\``;
     else if (det.method === "env-var") detStr = `env: \`${det.variable}\``;
     else if (det.method === "file-exists") detStr = `file: \`${det.path}\``;
@@ -448,7 +500,7 @@ function generateCapabilitiesMd(): string {
     L.push(`**Detection:** \`${JSON.stringify(d.detection)}\`  `);
     if (d.requires?.length) L.push(`**Requires:** ${d.requires.map((r: string) => `\`${r}\``).join(", ")}  `);
     // Which skills need this?
-    const neededBy = skills.filter(s => s.data.requiredCapabilities?.some((rc: any) => rc.capabilityId === d.id));
+    const neededBy = skills.filter(s => s.data.requiredCapabilities?.some((rc) => rc.capabilityId === d.id));
     if (neededBy.length) L.push(`**Required by skills:** ${neededBy.map(s => `\`${s.data.id}\``).join(", ")}  `);
     // Which actors provide this?
     const providedBy = actors.filter(a => a.data.capabilities?.includes(d.id));
@@ -481,7 +533,7 @@ function generateRequirementsMd(): string {
     L.push("| Key | Label | Conformance | Requirement | Satisfied By |");
     L.push("|-----|-------|-------------|-------------|-------------|");
     for (const s of d.statements || []) {
-      const satBy = (s.satisfiedBy || []).map((sb: any) => `\`${sb.kind}:${sb.ref}\``).join(", ") || "—";
+      const satBy = (s.satisfiedBy || []).map((sb) => `\`${sb.kind}:${sb.ref}\``).join(", ") || "—";
       L.push(`| \`${s.key}\` | ${s.label} | **${s.conformance}** | ${s.requirement} | ${satBy} |`);
     }
     L.push("");
@@ -662,7 +714,9 @@ function generateLifecycleMd(): string {
   L.push(`> **Auto-generated** on ${timestamp()} — Do not edit manually.`);
   L.push("");
 
-  const stages = ["plan", "author", "validate", "review", "test", "publish", "feedback", "retire"];
+  // Was a hand-copied literal of the same eight values. Reading the enum is
+  // what keeps LIFECYCLE.md from documenting stages the schema rejects.
+  const stages = LifecycleStageSchema.options;
 
   L.push("## Lifecycle Flow");
   L.push("");

--- a/scripts/generate-registry.ts
+++ b/scripts/generate-registry.ts
@@ -12,38 +12,70 @@
 import { readFileSync, writeFileSync, readdirSync, existsSync, mkdirSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
+import type {
+  ActorDefinition, CapabilityDefinition, HookCommand, Requirement, RoleAssignment,
+  SessionHook, SkillDefinition, SkillRegistry,
+} from "../schemas/assistant-types.ts";
+import type { SkillPackageManifest } from "../schemas/types.ts";
 
+// `.claude/skills/` and `skills/` are PLATFORM directories, so rooting at this
+// file's own location is right here — unlike the content pipeline, which must
+// find the folio.
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = join(__dirname, "..");
 
-interface RegistryOutput {
-  schemaVersion: "1.0";
-  repository: string;
-  generatedAt: string;
-  actors: any[];
-  capabilities: any[];
-  skills: any[];
-  requirements: any[];
-  packages: any[];
-  hooks: any[];
-}
+/**
+ * The registry, plus the generation stamp that is not part of the schema.
+ *
+ * This used to be a parallel hand-written interface whose six collections were
+ * all `any[]`. Two things went wrong behind that. It omitted
+ * `roleAssignments` — a required field of `SkillRegistry`, with a populated
+ * `.claude/skills/roles/role-assignments.json` sitting on disk that nothing
+ * loaded, so every generated registry claimed the repo had no role rules at
+ * all. And `hooks` was emitted in the shape of raw `.claude/settings.json`
+ * entries rather than `SessionHook`, so `commands[]` held
+ * `{matcher, hooks[]}` objects instead of `HookCommand`s and `matcher` was
+ * never set. Naming the real type is what makes both impossible.
+ */
+type RegistryOutput = SkillRegistry & { generatedAt: string };
 
-function loadJsonFiles(dir: string): any[] {
+function loadJsonFiles<T>(dir: string): T[] {
   if (!existsSync(dir)) return [];
   return readdirSync(dir)
     .filter(f => f.endsWith(".json"))
     .map(f => {
       try {
-        return JSON.parse(readFileSync(join(dir, f), "utf-8"));
+        return JSON.parse(readFileSync(join(dir, f), "utf-8")) as T;
       } catch {
         console.warn(`  ⚠ Failed to parse ${join(dir, f)}`);
         return null;
       }
     })
-    .filter(Boolean);
+    .filter((x): x is T => x !== null);
 }
 
-function loadPackageManifests(): any[] {
+/**
+ * Role-assignment rules, highest priority first.
+ *
+ * The file holds `{ assignments: [...] }`; a bare array is also accepted so a
+ * hand-written file in either shape loads.
+ */
+function loadRoleAssignments(): RoleAssignment[] {
+  const p = join(rootDir, ".claude", "skills", "roles", "role-assignments.json");
+  if (!existsSync(p)) return [];
+  try {
+    const raw: unknown = JSON.parse(readFileSync(p, "utf-8"));
+    const list: RoleAssignment[] = Array.isArray(raw)
+      ? raw as RoleAssignment[]
+      : (raw as { assignments?: RoleAssignment[] }).assignments ?? [];
+    return [...list].sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
+  } catch {
+    console.warn(`  ⚠ Failed to parse ${p}`);
+    return [];
+  }
+}
+
+function loadPackageManifests(): SkillPackageManifest[] {
   const skillsDir = join(rootDir, "skills");
   if (!existsSync(skillsDir)) return [];
   return readdirSync(skillsDir, { withFileTypes: true })
@@ -52,43 +84,54 @@ function loadPackageManifests(): any[] {
       const manifestPath = join(skillsDir, d.name, "package-manifest.json");
       if (!existsSync(manifestPath)) return null;
       try {
-        return JSON.parse(readFileSync(manifestPath, "utf-8"));
+        return JSON.parse(readFileSync(manifestPath, "utf-8")) as SkillPackageManifest;
       } catch {
         console.warn(`  ⚠ Failed to parse ${manifestPath}`);
         return null;
       }
     })
-    .filter(Boolean);
+    .filter((x): x is SkillPackageManifest => x !== null);
 }
 
 // ─── Main ────────────────────────────────────────────────────────────────────
 
 console.log("Generating skill registry...\n");
 
-const pkg = JSON.parse(readFileSync(join(rootDir, "package.json"), "utf-8"));
+const pkg = JSON.parse(readFileSync(join(rootDir, "package.json"), "utf-8")) as { name?: string };
 
 const registry: RegistryOutput = {
   schemaVersion: "1.0",
   repository: pkg.name || "folio-assistant",
   generatedAt: new Date().toISOString(),
-  actors: loadJsonFiles(join(rootDir, ".claude", "skills", "actors")),
-  capabilities: loadJsonFiles(join(rootDir, ".claude", "skills", "capabilities")),
-  skills: loadJsonFiles(join(rootDir, ".claude", "skills", "local")),
-  requirements: loadJsonFiles(join(rootDir, ".claude", "skills", "requirements")),
+  actors: loadJsonFiles<ActorDefinition>(join(rootDir, ".claude", "skills", "actors")),
+  capabilities: loadJsonFiles<CapabilityDefinition>(join(rootDir, ".claude", "skills", "capabilities")),
+  skills: loadJsonFiles<SkillDefinition>(join(rootDir, ".claude", "skills", "local")),
+  requirements: loadJsonFiles<Requirement>(join(rootDir, ".claude", "skills", "requirements")),
   packages: loadPackageManifests(),
   hooks: [],
+  roleAssignments: loadRoleAssignments(),
 };
 
 // Load hooks from settings if they exist
 const settingsPath = join(rootDir, ".claude", "settings.json");
 if (existsSync(settingsPath)) {
   try {
-    const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+    const settings = JSON.parse(readFileSync(settingsPath, "utf-8")) as {
+      hooks?: Record<string, Array<{ matcher?: string; hooks?: HookCommand[] }>>;
+    };
     if (settings.hooks) {
-      registry.hooks = Object.entries(settings.hooks).map(([event, config]: [string, any]) => ({
-        event,
-        commands: Array.isArray(config) ? config : [config],
-      }));
+      // `.claude/settings.json` nests one level deeper than `SessionHook`:
+      //   { "<Event>": [ { matcher?, hooks: [ {type, command, timeout?} ] } ] }
+      // The old mapping wrapped that middle object straight into
+      // `commands[]`, so the registry advertised `HookCommand`s that were
+      // really `{matcher, hooks}` records, and dropped `matcher` entirely.
+      registry.hooks = Object.entries(settings.hooks).flatMap(
+        ([event, entries]) => (Array.isArray(entries) ? entries : [entries]).map((entry) => ({
+          event: event as SessionHook["event"],
+          matcher: entry?.matcher,
+          commands: (Array.isArray(entry?.hooks) ? entry.hooks : []) as HookCommand[],
+        })),
+      );
     }
   } catch {
     console.warn("  ⚠ Failed to parse .claude/settings.json");
@@ -105,4 +148,6 @@ console.log(`    Capabilities: ${registry.capabilities.length}`);
 console.log(`    Skills: ${registry.skills.length}`);
 console.log(`    Requirements: ${registry.requirements.length}`);
 console.log(`    Packages: ${registry.packages.length}`);
+console.log(`    Hooks: ${registry.hooks.length}`);
+console.log(`    Role assignments: ${registry.roleAssignments.length}`);
 console.log("\nDone.");

--- a/scripts/lake-cache-fetch-multi.py
+++ b/scripts/lake-cache-fetch-multi.py
@@ -37,7 +37,6 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
-import os
 import re
 import shutil
 import subprocess

--- a/scripts/lake-cache-produce.py
+++ b/scripts/lake-cache-produce.py
@@ -28,9 +28,7 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
-import os
 import re
 import shutil
 import subprocess

--- a/scripts/lean-coverage.ts
+++ b/scripts/lean-coverage.ts
@@ -286,6 +286,13 @@ interface Stats {
     percent_primary_class_axiomatized: number;
     /** legacy: class-axiomatised among *all* conjecture blocks. */
     class_axiomatized: number;
+    /** legacy percentage matching `class_axiomatized`'s denominator. */
+    percent_class_axiomatized: number;
+    /** Conjecture blocks with a resolvable `.lean`, as for `provable` and
+     *  `definitions`. `readme-metadata.ts` and `refresh-authors-note.ts` both
+     *  read these two; neither existed, so the README and the authors' note
+     *  were interpolating `undefined`. */
+    with_lean_file: number;
   };
   definitions: {
     total: number;
@@ -350,6 +357,7 @@ function computeStats(paperDir: string, contentRoot: string): Stats {
   );
   const primaryAxiom = primary.filter(b => b.leanFile && b.leanHasClass);
   const allAxiom = conjectures.filter(b => b.leanFile && b.leanHasClass);
+  const conjWithFile = conjectures.filter(b => b.leanFile);
 
   const defs = blocks.filter(b => b.kind === "definition");
   const defsWithFile = defs.filter(b => b.leanFile);
@@ -377,6 +385,8 @@ function computeStats(paperDir: string, contentRoot: string): Stats {
       primary_class_axiomatized: primaryAxiom.length,
       percent_primary_class_axiomatized: pct(primaryAxiom.length, primary.length),
       class_axiomatized: allAxiom.length,
+      percent_class_axiomatized: pct(allAxiom.length, conjectures.length),
+      with_lean_file: conjWithFile.length,
     },
     definitions: {
       total: defs.length,

--- a/scripts/readme-metadata.ts
+++ b/scripts/readme-metadata.ts
@@ -9,7 +9,12 @@
 import { readdir, stat, readFile } from "fs/promises";
 import { join, basename } from "path";
 
-const root = join(import.meta.dir, "..");
+// The FOLIO's root. `join(import.meta.dir, "..")` is the PLATFORM's, which
+// holds no `content/folio.ts`, no papers and no `.github/workflows` for a
+// folio — every path below was resolving into the wrong repo. The
+// `folio-assistant/simulators` path below stays folio-relative on purpose:
+// the folio embeds the platform there as a symlink.
+const root = findContentRepoRoot();
 
 // ── Papers ──────────────────────────────────────────────────────────────────
 
@@ -53,14 +58,15 @@ async function getPapers(): Promise<PaperInfo[]> {
 interface ChapterInfo { dir: string; title: string; kind: "chapter" | "appendix" | "index" }
 
 async function getChapters(): Promise<ChapterInfo[]> {
-  const manifest = join(root, "content/quantum-observable-universe/quantum-observable-universe.ts");
+  const { paper } = statsTarget();
+  const manifest = join(root, "content", paper, `${paper}.ts`);
   const src = await readFile(manifest, "utf-8");
   // Extract dir values from chapterRef({ dir: "..." }) in order
   const dirs = [...src.matchAll(/chapterRef\(\{\s*dir:\s*["']([^"']+)["']/g)].map(m => m[1]);
 
   const chapters: ChapterInfo[] = [];
   for (const dir of dirs) {
-    const chapterTs = join(root, "content/quantum-observable-universe", dir, `${dir}.ts`);
+    const chapterTs = join(root, "content", paper, dir, `${dir}.ts`);
     let title = dir;
     try {
       const chSrc = await readFile(chapterTs, "utf-8");
@@ -81,7 +87,13 @@ async function getChapters(): Promise<ChapterInfo[]> {
 interface LeanModule { name: string; source: string; fileCount?: number }
 
 async function getLeanModules(): Promise<LeanModule[]> {
-  const qouDir = join(root, "content/quantum-observable-universe/lean/QOU");
+  const { paper } = statsTarget();
+  // The Lean library directory, from the registered Lake packages, rather than
+  // one folio's `QOU` namespace baked into a platform script.
+  const pkg = LEAN_PACKAGES.find((k) => k.lakeRoot.includes(`/${paper}/`) || k.lakeRoot.includes(paper));
+  const qouDir = pkg
+    ? join(root, pkg.lakeRoot, pkg.lib)
+    : join(root, "content", paper, "lean");
   const modules: LeanModule[] = [];
 
   try {
@@ -165,6 +177,40 @@ async function getWorkflows(): Promise<WorkflowInfo[]> {
 // ── Lean coverage stats ─────────────────────────────────────────────────────
 
 import { computeStats } from "./lean-coverage";
+import { findContentRepoRoot, findPapers, soleFolioPaper } from "../content/pipeline/repo-root";
+import { LEAN_PACKAGES } from "../schemas/lean-packages";
+
+/**
+ * The paper to report on, and the folio's `content/` root.
+ *
+ * Both were wrong: `computeStats(paperDir, contentRoot)` takes two arguments
+ * and was called with one — so `contentRoot` was `undefined` at runtime — and
+ * the paper was hardcoded to `quantum-observable-universe`, one folio's paper
+ * name living in the platform. `--paper` wins; otherwise take the folio's sole
+ * paper and refuse to guess when there are several.
+ */
+function statsTarget(): { paper: string; contentRoot: string } {
+  const repoRoot = findContentRepoRoot();
+  const contentRoot = join(repoRoot, "content");
+  const argIdx = process.argv.indexOf("--paper");
+  const paper = argIdx >= 0 && process.argv[argIdx + 1]
+    ? process.argv[argIdx + 1]
+    : soleFolioPaper(repoRoot);
+  if (!paper) {
+    // Exit cleanly rather than throwing: this is a CLI entry point, and a raw
+    // stack trace buries the one line that tells the operator what to do.
+    // Matches `export-json.ts` and `validate.ts`.
+    const found = findPapers(repoRoot);
+    console.error(
+      found.length === 0
+        ? `no paper found under ${contentRoot} — run from a folio checkout, or pass --paper`
+        : `this folio has ${found.length} papers (${found.join(", ")}) — pass --paper to choose one`,
+    );
+    process.exit(2);
+  }
+  return { paper, contentRoot };
+}
+
 
 interface LeanCoverage {
   provable_total: number;
@@ -181,7 +227,8 @@ interface LeanCoverage {
 
 async function getLeanCoverage(): Promise<LeanCoverage | null> {
   try {
-    const s = computeStats("quantum-observable-universe");
+    const target = statsTarget();
+    const s = computeStats(target.paper, target.contentRoot);
     return {
       provable_total: s.provable.total,
       provable_with_lean: s.provable.with_lean_file,

--- a/scripts/refresh-authors-note.ts
+++ b/scripts/refresh-authors-note.ts
@@ -18,40 +18,102 @@
  */
 
 import { readFileSync, writeFileSync } from "fs";
-import { resolve, join } from "path";
+import { join } from "path";
 import { computeStats } from "./lean-coverage";
+import { findContentRepoRoot, findPapers, soleFolioPaper } from "../content/pipeline/repo-root";
 
-const REPO_ROOT = resolve(import.meta.dir, "..");
-const NOTE_PATH = join(
-  REPO_ROOT,
-  "content/quantum-observable-universe/introduction/authors-note.md",
-);
+/**
+ * The paper to report on, and the folio's `content/` root.
+ *
+ * Both were wrong: `computeStats(paperDir, contentRoot)` takes two arguments
+ * and was called with one — so `contentRoot` was `undefined` at runtime — and
+ * the paper was hardcoded to `quantum-observable-universe`, one folio's paper
+ * name living in the platform. `--paper` wins; otherwise take the folio's sole
+ * paper and refuse to guess when there are several.
+ */
+function statsTarget(): { paper: string; contentRoot: string } {
+  const repoRoot = findContentRepoRoot();
+  const contentRoot = join(repoRoot, "content");
+  const argIdx = process.argv.indexOf("--paper");
+  const paper = argIdx >= 0 && process.argv[argIdx + 1]
+    ? process.argv[argIdx + 1]
+    : soleFolioPaper(repoRoot);
+  if (!paper) {
+    // Exit cleanly rather than throwing: this is a CLI entry point, and a raw
+    // stack trace buries the one line that tells the operator what to do.
+    // Matches `export-json.ts` and `validate.ts`.
+    const found = findPapers(repoRoot);
+    console.error(
+      found.length === 0
+        ? `no paper found under ${contentRoot} — run from a folio checkout, or pass --paper`
+        : `this folio has ${found.length} papers (${found.join(", ")}) — pass --paper to choose one`,
+    );
+    process.exit(2);
+  }
+  return { paper, contentRoot };
+}
+
+
+// The FOLIO's root, and the chosen paper's note — not `import.meta.dir`, which
+// lands in the platform tree (and the folio embeds the platform as a symlink,
+// so it resolves there even when run from the content repo). The paper name
+// came from `statsTarget()` rather than being baked into the path.
+const REPO_ROOT = findContentRepoRoot();
+const notePathFor = (paper: string): string =>
+  join(REPO_ROOT, "content", paper, "introduction", "authors-note.md");
 
 const PROVABLE_RE = /\*\*\d+\s+of\s+\d+\s+\([\d.]+%\)\s+provable\s+claims\*\*/;
-const CONJECTURE_RE = /\*\*\d+\s+open\s+conjectures\*\*,\s+of\s+which\s+\*\*\d+\s+\([\d.]+%\)\s+are\s+class-axiomatised\s+in\s+Lean\*\*/;
+// The note's prose was rewritten to distinguish PRIMARY conjectures from the
+// external and dependent ones ("famous external open problems it connects to,
+// and conjectures conditional on those primaries, are tallied separately"),
+// and the interstitial em-dash clause sits between the two bold spans. This
+// pattern still expected the old `…conjectures**, of which **…` wording and no
+// longer matched anything, so the refresh could not run — which nothing
+// noticed, because the script could not run at all: it called `computeStats`
+// with one of its two arguments and read the note from a platform path.
+//
+// The two bold spans are matched separately, so the sentence between them can
+// be reworded without breaking the refresh again.
+const CONJECTURE_COUNT_RE = /\*\*\d+\s+primary\s+open\s+conjectures\*\*/;
+const CONJECTURE_AXIOM_RE = /\*\*\d+\s+\([\d.]+%\)\s+are\s+class-axiomatised\s+in\s+Lean\*\*/;
 
 function buildProvableClause(s: ReturnType<typeof computeStats>): string {
   return `**${s.provable.sorry_free} of ${s.provable.total} (${s.provable.percent_sorry_free}%) provable claims**`;
 }
 
-function buildConjectureClause(s: ReturnType<typeof computeStats>): string {
-  return `**${s.conjectures.total} open conjectures**, of which **${s.conjectures.class_axiomatized} (${s.conjectures.percent_class_axiomatized}%) are class-axiomatised in Lean**`;
+function buildConjectureClause(s: ReturnType<typeof computeStats>): { count: string; axiom: string } {
+  // PRIMARY, matching what the note now says. `class_axiomatized` /
+  // `percent_class_axiomatized` count every conjecture block including the
+  // external and dependent ones the prose explicitly says are tallied
+  // separately — using them here would have contradicted the sentence around
+  // them.
+  return {
+    count: `**${s.conjectures.primary} primary open conjectures**`,
+    axiom: `**${s.conjectures.primary_class_axiomatized} (${s.conjectures.percent_primary_class_axiomatized}%) are class-axiomatised in Lean**`,
+  };
 }
 
 function main(): number {
   const check = process.argv.includes("--check");
-  const stats = computeStats("quantum-observable-universe");
+  const target = statsTarget();
+  const stats = computeStats(target.paper, target.contentRoot);
 
+  const NOTE_PATH = notePathFor(target.paper);
   const src = readFileSync(NOTE_PATH, "utf-8");
   if (!PROVABLE_RE.test(src)) {
     console.error(`ERROR: authors-note.md does not contain the expected provable-claims pattern.`);
     console.error(`  Expected match for: ${PROVABLE_RE}`);
     return 1;
   }
-  if (!CONJECTURE_RE.test(src)) {
-    console.error(`ERROR: authors-note.md does not contain the expected conjecture pattern.`);
-    console.error(`  Expected match for: ${CONJECTURE_RE}`);
-    return 1;
+  for (const [what, re] of [
+    ["primary-conjecture count", CONJECTURE_COUNT_RE],
+    ["class-axiomatised count", CONJECTURE_AXIOM_RE],
+  ] as const) {
+    if (!re.test(src)) {
+      console.error(`ERROR: authors-note.md does not contain the expected ${what} pattern.`);
+      console.error(`  Expected match for: ${re}`);
+      return 1;
+    }
   }
 
   const provableNew = buildProvableClause(stats);
@@ -59,7 +121,8 @@ function main(): number {
 
   const updated = src
     .replace(PROVABLE_RE, provableNew)
-    .replace(CONJECTURE_RE, conjectureNew);
+    .replace(CONJECTURE_COUNT_RE, conjectureNew.count)
+    .replace(CONJECTURE_AXIOM_RE, conjectureNew.axiom);
 
   if (updated === src) {
     console.log("authors-note.md is up to date.");
@@ -71,14 +134,14 @@ function main(): number {
     console.error("");
     console.error("Expected:");
     console.error(`  ${provableNew}`);
-    console.error(`  ${conjectureNew}`);
+    console.error(`  ${conjectureNew.count} … ${conjectureNew.axiom}`);
     return 1;
   }
 
   writeFileSync(NOTE_PATH, updated);
   console.log(`Updated: ${NOTE_PATH}`);
   console.log(`  provable: ${provableNew}`);
-  console.log(`  conjectures: ${conjectureNew}`);
+  console.log(`  conjectures: ${conjectureNew.count} … ${conjectureNew.axiom}`);
   return 0;
 }
 

--- a/scripts/tests/audit-tools.test.ts
+++ b/scripts/tests/audit-tools.test.ts
@@ -4,6 +4,7 @@
  */
 import { test, expect, describe } from "bun:test";
 import { registerAuditTools } from "../../adapters/paper/tools/audit.ts";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 /** An MCP tool handler, as the registration stubs below see it. */
 type ToolHandler = (
@@ -11,9 +12,22 @@ type ToolHandler = (
 ) => Promise<{ content: Array<{ type: string; text: string }> }>;
 
 
+/**
+ * A stand-in for `McpServer` that records what a `register*Tools` call
+ * registers. Only `tool` is exercised, so the cast to `McpServer` at each use
+ * is narrowed through `unknown` rather than `any` — the recorder itself stays
+ * typed, and a change to the `tool` signature still breaks here.
+ */
+interface ToolRecorder {
+  tool(name: string, desc: string, schema: unknown, handler: ToolHandler): void;
+}
+
 describe("registerAuditTools", () => {
   const reg: Record<string, { desc: string; handler: ToolHandler }> = {};
-  registerAuditTools({ tool(name: string, desc: string, _s: any, handler: ToolHandler) { reg[name] = { desc, handler }; } } as any);
+  const recorder: ToolRecorder = {
+    tool(name, desc, _schema, handler) { reg[name] = { desc, handler }; },
+  };
+  registerAuditTools(recorder as unknown as McpServer);
 
   const expected = [
     "latex_overfull", "qa_staleness", "tex_source_audit", "dangling_remarks",

--- a/scripts/tests/chapters-dir.test.ts
+++ b/scripts/tests/chapters-dir.test.ts
@@ -1,0 +1,105 @@
+/**
+ * `chapters/*.tex` is `content_build` output and lives in the FOLIO. The test
+ * helper resolved it as `join(REPO_ROOT, "chapters")` where
+ * `REPO_ROOT = resolve(import.meta.dir, "../..")` — this file's own location,
+ * i.e. the PLATFORM checkout.
+ *
+ * So `findChapterFiles()` returned `[]` even with a folio attached, and
+ * `latex-lean-coverage.test.ts` — every one of whose assertions needs those
+ * files — had never run a single one of them in either repo. Measured against
+ * a synthetic folio: 0 pass / 6 skip before the fix, 6 pass / 1 fail after
+ * (the failure correct — the fixture carries no Lean source).
+ *
+ * This is the same split-repo trap the `FOLIO_ROOT` comment two lines below
+ * the old declaration already warned about: a folio embeds the platform as a
+ * `folio-assistant/` SYMLINK, so `import.meta.dir` resolves back through it to
+ * the real platform path and walking up from there never reaches the folio.
+ * `QOU_LEAN_DIR`, immediately above, already did the right thing.
+ *
+ * Resolution happens at module load from `process.cwd()`, so pinning it needs
+ * a subprocess launched from inside a folio — which is what this does.
+ */
+import { describe, test, expect, afterAll } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from "fs";
+import { join, resolve } from "path";
+import { tmpdir } from "os";
+import { spawnSync } from "child_process";
+
+const PLATFORM = resolve(import.meta.dir, "..", "..");
+const DIR = mkdtempSync(join(tmpdir(), "chapters-dir-"));
+afterAll(() => {
+  try {
+    rmSync(DIR, { recursive: true, force: true });
+  } catch {}
+});
+
+/**
+ * A minimal folio: one paper manifest (so `findPapers` sees it), a `chapters/`
+ * directory, and the `folio-assistant/` symlink a real folio carries.
+ */
+function makeFolio(name: string, opts: { withChapter?: boolean } = {}): string {
+  const root = join(DIR, name);
+  mkdirSync(join(root, "content", "demo-paper"), { recursive: true });
+  mkdirSync(join(root, "chapters"), { recursive: true });
+  writeFileSync(
+    join(root, "content", "demo-paper", "demo-paper.ts"),
+    'export default { title: "Demo", authors: [], chapters: [] };\n',
+  );
+  if (opts.withChapter) {
+    writeFileSync(
+      join(root, "chapters", "ch01.tex"),
+      "\\begin{theorem}\\label{thm:demo}\n\\lean{Demo.thmDemo}\nA statement.\n\\end{theorem}\n",
+    );
+  }
+  try {
+    symlinkSync(PLATFORM, join(root, "folio-assistant"));
+  } catch {
+    /* already linked */
+  }
+  return root;
+}
+
+/** Import the helpers from `cwd` and report what they resolved. */
+function probe(cwd: string): { chaptersDir: string; hasFolio: boolean; chapterFiles: number } {
+  const script = join(DIR, "probe.ts");
+  writeFileSync(
+    script,
+    `import { CHAPTERS_DIR, hasFolio, findChapterFiles } from ${JSON.stringify(
+      join(PLATFORM, "scripts", "tests", "helpers.ts"),
+    )};\n` +
+      "console.log(JSON.stringify({ chaptersDir: CHAPTERS_DIR, hasFolio: hasFolio(), chapterFiles: findChapterFiles().length }));\n",
+  );
+  const r = spawnSync("bun", ["run", script], { cwd, encoding: "utf-8", timeout: 30_000 });
+  if (r.status !== 0) throw new Error(`probe failed: ${r.stderr}`);
+  return JSON.parse(r.stdout.trim());
+}
+
+describe("CHAPTERS_DIR resolves against the folio", () => {
+  test("a folio is detected when run from one", () => {
+    // Guard the guard: if this were false the assertions below would pass for
+    // the wrong reason, which is the failure mode this whole file is about.
+    expect(probe(makeFolio("detect")).hasFolio).toBe(true);
+  });
+
+  test("points inside the folio, not the platform", () => {
+    const folio = makeFolio("resolves");
+    const { chaptersDir } = probe(folio);
+    expect(chaptersDir).toBe(join(folio, "chapters"));
+    expect(chaptersDir.startsWith(PLATFORM)).toBe(false);
+  });
+
+  test("findChapterFiles() actually finds the folio's chapters", () => {
+    // The end-to-end fact: with `join(REPO_ROOT, "chapters")` this was 0 even
+    // here, and every test downstream of it silently skipped.
+    expect(probe(makeFolio("finds", { withChapter: true })).chapterFiles).toBe(1);
+  });
+
+  test("falls back to the platform when no folio is attached", () => {
+    // A bare `bun test` in this repo must still resolve to something, and
+    // report zero chapters rather than throwing.
+    const { hasFolio, chaptersDir, chapterFiles } = probe(PLATFORM);
+    expect(hasFolio).toBe(false);
+    expect(chaptersDir).toBe(join(PLATFORM, "chapters"));
+    expect(chapterFiles).toBe(0);
+  });
+});

--- a/scripts/tests/codemod-refterm.test.ts
+++ b/scripts/tests/codemod-refterm.test.ts
@@ -1,0 +1,80 @@
+/**
+ * The refterm codemod rewrites bare mentions of a known glossary phrase into
+ * `:refterm[…]{#slug}` directives, and must leave alone anything that is not
+ * prose: code, math, and terms already wrapped.
+ *
+ * It guarded that with a list of parent node types — `textDirective`,
+ * `leafDirective`, `containerDirective`, `code`, `inlineCode`, `math`,
+ * `inlineMath` — five of which could never fire. `code`/`inlineCode`/`math`/
+ * `inlineMath` are mdast *literal* nodes: they carry `value` and no `children`
+ * at all, so a `text` node is never inside one; a `containerDirective` holds
+ * block content, so its text sits a paragraph deeper. Typing the visitor made
+ * all five unreachable-comparison errors, and they were removed.
+ *
+ * These pin the behaviour that made removing them safe — the protection comes
+ * from mdast's own structure, not from the guard list. If someone reworks the
+ * visitor (or re-adds the guards on a hunch), this says what must stay true.
+ */
+import { describe, test, expect } from "bun:test";
+import { rewriteMarkdown } from "../../content/pipeline/codemod-refterm.ts";
+
+const SLUGS = new Set(["rigid-monoidal-category"]);
+const rewrite = (md: string) => rewriteMarkdown(md, SLUGS, new Set());
+const WRAPPED = ":refterm[rigid monoidal category]{#rigid-monoidal-category}";
+
+describe("leaves non-prose alone", () => {
+  test("inline code", () => {
+    const out = rewrite("A `rigid monoidal category` and a bare rigid monoidal category.");
+    expect(out).toContain("`rigid monoidal category`");
+    expect(out).toContain(WRAPPED);
+    // Exactly one rewrite: the bare mention, not the code span.
+    expect(out!.split(WRAPPED).length - 1).toBe(1);
+  });
+
+  test("fenced code", () => {
+    const out = rewrite("```\nrigid monoidal category\n```\n\nAnd a bare rigid monoidal category.");
+    expect(out).toContain("```\nrigid monoidal category\n```");
+    expect(out!.split(WRAPPED).length - 1).toBe(1);
+  });
+
+  test("inline math", () => {
+    const out = rewrite("Math $rigid monoidal category$ and bare rigid monoidal category.");
+    expect(out).toContain("$rigid monoidal category$");
+    expect(out!.split(WRAPPED).length - 1).toBe(1);
+  });
+
+  test("display math", () => {
+    const out = rewrite("$$\nrigid monoidal category\n$$\n\nbare rigid monoidal category.");
+    expect(out).toContain("$$\nrigid monoidal category\n$$");
+    expect(out!.split(WRAPPED).length - 1).toBe(1);
+  });
+
+  test("an already-wrapped term is not re-wrapped", () => {
+    // The one guard that IS live: text inside a textDirective.
+    expect(rewrite(`Already ${WRAPPED} wrapped.`)).toBeNull();
+  });
+});
+
+describe("rewrites prose wherever it appears", () => {
+  test("paragraph, heading, emphasis, table cell, container directive", () => {
+    for (const md of [
+      "A rigid monoidal category.",
+      "# A rigid monoidal category heading",
+      "*a rigid monoidal category emphasised*",
+      "| a | b |\n|---|---|\n| rigid monoidal category | x |",
+      // Its text lives in a paragraph inside the directive, which is why the
+      // old `containerDirective` guard never fired here either.
+      ":::note\nA rigid monoidal category inside a container.\n:::",
+    ]) {
+      expect(rewrite(md)).toContain(WRAPPED);
+    }
+  });
+
+  test("a block does not re-wrap the term it defines itself", () => {
+    expect(rewriteMarkdown("A rigid monoidal category.", SLUGS, SLUGS)).toBeNull();
+  });
+
+  test("no known phrase, no change", () => {
+    expect(rewrite("Nothing to see here.")).toBeNull();
+  });
+});

--- a/scripts/tests/helpers.ts
+++ b/scripts/tests/helpers.ts
@@ -63,7 +63,17 @@ export const QOU_LEAN_DIR = join(
   FOLIO_ROOT ?? REPO_ROOT,
   "content/quantum-observable-universe/lean",
 );
-export const CHAPTERS_DIR = join(REPO_ROOT, "chapters");
+/**
+ * `chapters/*.tex` — `content_build` output, which lives in the FOLIO.
+ *
+ * Was `join(REPO_ROOT, "chapters")`, i.e. the PLATFORM, so
+ * `findChapterFiles()` returned `[]` even with a folio attached and
+ * `latex-lean-coverage.test.ts` has never run a single one of its real
+ * assertions in either repo. `QOU_LEAN_DIR` directly above already resolves
+ * against `FOLIO_ROOT`; this is the same rule, and the same split-repo trap
+ * the `FOLIO_ROOT` comment warns about.
+ */
+export const CHAPTERS_DIR = join(FOLIO_ROOT ?? REPO_ROOT, "chapters");
 export const SCHEMAS_DIR = join(REPO_ROOT, "schemas");
 
 // ── Lean project discovery ──────────────────────────────────────

--- a/scripts/tests/helpers.ts
+++ b/scripts/tests/helpers.ts
@@ -146,6 +146,24 @@ export function findChapterFiles(): string[] {
 
 import { parse } from "@unified-latex/unified-latex-util-parse";
 import { attachMacroArgs } from "@unified-latex/unified-latex-util-arguments";
+import type {
+  Ast as LatexAstUnion, Environment, Macro,
+} from "@unified-latex/unified-latex-types";
+
+/** One node of the unified-latex AST — `Ast` also admits an array; the
+ *  walkers below take the element type. Same alias as `render-latex.ts`. */
+type LatexNode = Exclude<LatexAstUnion, unknown[]>;
+
+/** Child nodes, when this node's `content` is an array.
+ *
+ *  On `macro`, `string`, `comment` and `verb`, `content` is a plain STRING
+ *  (for a macro, its name) rather than children — which is exactly the
+ *  distinction the recursive walkers here depend on, and exactly what `any`
+ *  stopped the compiler from enforcing. */
+function latexChildren(node: LatexNode): LatexNode[] {
+  const c = (node as { content?: unknown }).content;
+  return Array.isArray(c) ? (c as LatexNode[]) : [];
+}
 
 export interface LatexEnvironment {
   envType: string;
@@ -170,33 +188,36 @@ const MACRO_SIGNATURES = {
 };
 
 /** Extract text content from a unified-latex AST node's arguments. */
-function argText(node: any, argIndex = 0): string | undefined {
+function argText(node: Macro, argIndex = 0): string | undefined {
   const args = node.args;
   if (!args) return undefined;
   // Find the first arg with openMark "{" (mandatory arg)
-  const mandatoryArgs = args.filter((a: any) => a.openMark === "{");
+  const mandatoryArgs = args.filter((a) => a.openMark === "{");
   const arg = mandatoryArgs[argIndex];
   if (!arg?.content?.length) return undefined;
-  return arg.content.map((c: any) => c.content ?? "").join("");
+  // `content` on the leaves here is the string payload of a `string`/`macro`
+  // node; anything else contributes nothing, as before.
+  return arg.content
+    .map((c) => (typeof (c as { content?: unknown }).content === "string"
+      ? (c as { content: string }).content : ""))
+    .join("");
 }
 
 /** Recursively check if an AST node array contains a macro with given name. */
-function hasMacro(nodes: any[], name: string): boolean {
+function hasMacro(nodes: LatexNode[], name: string): boolean {
   for (const n of nodes) {
     if (n.type === "macro" && n.content === name) return true;
-    if (n.content && Array.isArray(n.content) && hasMacro(n.content, name)) return true;
+    if (hasMacro(latexChildren(n), name)) return true;
   }
   return false;
 }
 
 /** Find a macro node by name in an AST node array. */
-function findMacro(nodes: any[], name: string): any | undefined {
+function findMacro(nodes: LatexNode[], name: string): Macro | undefined {
   for (const n of nodes) {
     if (n.type === "macro" && n.content === name) return n;
-    if (n.content && Array.isArray(n.content)) {
-      const found = findMacro(n.content, name);
-      if (found) return found;
-    }
+    const found = findMacro(latexChildren(n), name);
+    if (found) return found;
   }
   return undefined;
 }
@@ -213,10 +234,10 @@ export function extractEnvironments(texFile: string): LatexEnvironment[] {
   const envs: LatexEnvironment[] = [];
 
   // Walk AST for environment nodes
-  function walkForEnvs(nodes: any[]) {
+  function walkForEnvs(nodes: LatexNode[]) {
     for (const node of nodes) {
-      if (node.type === "environment" && ENV_TYPES.has(node.env)) {
-        const body = node.content || [];
+      if (node.type === "environment" && ENV_TYPES.has((node as Environment).env)) {
+        const body = latexChildren(node);
 
         // Find \label
         const labelNode = findMacro(body, "label");
@@ -243,9 +264,7 @@ export function extractEnvironments(texFile: string): LatexEnvironment[] {
       }
 
       // Recurse into content
-      if (node.content && Array.isArray(node.content)) {
-        walkForEnvs(node.content);
-      }
+      walkForEnvs(latexChildren(node));
     }
   }
 

--- a/scripts/tests/infrastructure.test.ts
+++ b/scripts/tests/infrastructure.test.ts
@@ -44,7 +44,11 @@ describe("session-status.sh", () => {
     if (status) {
       expect(status).toHaveProperty("lean_mode");
       const validModes = ["local", "remote", "local-degraded", "none"];
-      expect(validModes).toContain(status.lean_mode);
+      // `status` is `Record<string, unknown>`, and `expect` does not narrow,
+      // so assert the type first — that is worth checking in its own right —
+      // and the cast on the next line is then guarded rather than assumed.
+      expect(typeof status.lean_mode).toBe("string");
+      expect(validModes).toContain(status.lean_mode as string);
     }
   });
 

--- a/scripts/tests/lake-cache.test.ts
+++ b/scripts/tests/lake-cache.test.ts
@@ -35,10 +35,14 @@ function run(
       timeout: 60_000,
     });
     return { code: 0, out };
-  } catch (e: any) {
+  } catch (e) {
+    // `execFileSync` throws an Error decorated with the child's exit status
+    // and captured streams. Node types that as plain `Error`, so the extra
+    // fields need naming rather than an `any`.
+    const err = e as Partial<{ status: number; stdout: string; stderr: string }>;
     return {
-      code: e.status ?? -1,
-      out: `${e.stdout ?? ""}${e.stderr ?? ""}`,
+      code: err.status ?? -1,
+      out: `${err.stdout ?? ""}${err.stderr ?? ""}`,
     };
   }
 }

--- a/scripts/tests/latex-lean-coverage.test.ts
+++ b/scripts/tests/latex-lean-coverage.test.ts
@@ -8,6 +8,19 @@
  *
  * Coverage results feed into the publication pipeline — the ∀ symbol
  * in PDF/HTML links readers to pretty-printed Lean documentation.
+ *
+ * EVERY assertion here needs `chapters/*.tex`, which is `content_build`
+ * output and lives in the FOLIO. With no folio attached the file has nothing
+ * to check, and it must say `skip` — not `pass`.
+ *
+ * It used to say `pass`. Two tests did `console.log("ℹ Skipped: …"); return;`
+ * and two more asserted `expect(true).toBe(true)` after computing (and
+ * logging) the violations they were named for — so CI printed
+ * `✓ label prefixes match environment types` whether or not they did.
+ * The per-declaration loop below generated ZERO tests, silently, because
+ * `chapterFiles` was empty. And it was ALWAYS empty: `CHAPTERS_DIR` pointed
+ * at the platform checkout rather than the folio, so this file had never run
+ * one of its real assertions in either repo.
  */
 
 import { describe, test, expect } from "bun:test";
@@ -25,6 +38,9 @@ import {
 const chapterFiles = findChapterFiles();
 const allEnvs: LatexEnvironment[] = chapterFiles.flatMap(extractEnvironments);
 const allLeanFiles = findLeanFiles(LEAN_DIR);
+
+/** No `chapters/*.tex` → nothing to check. Skip, visibly. */
+const noChapters = chapterFiles.length === 0;
 
 /** Read all Lean source into a searchable map: filename → content */
 const leanContents = new Map<string, string>();
@@ -51,16 +67,19 @@ function declExistsInLean(declName: string): boolean {
 describe("\\lean{} tags → Lean declarations", () => {
   const envsWithLean = allEnvs.filter((e) => e.leanDecl);
 
-  test("at least one \\lean{} tag found (requires chapters/ from content_build)", () => {
-    if (chapterFiles.length === 0) {
-      console.log("    ℹ Skipped: no chapters/*.tex found (run content_build first)");
-      return; // skip — chapters not generated yet
-    }
+  test.skipIf(noChapters)("at least one \\lean{} tag found", () => {
     expect(envsWithLean.length).toBeGreaterThan(0);
   });
 
   // Group by declaration to avoid duplicate tests
   const uniqueDecls = [...new Set(envsWithLean.map((e) => e.leanDecl!))];
+
+  test.skipIf(noChapters)("the per-declaration checks below were generated", () => {
+    // A `for` loop over an empty array registers no tests at all, so the
+    // checks simply vanish from the run and the file still reports green.
+    // This is the one test that notices.
+    expect(uniqueDecls.length).toBeGreaterThan(0);
+  });
 
   for (const decl of uniqueDecls) {
     test(`${decl} exists in Lean source`, () => {
@@ -81,11 +100,7 @@ describe("Coverage completeness", () => {
 
   const formalizable = allEnvs.filter((e) => formalizableTypes.has(e.envType));
 
-  test("formalizable environments found (requires chapters/ from content_build)", () => {
-    if (chapterFiles.length === 0) {
-      console.log("    ℹ Skipped: no chapters/*.tex found (run content_build first)");
-      return; // skip — chapters not generated yet
-    }
+  test.skipIf(noChapters)("formalizable environments found", () => {
     expect(formalizable.length).toBeGreaterThan(0);
   });
 
@@ -110,9 +125,14 @@ describe("Coverage completeness", () => {
   const total = formalizable.length;
   const pct = total > 0 ? ((covered / (total - notready)) * 100).toFixed(1) : "0";
 
-  test("coverage statistics logged", () => {
+  // A report, not a check — so it says so, and it skips rather than printing
+  // "Coverage: 0/0 formalizable (0%)" over an empty corpus, which is not a
+  // coverage figure at all. It was `expect(true).toBe(true)`: a console.log
+  // wearing a test's clothes, counted among the passes.
+  test.skipIf(noChapters)("coverage statistics (report)", () => {
     console.log(`\n    Coverage: ${covered}/${total - notready} formalizable (${pct}%), ${notready} not-ready`);
-    expect(true).toBe(true);
+    // The report is only meaningful over a corpus it actually read.
+    expect(total).toBeGreaterThan(0);
   });
 });
 
@@ -121,7 +141,9 @@ describe("Coverage completeness", () => {
 describe("\\leanok consistency", () => {
   const orphans = allEnvs.filter((e) => e.hasLeanok && !e.leanDecl);
 
-  test("no \\leanok without \\lean{}", () => {
+  // A real gate — but `[]` has length 0, so with no corpus it passed by
+  // finding nothing. Skipped instead, like the rest of the file.
+  test.skipIf(noChapters)("no \\leanok without \\lean{}", () => {
     if (orphans.length > 0) {
       console.log(`\n    Orphan \\leanok tags:`);
       for (const e of orphans) {
@@ -151,14 +173,24 @@ describe("Label conventions", () => {
     return expected && !env.label.startsWith(expected);
   });
 
-  test("label prefixes match environment types", () => {
+  // Named "label prefixes match environment types" and asserting
+  // `expect(true).toBe(true)` — so CI printed a green tick for a property it
+  // never checked, next to a log of every violation. Renamed to what it does.
+  //
+  // It stays a REPORT rather than becoming a gate because the live count is
+  // unknown from this repo — the corpus is in the folio — and the ratchet
+  // rule is that a rule becomes an error only once its count is zero.
+  // Measure in a folio, then flip the last line to
+  // `expect(mismatches).toHaveLength(0)`.
+  test.skipIf(noChapters)("label prefix mismatches (report)", () => {
     if (mismatches.length > 0) {
       console.log(`\n    ℹ ${mismatches.length} label prefix mismatches (fix or reclassify):`);
       for (const e of mismatches) {
         console.log(`      - ${e.label} is ${e.envType} (expected ${prefixMap[e.envType]}*) in ${e.file}:${e.line}`);
       }
     }
-    // Informational — these are data quality issues to fix in LaTeX
-    expect(true).toBe(true);
+    // Asserts the report ran over a real corpus — the one thing that can
+    // actually go wrong here without anybody noticing.
+    expect(allEnvs.length).toBeGreaterThan(0);
   });
 });

--- a/scripts/tests/lean-projects.test.ts
+++ b/scripts/tests/lean-projects.test.ts
@@ -141,8 +141,12 @@ for (const pkg of LEAN_PACKAGES) {
       });
     }
 
-    // Sorry audit (informational — never fails the test run)
-    test("sorry audit", () => {
+    // A REPORT, not a gate: a nonzero `sorry` count is the expected state of
+    // a paper in progress, so asserting zero would be wrong. It used to end
+    // in `expect(true).toBe(true)` and so could not fail for ANY reason —
+    // including the one that matters, `findLeanFiles` returning nothing and
+    // the audit reporting a clean "0 sorry" over an empty directory.
+    test("sorry audit (report)", () => {
       let totalSorry = 0;
       const sorryFiles: string[] = [];
       for (const file of leanFiles) {
@@ -156,7 +160,8 @@ for (const pkg of LEAN_PACKAGES) {
       if (totalSorry > 0) {
         console.log(`    ℹ ${pkg.lib}: ${totalSorry} sorry in ${sorryFiles.length} files: ${sorryFiles.join(", ")}`);
       }
-      expect(true).toBe(true);
+      // The one thing that can go wrong unnoticed: an audit of no files.
+      expect(leanFiles.length).toBeGreaterThan(0);
     });
 
     // Build artifacts not tracked

--- a/scripts/tests/manifest-entries.test.ts
+++ b/scripts/tests/manifest-entries.test.ts
@@ -1,0 +1,88 @@
+/**
+ * The two resolvers — `adapters/mcp-server/server.ts` and
+ * `adapters/paper/resolver.ts` — each carried their own copy of these helpers,
+ * taking `any`, and the copies had drifted apart on the one question that
+ * matters: which `sections[]` entries carry blocks.
+ *
+ * `resolveFolio` used `!("blocks" in sec) → skip`, and `resolvePaper` used
+ * `"name" in sec && !("blocks" in sec) → skip`. They agree on a plain inline
+ * section and on a plain reference, and disagree on exactly the case
+ * `sectionBlockNames` exists to handle: a section that keeps every block in
+ * its `subsections[]` and so declares no `blocks` of its own. The folio
+ * landing page skipped those entirely and undercounted the paper; the viewer
+ * kept them.
+ *
+ * These pin the shared predicate and the flattening, including that case.
+ */
+import { describe, test, expect } from "bun:test";
+import type { Section, SectionRef } from "../../schemas/types.ts";
+import { isSectionRef, sectionBlockNames } from "../../adapters/manifest-entries.ts";
+
+/** `Section` requires `blocks`; authored manifests omit it. Model that. */
+const entry = (o: Record<string, unknown>) => o as unknown as Section | SectionRef;
+
+describe("isSectionRef", () => {
+  test("a bare reference is a reference", () => {
+    expect(isSectionRef(entry({ name: "preliminaries" }))).toBe(true);
+    expect(isSectionRef(entry({ name: "prelim", uri: "./prelim/prelim.ts" }))).toBe(true);
+  });
+
+  test("an inline section is not", () => {
+    expect(isSectionRef(entry({ title: "Preliminaries", blocks: ["def-x"] }))).toBe(false);
+  });
+
+  test("a section with only subsections is NOT a reference — the case the two copies disagreed on", () => {
+    const sec = entry({ title: "Overview", subsections: [{ title: "A", blocks: ["def-a"] }] });
+    expect(isSectionRef(sec)).toBe(false);
+  });
+
+  test("an entry that names a target AND carries blocks is inline", () => {
+    // `name` alone does not make it a reference — the blocks are right there.
+    expect(isSectionRef(entry({ name: "x", title: "X", blocks: ["def-x"] }))).toBe(false);
+  });
+});
+
+describe("sectionBlockNames", () => {
+  test("own blocks, in order", () => {
+    expect(sectionBlockNames(entry({ title: "S", blocks: ["a", "b"] }) as Section)).toEqual(["a", "b"]);
+  });
+
+  test("own blocks first, then each subsection's, in declaration order", () => {
+    // Mirrors render-latex: parent blocks, then each \subsection with its own.
+    const sec = entry({
+      title: "S",
+      blocks: ["a"],
+      subsections: [{ title: "S1", blocks: ["b", "c"] }, { title: "S2", blocks: ["d"] }],
+    }) as Section;
+    expect(sectionBlockNames(sec)).toEqual(["a", "b", "c", "d"]);
+  });
+
+  test("reaches blocks that exist ONLY in subsections", () => {
+    // Without this the section renders empty in the viewer.
+    const sec = entry({
+      title: "S",
+      subsections: [{ title: "S1", blocks: ["b"] }, { title: "S2", blocks: ["c"] }],
+    }) as Section;
+    expect(sectionBlockNames(sec)).toEqual(["b", "c"]);
+  });
+
+  test("skips a subsection that is a bare reference", () => {
+    const sec = entry({
+      title: "S",
+      blocks: ["a"],
+      subsections: [{ name: "elsewhere" }, { title: "S2", blocks: ["d"] }],
+    }) as Section;
+    expect(sectionBlockNames(sec)).toEqual(["a", "d"]);
+  });
+
+  test("tolerates a missing or non-array blocks/subsections", () => {
+    expect(sectionBlockNames(entry({ title: "S" }) as Section)).toEqual([]);
+    expect(sectionBlockNames(entry({ title: "S", blocks: "nope" }) as Section)).toEqual([]);
+    expect(sectionBlockNames(entry({ title: "S", blocks: ["a"], subsections: "nope" }) as Section)).toEqual(["a"]);
+  });
+
+  test("tolerates a hole in subsections", () => {
+    const sec = entry({ title: "S", subsections: [null, { title: "S1", blocks: ["b"] }] }) as Section;
+    expect(sectionBlockNames(sec)).toEqual(["b"]);
+  });
+});

--- a/scripts/tests/qa-dispensation-precedence.test.ts
+++ b/scripts/tests/qa-dispensation-precedence.test.ts
@@ -42,14 +42,14 @@ const HASHES = { ts: "aaaaaaaaaaaa", md: "bbbbbbbbbbbb", lean: "cccccccccccc" };
 
 let seq = 0;
 /** Write a block `.ts` + its sidecar; returns the block triple. */
-function block(entries: unknown[]): { ts: string; label: string } {
+function block(entries: unknown[]): { ts: string } {
   const ts = join(DIR, `b${seq++}.ts`);
   writeFileSync(ts, "export default conjecture({});\n");
   writeFileSync(
     ts.replace(/\.ts$/, ".qa.json"),
     JSON.stringify({ criteria: { [CRITERION]: entries } }, null, 2),
   );
-  return { ts, label: "conj:x" };
+  return { ts };
 }
 
 const human = (at: string, result = "pass") => ({
@@ -116,6 +116,6 @@ describe("human dispensation precedence", () => {
   test("a block with no sidecar has no dispensation", () => {
     const ts = join(DIR, `nosidecar.ts`);
     writeFileSync(ts, "export default conjecture({});\n");
-    expect(hasHumanDispensation({ ts, label: "conj:y" }, CRITERION, HASHES)).toBe(false);
+    expect(hasHumanDispensation({ ts }, CRITERION, HASHES)).toBe(false);
   });
 });

--- a/scripts/tests/qa-tools.test.ts
+++ b/scripts/tests/qa-tools.test.ts
@@ -14,6 +14,17 @@ import {
   asToolText,
 } from "../../adapters/paper/tools/_pipeline.ts";
 import { registerQaTools } from "../../adapters/paper/tools/qa.ts";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+/**
+ * A stand-in for `McpServer` that records what a `register*Tools` call
+ * registers. Only `tool` is exercised, so the cast to `McpServer` at each use
+ * is narrowed through `unknown` rather than `any` — the recorder itself stays
+ * typed, and a change to the `tool` signature still breaks here.
+ */
+interface ToolRecorder {
+  tool(name: string, desc: string, schema: unknown, handler: ToolHandler): void;
+}
 
 /** An MCP tool handler, as the registration stubs below see it. */
 type ToolHandler = (
@@ -60,13 +71,12 @@ describe("_pipeline helper", () => {
 describe("registerQaTools", () => {
   test("registers the expected mechanical tools with handlers", () => {
     const registered: Record<string, { desc: string; schema: unknown; handler: ToolHandler }> = {};
-    const stub = {
-      tool(name: string, desc: string, schema: unknown, handler: ToolHandler) {
+    const stub: ToolRecorder = {
+      tool(name, desc, schema, handler) {
         registered[name] = { desc, schema, handler };
       },
     };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    registerQaTools(stub as any);
+    registerQaTools(stub as unknown as McpServer);
 
     for (const name of [
       "qa_sweep",

--- a/scripts/tests/references-registry-di.test.ts
+++ b/scripts/tests/references-registry-di.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Six pipeline entry points imported the bibliography as
+ * `../../schemas/references` — a path that does not exist in this repo. The
+ * reference database is CONTENT (in qou it is `content/schema/references.ts`,
+ * ~7900 lines of CSL-JSON), so it belongs to the folio the same way the values
+ * registry and the Lake package list do.
+ *
+ * They did not merely fail to type-check. **Every one threw `Cannot find
+ * module` at import**, so `validate-bib`, `bib-qa`, `export-bibtex`,
+ * `export-json`, `validate-references` and `validate-references-human-review`
+ * could not run at all. The whole bibliography subsystem was dead, and nothing
+ * reported it: `content/**` was outside the tsconfig program, and nothing else
+ * imports these entry points.
+ *
+ * Downstream cost, measured: qou's committed `references.bib` carries 372
+ * entries against 463 in the CSL source, and a DOI corrected on 2026-07-06 is
+ * absent from it. Its generator is `export-bibtex.ts`, which has been unable
+ * to run since the split — so the LaTeX bibliography the paper builds from
+ * silently froze on 2026-07-04.
+ *
+ * These pin the DI contract that replaces the direct import. The Proxy is what
+ * lets the six consumers keep reading `references` as a plain array, so the
+ * array-ness is the part worth testing.
+ */
+import { describe, test, expect, beforeAll } from "bun:test";
+import {
+  configureReferenceRegistry,
+  getReferenceRegistry,
+  references,
+  referenceMap,
+} from "../../content/pipeline/references-registry-di";
+import type { Data as CSLData } from "csl-json";
+
+const ENTRIES: CSLData[] = [
+  { id: "alpha2020", type: "article-journal", title: "Alpha", DOI: "10.1/a" },
+  { id: "beta2021", type: "book", title: "Beta" },
+  { id: "gamma2022", type: "article-journal", title: "Gamma", DOI: "10.1/c" },
+];
+
+describe("reference registry DI", () => {
+  test("is unconfigured before injection, and says so", () => {
+    // The message has to name the remedy: this is what a folio author sees
+    // when they invoke a pipeline entry point without a runner script.
+    expect(() => getReferenceRegistry()).toThrow(/configureReferenceRegistry/);
+  });
+});
+
+describe("reference registry DI — once configured", () => {
+  beforeAll(() => {
+    configureReferenceRegistry({
+      references: ENTRIES,
+      referenceMap: new Map(ENTRIES.map((e) => [e.id as string, e])),
+      CSLEntrySchema: { parse: (v: unknown) => v } as never,
+    });
+  });
+
+  test("`references` behaves as the array the consumers expect", () => {
+    // Each of these is a real access pattern in the six files. A Proxy that
+    // only forwarded property reads would fail every method call here.
+    expect(references.length).toBe(3);
+    expect(references[0].id).toBe("alpha2020");
+    expect(references.map((r) => r.id)).toEqual(["alpha2020", "beta2021", "gamma2022"]);
+    expect(references.filter((r) => !!r.DOI).length).toBe(2);
+    expect([...references].length).toBe(3);
+    expect(references.find((r) => r.id === "beta2021")?.type).toBe("book");
+  });
+
+  test("`for…of` iterates it", () => {
+    const ids: string[] = [];
+    for (const r of references) ids.push(r.id as string);
+    expect(ids).toEqual(["alpha2020", "beta2021", "gamma2022"]);
+  });
+
+  test("`referenceMap` behaves as a Map", () => {
+    expect(referenceMap.size).toBe(3);
+    expect(referenceMap.get("gamma2022")?.title).toBe("Gamma");
+    expect(referenceMap.has("nope")).toBe(false);
+  });
+
+  test("re-injection swaps the data", () => {
+    // A runner may configure once per process; nothing should cache the first
+    // array by identity.
+    configureReferenceRegistry({
+      references: [ENTRIES[0]],
+      referenceMap: new Map([["alpha2020", ENTRIES[0]]]),
+      CSLEntrySchema: { parse: (v: unknown) => v } as never,
+    });
+    expect(references.length).toBe(1);
+    expect(referenceMap.size).toBe(1);
+    // Restore for any later test in this file.
+    configureReferenceRegistry({
+      references: ENTRIES,
+      referenceMap: new Map(ENTRIES.map((e) => [e.id as string, e])),
+      CSLEntrySchema: { parse: (v: unknown) => v } as never,
+    });
+  });
+});

--- a/scripts/tests/registry.test.ts
+++ b/scripts/tests/registry.test.ts
@@ -1,0 +1,93 @@
+/**
+ * `scripts/generate-registry.ts` writes `.claude/skills/registry.json`, whose
+ * contract is `SkillRegistrySchema`. Nothing ever checked that it satisfied it,
+ * and it did not:
+ *
+ *   INVALID — 15 issues
+ *     packages.0.repo  Required
+ *     packages.0.path  Required
+ *     packages.0.ref   Required   … × 5 packages
+ *
+ * The generator's own output type declared all six collections as `any[]`, so
+ * `packages` was filled with `skills/<name>/package-manifest.json` files while
+ * the schema asked for `SkillPackageRef` — a reference to an *external* package
+ * in another repo. On top of that the generator never emitted
+ * `roleAssignments` at all, though `.claude/skills/roles/role-assignments.json`
+ * has three rules in it and the field is required.
+ *
+ * This runs the generator and validates its output. It is the check whose
+ * absence let a registry that could not be parsed ship as the framework's
+ * machine-readable manifest.
+ */
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { existsSync, readdirSync, readFileSync, renameSync, unlinkSync } from "fs";
+import { join } from "path";
+import { spawnSync } from "child_process";
+import { SkillRegistrySchema } from "../../schemas/constraints.ts";
+
+const ROOT = join(import.meta.dir, "..", "..");
+const OUT = join(ROOT, ".claude", "skills", "registry.json");
+const SAVED = `${OUT}.testbak`;
+
+// The generator writes to a fixed path in the working tree. Preserve whatever
+// is there so a developer's copy is not clobbered by running the suite.
+let hadExisting = false;
+beforeAll(() => {
+  hadExisting = existsSync(OUT);
+  if (hadExisting) renameSync(OUT, SAVED);
+  const r = spawnSync("bun", ["run", join(ROOT, "scripts", "generate-registry.ts")], {
+    cwd: ROOT, stdio: "pipe",
+  });
+  if (r.status !== 0) throw new Error(`generate-registry failed: ${r.stderr?.toString()}`);
+});
+afterAll(() => {
+  try {
+    if (hadExisting) renameSync(SAVED, OUT);
+    else if (existsSync(OUT)) unlinkSync(OUT);
+  } catch {}
+});
+
+describe("generated skill registry", () => {
+  test("satisfies SkillRegistrySchema", () => {
+    const raw: unknown = JSON.parse(readFileSync(OUT, "utf-8"));
+    const parsed = SkillRegistrySchema.safeParse(raw);
+    const detail = parsed.success
+      ? ""
+      : parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("\n");
+    expect(detail).toBe("");
+    expect(parsed.success).toBe(true);
+  });
+
+  test("carries the role rules that are on disk", () => {
+    // Required by the schema, and never populated before: the registry
+    // advertised no role assignments while three sat in
+    // `.claude/skills/roles/role-assignments.json`.
+    const reg = SkillRegistrySchema.parse(JSON.parse(readFileSync(OUT, "utf-8")));
+    expect(reg.roleAssignments.length).toBeGreaterThan(0);
+    // Highest priority first — the evaluation order the type documents.
+    const priorities = reg.roleAssignments.map((r) => r.priority);
+    expect([...priorities].sort((a, b) => b - a)).toEqual(priorities);
+  });
+
+  test("hooks are HookCommands, not raw settings entries", () => {
+    // `.claude/settings.json` nests `{ matcher, hooks: [...] }` inside each
+    // event; the old mapping put that object into `commands[]` verbatim.
+    const reg = SkillRegistrySchema.parse(JSON.parse(readFileSync(OUT, "utf-8")));
+    for (const h of reg.hooks) {
+      for (const c of h.commands) {
+        expect(c.type).toBe("command");
+        expect(typeof c.command).toBe("string");
+      }
+    }
+  });
+
+  test("every package manifest on disk is in the registry", () => {
+    const reg = SkillRegistrySchema.parse(JSON.parse(readFileSync(OUT, "utf-8")));
+    const onDisk = readdirSync(join(ROOT, "skills"), { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .filter((d) => existsSync(join(ROOT, "skills", d.name, "package-manifest.json")))
+      .map((d) => d.name);
+    expect(onDisk.length).toBeGreaterThan(0);
+    expect(reg.packages.map((p) => p.name).sort()).toEqual([...onDisk].sort());
+  });
+});

--- a/scripts/tests/report.ts
+++ b/scripts/tests/report.ts
@@ -40,13 +40,32 @@ try {
 // Parse JUnit XML → TestResult[] using fast-xml-parser
 const xml = readFileSync(junitPath, "utf-8");
 const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: "@_" });
-const parsed = parser.parse(xml);
+const parsed = parser.parse(xml) as { testsuites?: JUnitSuite | JUnitSuite[] };
 
 const results: TestResult[] = [];
 
+/**
+ * A JUnit `<testcase>` as `fast-xml-parser` yields it, and the `<testsuite>`
+ * tree it is nested in. Only the fields this file reads are named; the parser
+ * hands back arbitrary JSON, so everything else stays `unknown`.
+ */
+interface JUnitTestcase {
+  "@_name"?: string;
+  "@_classname"?: string;
+  "@_time"?: string;
+  "@_file"?: string;
+  failure?: { "@_message"?: string };
+  error?: unknown;
+  skipped?: unknown;
+}
+interface JUnitSuite {
+  testcase?: JUnitTestcase | JUnitTestcase[];
+  testsuite?: JUnitSuite | JUnitSuite[];
+}
+
 /** Recursively collect all testcase nodes from nested testsuites. */
-function collectTestcases(node: any): any[] {
-  const cases: any[] = [];
+function collectTestcases(node: JUnitSuite | JUnitSuite[] | undefined): JUnitTestcase[] {
+  const cases: JUnitTestcase[] = [];
   if (!node) return cases;
   const items = Array.isArray(node) ? node : [node];
   for (const item of items) {
@@ -104,13 +123,17 @@ function inferCategory(testId: string): TestCategory {
   return "custom";
 }
 
-const byCategory: TestSummary["by_category"] = {} as any;
+// `by_category` is a total `Record<TestCategory, …>`, but it is filled in as
+// categories are encountered — so it is genuinely partial while being built.
+// Saying that beats starting from `{} as any` and hoping.
+const byCategory: Partial<TestSummary["by_category"]> = {};
 for (const r of results) {
   const cat = inferCategory(r.test_id);
   if (!byCategory[cat]) byCategory[cat] = { total: 0, passed: 0, failed: 0 };
-  byCategory[cat].total++;
-  if (r.outcome === "pass") byCategory[cat].passed++;
-  if (r.outcome === "fail") byCategory[cat].failed++;
+  const bucket = byCategory[cat]!;
+  bucket.total++;
+  if (r.outcome === "pass") bucket.passed++;
+  if (r.outcome === "fail") bucket.failed++;
 }
 
 const report: TestReport = {
@@ -125,7 +148,9 @@ const report: TestReport = {
     skipped,
     errored,
     duration_ms,
-    by_category: byCategory,
+    // Every category present is fully populated; absent ones simply had no
+    // tests in this run, which is what a reader of the report needs to know.
+    by_category: byCategory as TestSummary["by_category"],
   },
   results,
 };

--- a/scripts/tests/schema-ts-zod-parity.test.ts
+++ b/scripts/tests/schema-ts-zod-parity.test.ts
@@ -1,0 +1,162 @@
+/**
+ * `schemas/types.ts` declares the `Block` union; `schemas/constraints.ts`
+ * declares the Zod schemas that actually validate content. They had drifted,
+ * in both directions:
+ *
+ *     kind        in TS not Zod     in Zod not TS
+ *     diagram     title, uses       —
+ *     prose       title, uses       —
+ *     equation    —                 tags
+ *
+ * plus `equation` carrying no `uses` on either side — the only member of the
+ * union with neither `uses` nor a base supplying it, while its three
+ * standalone siblings (`prose`, `diagram`, `table`) all declare it.
+ *
+ * The Zod objects are neither `.strict()` nor `.passthrough()`, so the default
+ * applies: an unknown key is **stripped, silently, and the parse succeeds**.
+ * Verified — a prose block carrying `uses: ["def:a"]` parsed clean and came
+ * back with `uses === undefined`. On the qou corpus that is 25 prose and 4
+ * diagram blocks whose editorial edges vanished at the validation boundary,
+ * and 106 blocks whose `title` did. AGENTS.md calls `uses[]` the relation
+ * "every ordering metric is computed from".
+ *
+ * A field-name comparison is crude — it does not check types — but it is
+ * exactly the class of drift that occurred, and it is cheap and total.
+ */
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const ROOT = join(import.meta.dir, "..", "..");
+const tsSrc = readFileSync(join(ROOT, "schemas", "types.ts"), "utf-8");
+const zodSrc = readFileSync(join(ROOT, "schemas", "constraints.ts"), "utf-8");
+
+/** Field names declared directly in an interface/object body. */
+function fieldNames(body: string, indent = 2): Set<string> {
+  return new Set(
+    [...body.matchAll(new RegExp(`^\\s{${indent}}(\\w+)\\??:`, "gm"))].map((m) => m[1]),
+  );
+}
+
+/** `interface X extends Y { … }` bodies, keyed by name. */
+function interfaces(src: string): Map<string, { ext?: string; fields: Set<string> }> {
+  const out = new Map<string, { ext?: string; fields: Set<string> }>();
+  for (const m of src.matchAll(
+    /(?:export )?interface (\w+)\s*(?:extends (\w+))?\s*\{([\s\S]*?)\n\}/g,
+  )) {
+    out.set(m[1], { ext: m[2], fields: fieldNames(m[3]) });
+  }
+  return out;
+}
+
+const ifaces = interfaces(tsSrc);
+
+/** A block interface's fields, including everything it inherits. */
+function tsFields(name: string): Set<string> {
+  const entry = ifaces.get(name);
+  if (!entry) return new Set();
+  const inherited = entry.ext ? tsFields(entry.ext) : new Set<string>();
+  return new Set([...entry.fields, ...inherited]);
+}
+
+/**
+ * Zod block schemas, keyed by the `kind` literal they pin.
+ *
+ * Most are `SomeBaseSchema.extend({ … })`, so the base's fields have to be
+ * followed the same way TS `extends` is. Only the four standalone kinds
+ * (`prose`, `equation`, `diagram`, `table`) are flat `z.object({ … })` — and
+ * those are exactly the four where drift was possible, and where it happened.
+ *
+ * Bodies are taken by brace counting rather than a non-greedy regex: several
+ * schemas nest `z.object({ … })` inside a field, and a lazy `\n\}` stops at
+ * the first inner brace.
+ */
+function zodSchemaBodies(): Map<string, { base?: string; fields: Set<string> }> {
+  const out = new Map<string, { base?: string; fields: Set<string> }>();
+  // The two base schemas are declared WITHOUT `export`, so requiring it
+  // silently produced empty field sets for every kind that extends them.
+  const re = /(?:export )?const (\w+Schema) = (?:(\w+Schema)\.extend\(|z\.object\()\{/g;
+  for (const m of zodSrc.matchAll(re)) {
+    const open = m.index! + m[0].length - 1;
+    let depth = 0, i = open;
+    for (; i < zodSrc.length; i++) {
+      if (zodSrc[i] === "{") depth++;
+      else if (zodSrc[i] === "}" && --depth === 0) break;
+    }
+    out.set(m[1], { base: m[2], fields: fieldNames(zodSrc.slice(open + 1, i)) });
+  }
+  return out;
+}
+
+const zodSchemas = zodSchemaBodies();
+
+/** A Zod schema's fields, including everything it extends. */
+function zodFields(name: string): Set<string> {
+  const e = zodSchemas.get(name);
+  if (!e) return new Set();
+  return new Set([...e.fields, ...(e.base ? zodFields(e.base) : [])]);
+}
+
+function zodBlockSchemas(): Map<string, Set<string>> {
+  const out = new Map<string, Set<string>>();
+  for (const [name] of zodSchemas) {
+    const all = zodFields(name);
+    if (!all.has("kind")) continue;
+    // Read the literal off this schema's OWN body, not an inherited one.
+    const body = zodSchemas.get(name)!;
+    void body;
+    const km = new RegExp(
+      `(?:export )?const ${name} = (?:\\w+Schema\\.extend\\(|z\\.object\\()\\{[\\s\\S]*?kind: z\\.literal\\("(\\w+)"\\)`,
+    ).exec(zodSrc);
+    if (km) out.set(km[1], all);
+  }
+  return out;
+}
+
+const zodByKind = zodBlockSchemas();
+
+/** `kind` literal → TS interface name, read off each interface's own body. */
+function tsBlockByKind(): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const [name, { fields }] of ifaces) {
+    if (!name.endsWith("Block") || !fields.has("kind")) continue;
+    const body = /interface ${name}/.source; // placeholder, resolved below
+    void body;
+    const m = new RegExp(`interface ${name}\\s*(?:extends \\w+)?\\s*\\{[\\s\\S]*?kind: "(\\w+)"`).exec(
+      tsSrc,
+    );
+    if (m) out.set(m[1], name);
+  }
+  return out;
+}
+
+const tsByKind = tsBlockByKind();
+
+describe("schema parity: TS interfaces vs Zod schemas", () => {
+  test("both sides describe the same block kinds", () => {
+    expect([...tsByKind.keys()].sort()).toEqual([...zodByKind.keys()].sort());
+  });
+
+  for (const [kind, ifaceName] of [...tsByKind].sort()) {
+    test(`${kind}: field sets agree`, () => {
+      const ts = tsFields(ifaceName);
+      const zod = zodByKind.get(kind) ?? new Set<string>();
+      // `md` is a filesystem companion, not a manifest field; `$schema` and
+      // refinement-only keys never appear in the TS interface.
+      const ignore = new Set(["md"]);
+      const onlyTs = [...ts].filter((f) => !zod.has(f) && !ignore.has(f)).sort();
+      const onlyZod = [...zod].filter((f) => !ts.has(f) && !ignore.has(f)).sort();
+      // A field present in TS but absent from Zod is the dangerous direction:
+      // authors can write it, it type-checks, and Zod silently strips it.
+      expect({ onlyTs, onlyZod }).toEqual({ onlyTs: [], onlyZod: [] });
+    });
+  }
+});
+
+describe("every block kind carries the editorial relation", () => {
+  test("`uses` is declared on all of them", () => {
+    // `equation` was the sole exception, in both TS and Zod.
+    const missing = [...tsByKind].filter(([, n]) => !tsFields(n).has("uses")).map(([k]) => k);
+    expect(missing).toEqual([]);
+  });
+});

--- a/scripts/tests/transform-bib-tools.test.ts
+++ b/scripts/tests/transform-bib-tools.test.ts
@@ -6,6 +6,7 @@
 import { test, expect, describe } from "bun:test";
 import { registerBibTools } from "../../adapters/paper/tools/bib.ts";
 import { registerTransformTools } from "../../adapters/paper/tools/transform.ts";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 /** An MCP tool handler, as the registration stubs below see it. */
 type ToolHandler = (
@@ -13,9 +14,22 @@ type ToolHandler = (
 ) => Promise<{ content: Array<{ type: string; text: string }> }>;
 
 
-function collect(register: (s: any) => void) {
-  const reg: Record<string, { desc: string; schema: any; handler: ToolHandler }> = {};
-  register({ tool(name: string, desc: string, schema: any, handler: ToolHandler) { reg[name] = { desc, schema, handler }; } });
+/**
+ * A stand-in for `McpServer` that records what a `register*Tools` call
+ * registers. Only `tool` is exercised, so the cast to `McpServer` at each use
+ * is narrowed through `unknown` rather than `any` — the recorder itself stays
+ * typed, and a change to the `tool` signature still breaks here.
+ */
+interface ToolRecorder {
+  tool(name: string, desc: string, schema: unknown, handler: ToolHandler): void;
+}
+
+function collect(register: (s: McpServer) => void) {
+  const reg: Record<string, { desc: string; schema: unknown; handler: ToolHandler }> = {};
+  const recorder: ToolRecorder = {
+    tool(name, desc, schema, handler) { reg[name] = { desc, schema, handler }; },
+  };
+  register(recorder as unknown as McpServer);
   return reg;
 }
 

--- a/scripts/tests/workflow-yaml.test.ts
+++ b/scripts/tests/workflow-yaml.test.ts
@@ -58,4 +58,52 @@ describe("GitHub Actions workflows", () => {
       expect(triggers, `${file} has no on: triggers`).toBeDefined();
     });
   }
+
+  /**
+   * `code-quality-gates.yml` runs `bun test`, `bun run lint` and
+   * `tsc --noEmit`. Nothing else in this repo does — of 33 workflows, only
+   * `atomic-mass-gen-check` and `docs-site` auto-trigger, and neither touches
+   * TypeScript.
+   *
+   * It was written `workflow_dispatch`-only, in a commit whose own message
+   * said "no folio-assistant workflow triggers on `pull_request`" and "a
+   * ratchet only works if something runs it". So every gate landed since —
+   * the suite at 0 failures, eslint with every rule at `error`, `tsc` over all
+   * five trees — was enforced by nothing at all, behind a workflow whose
+   * header claimed it was the enforcement.
+   *
+   * A dispatch-only gate is indistinguishable from a working one until you
+   * look at the Actions tab and find no runs. This is the check that looks.
+   */
+  test("code-quality-gates.yml actually triggers on pull_request", () => {
+    const doc = Bun.YAML.parse(
+      readFileSync(join(WORKFLOW_DIR, "code-quality-gates.yml"), "utf-8"),
+    ) as Record<string, unknown>;
+    const triggers = (doc.on ?? doc["true"]) as Record<string, unknown>;
+    expect(Object.keys(triggers).sort()).toContain("pull_request");
+  });
+
+  test("code-quality-gates.yml has no paths: filter on pull_request", () => {
+    // A `paths:` filter is how a whole-repo gate quietly stops covering the
+    // file that broke it — and, because GitHub reports a filtered-out required
+    // check as never having run, how a branch protection rule blocks forever.
+    const doc = Bun.YAML.parse(
+      readFileSync(join(WORKFLOW_DIR, "code-quality-gates.yml"), "utf-8"),
+    ) as Record<string, unknown>;
+    const triggers = (doc.on ?? doc["true"]) as Record<string, unknown>;
+    const pr = triggers.pull_request as Record<string, unknown> | null;
+    expect(pr == null || !("paths" in pr)).toBe(true);
+  });
+
+  test("the TypeScript gate runs all three checks", () => {
+    // Each is a separate ratchet; a gate that runs two of the three reads as
+    // full coverage in the Actions UI.
+    const doc = Bun.YAML.parse(
+      readFileSync(join(WORKFLOW_DIR, "code-quality-gates.yml"), "utf-8"),
+    ) as { jobs: Record<string, { steps: Array<{ run?: string }> }> };
+    const runs = (doc.jobs.typescript?.steps ?? []).map((s) => s.run ?? "").join("\n");
+    expect(runs).toContain("bun test");
+    expect(runs).toContain("bun run lint");
+    expect(runs).toContain("tsc --noEmit");
+  });
 });

--- a/scripts/validate-skills.ts
+++ b/scripts/validate-skills.ts
@@ -7,6 +7,7 @@
  * Usage: npx ts-node scripts/validate-skills.ts
  */
 
+import type { z } from "zod";
 import { readFileSync, readdirSync, existsSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
@@ -24,7 +25,7 @@ const rootDir = join(__dirname, "..");
 let errors = 0;
 let validated = 0;
 
-function validateDir(dir: string, schema: any, label: string): void {
+function validateDir(dir: string, schema: z.ZodType<unknown>, label: string): void {
   if (!existsSync(dir)) return;
   for (const file of readdirSync(dir).filter(f => f.endsWith(".json"))) {
     const path = join(dir, file);

--- a/scripts/validate-skills.ts
+++ b/scripts/validate-skills.ts
@@ -33,8 +33,8 @@ function validateDir(dir: string, schema: any, label: string): void {
       schema.parse(data);
       console.log(`  ✓ ${label}/${file}`);
       validated++;
-    } catch (e: any) {
-      console.error(`  ✗ ${label}/${file}: ${e.message}`);
+    } catch (e) {
+      console.error(`  ✗ ${label}/${file}: ${e instanceof Error ? e.message : String(e)}`);
       errors++;
     }
   }
@@ -74,8 +74,8 @@ if (existsSync(skillsDir)) {
         SkillPackageManifestSchema.parse(data);
         console.log(`  ✓ skills/${pkg.name}/package-manifest.json`);
         validated++;
-      } catch (e: any) {
-        console.error(`  ✗ skills/${pkg.name}/package-manifest.json: ${e.message}`);
+      } catch (e) {
+        console.error(`  ✗ skills/${pkg.name}/package-manifest.json: ${e instanceof Error ? e.message : String(e)}`);
         errors++;
       }
     }

--- a/scripts/witness-audit.ts
+++ b/scripts/witness-audit.ts
@@ -24,6 +24,24 @@ import { resolve, basename, dirname } from "path";
 import { globSync } from "glob";
 import { createHash } from "crypto";
 import { execSync } from "child_process";
+import type { ComputationWitness } from "../schemas/types.ts";
+
+/**
+ * A `.witness.json` as it appears on disk.
+ *
+ * Every field is optional and read defensively: these files are produced by
+ * the folio's Python `WitnessBuilder` and can be malformed (this script
+ * counts that case), so nothing here is guaranteed. `scriptFile`,
+ * `scriptHash`, `scriptCommitSha` and `git_sha` are written by the builder
+ * but are NOT on `ComputationWitness` in `schemas/types.ts` — the two have
+ * drifted, and the drift is only visible once this stops being `any`.
+ */
+interface WitnessFile extends Partial<ComputationWitness> {
+  scriptFile?: string;
+  scriptHash?: string;
+  scriptCommitSha?: string;
+  git_sha?: string;
+}
 
 const REPO_ROOT = resolve(import.meta.dir, "..");
 
@@ -206,11 +224,13 @@ function auditPythonWitnesses(): WitnessStatus[] {
 
   // Pre-collect all script paths for batch git query
   const scriptPaths: string[] = [];
-  const witnessData: { wf: string; witness: any; scriptFile: string; scriptPath: string }[] = [];
+  // `witness` is null for a file that failed to parse — the loop below
+  // pushes that case explicitly, which `any` let pass unremarked.
+  const witnessData: { wf: string; witness: WitnessFile | null; scriptFile: string; scriptPath: string }[] = [];
 
   for (const wf of witnessFiles) {
     try {
-      const witness = JSON.parse(readFileSync(wf, "utf-8"));
+      const witness = JSON.parse(readFileSync(wf, "utf-8")) as WitnessFile;
       const witnessName = basename(wf, ".witness.json");
       const scriptFile = witness.scriptFile || `${witnessName}.py`;
       const scriptPath = resolve(dirname(wf), scriptFile);

--- a/src/core/feedback.ts
+++ b/src/core/feedback.ts
@@ -9,6 +9,38 @@
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync } from "fs";
 import { join } from "path";
+import type { FeedbackItem, TodoPriority, TodoStatus } from "../../schemas/types.js";
+import { TodoItemSchema } from "../../schemas/constraints.js";
+
+/** Sentinel: the client sent a value the target enum does not accept. */
+export const INVALID_ENUM = Symbol("invalid-enum");
+
+function parseEnum<T extends string>(
+  schema: { safeParse: (v: unknown) => { success: true; data: T } | { success: false } },
+  value: string | undefined,
+): T | undefined | typeof INVALID_ENUM {
+  if (value === undefined) return undefined;
+  const parsed = schema.safeParse(value);
+  return parsed.success ? parsed.data : INVALID_ENUM;
+}
+
+/**
+ * Narrow a wire string to a `TodoPriority` / `TodoStatus`.
+ *
+ * `undefined` in → `undefined` out ("field absent, leave it alone"); an
+ * unrecognised string → `INVALID_ENUM`, for the caller to turn into a 400.
+ *
+ * The `/api/feedback/{create,update}` handlers used to assign these straight
+ * onto a stored item, which typechecked only because the array was `any[]`.
+ * `{"status":"banana"}` was persisted verbatim and then matched no filter in
+ * the codebase, so the item silently disappeared from every view of it.
+ */
+export const parseTodoPriority = (v: string | undefined) => parseEnum<TodoPriority>(TodoItemSchema.shape.priority, v);
+export const parseTodoStatus = (v: string | undefined) => parseEnum<TodoStatus>(TodoItemSchema.shape.status, v);
+
+/** The accepted values, for error messages. */
+export const TODO_PRIORITIES = TodoItemSchema.shape.priority.options;
+export const TODO_STATUSES = TodoItemSchema.shape.status.options;
 
 export class FeedbackStore {
   constructor(private feedbackDir: string) {}
@@ -17,25 +49,33 @@ export class FeedbackStore {
     return join(this.feedbackDir, itemId, `${rootName}.json`);
   }
 
-  read(itemId: string, rootName: string): unknown[] {
+  /**
+   * Read one feedback file's items.
+   *
+   * The file is written only by `write`, so `FeedbackItem` is the contract.
+   * Entries are returned as-is rather than filtered against it: every caller
+   * is read-modify-write over the whole file, so dropping a malformed entry
+   * here would delete it on the next unrelated edit.
+   */
+  read(itemId: string, rootName: string): FeedbackItem[] {
     const p = this.feedbackPath(itemId, rootName);
     if (!existsSync(p)) return [];
     try {
-      return JSON.parse(readFileSync(p, "utf-8"));
+      return JSON.parse(readFileSync(p, "utf-8")) as FeedbackItem[];
     } catch {
       return [];
     }
   }
 
-  write(itemId: string, rootName: string, todos: unknown[]): void {
+  write(itemId: string, rootName: string, todos: FeedbackItem[]): void {
     const dir = join(this.feedbackDir, itemId);
     mkdirSync(dir, { recursive: true });
     writeFileSync(this.feedbackPath(itemId, rootName), JSON.stringify(todos, null, 2), "utf-8");
   }
 
   /** List all feedback items across all items, optionally filtered by status. */
-  listAll(status?: string): Array<{ itemId: string; rootName: string; todo: any }> {
-    const results: Array<{ itemId: string; rootName: string; todo: any }> = [];
+  listAll(status?: string): Array<{ itemId: string; rootName: string; todo: FeedbackItem }> {
+    const results: Array<{ itemId: string; rootName: string; todo: FeedbackItem }> = [];
     if (!existsSync(this.feedbackDir)) return results;
     for (const itemId of readdirSync(this.feedbackDir)) {
       const itemFbDir = join(this.feedbackDir, itemId);
@@ -44,7 +84,7 @@ export class FeedbackStore {
           if (!file.endsWith(".json")) continue;
           const rootName = file.replace(/\.json$/, "");
           const todos = this.read(itemId, rootName);
-          for (const t of todos as any[]) {
+          for (const t of todos) {
             if (!status || t.status === status) {
               results.push({ itemId, rootName, todo: t });
             }

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -173,15 +173,24 @@ export class GitHelper {
     }
   }
 
-  /** Import a .ts module — from disk if current branch, via temp file otherwise. */
-  async importTsBranch(branch: string | undefined, relPath: string): Promise<unknown> {
+  /**
+   * Import a .ts module — from disk if current branch, via temp file otherwise.
+   *
+   * Generic, matching `adapters/mcp-server/git.ts`: every caller knows the
+   * manifest shape it asked for, and returning bare `unknown` meant each one
+   * re-asserted it with `as any` — nine of them in `adapters/paper/resolver.ts`
+   * alone, which is how `blk.status` (a field no block manifest carries) went
+   * unnoticed there. `T` defaults to `unknown`, so a caller that does not
+   * supply one is no worse off than before.
+   */
+  async importTsBranch<T = unknown>(branch: string | undefined, relPath: string): Promise<T> {
     if (this.isCurrentBranch(branch)) {
       const absPath = resolve(this.repoRoot, relPath);
       delete require.cache?.[absPath];
       const mod = await import(`${absPath}?t=${Date.now()}`);
-      return mod.default ?? mod;
+      return (mod.default ?? mod) as T;
     }
-    return this.gitImportTs(branch!, relPath);
+    return this.gitImportTs(branch!, relPath) as Promise<T>;
   }
 
   /** Get commits that touched any of the given files (relative paths). */

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -90,10 +90,17 @@ export async function handleChatPost(
               messages: apiMessages,
             });
 
-            const toolUses = response.content.filter((b) => b.type === "tool_use");
+            // Predicate form: `Array.filter` narrows the element type only
+            // when the callback is a type guard, which is why the `.map`s
+            // below had to reopen each block to reach fields the SDK declares.
+            const toolUses = response.content.filter(
+              (b): b is Anthropic.ToolUseBlock => b.type === "tool_use",
+            );
             if (toolUses.length === 0) {
-              const textBlocks = response.content.filter((b) => b.type === "text");
-              const fullText = textBlocks.map((b) => (b as any).text).join("");
+              const textBlocks = response.content.filter(
+                (b): b is Anthropic.TextBlock => b.type === "text",
+              );
+              const fullText = textBlocks.map((b) => b.text).join("");
               const chunkSize = 20;
               for (let i = 0; i < fullText.length; i += chunkSize) {
                 send({ text: fullText.slice(i, i + chunkSize) });
@@ -105,7 +112,7 @@ export async function handleChatPost(
               return;
             }
 
-            const toolNames = toolUses.map((t) => (t as any).name);
+            const toolNames = toolUses.map((t) => t.name);
             logDebug("chat:tools", `round ${toolRounds + 1}: ${toolUses.length} calls`, toolNames.join(", "));
             send({ status: toolNames.join(", ") + "..." });
 

--- a/src/routes/feedback.ts
+++ b/src/routes/feedback.ts
@@ -11,7 +11,11 @@
  * @module folio-assistant/routes/feedback
  */
 
-import { FeedbackStore } from "../core/feedback.js";
+import {
+  FeedbackStore, INVALID_ENUM, parseTodoPriority, parseTodoStatus,
+  TODO_PRIORITIES, TODO_STATUSES,
+} from "../core/feedback.js";
+import type { FeedbackItem } from "../../schemas/types.js";
 import type { ContentAdapter } from "../types.js";
 import { getUserName, getUserEmail, hasRole, forbidden } from "../core/rbac.js";
 import { log } from "../core/logging.js";
@@ -60,12 +64,19 @@ export async function handleFeedbackPost(
       };
       const itemId = body.itemId || body.paperId || "";
 
-      const todo = {
+      const priority = parseTodoPriority(body.priority || undefined);
+      if (priority === INVALID_ENUM) {
+        return Response.json({
+          error: `Invalid priority: must be one of ${TODO_PRIORITIES.join("|")}`,
+        }, { status: 400 });
+      }
+
+      const todo: FeedbackItem = {
         id: FeedbackStore.makeId(),
         summary: body.summary,
         comment: body.comment,
         status: "open",
-        priority: body.priority || "medium",
+        priority: priority ?? "medium",
         origin: "human",
         author: getUserName(req),
         authorEmail: getUserEmail(req),
@@ -96,11 +107,21 @@ export async function handleFeedbackPost(
         status?: string;
       };
       const itemId = body.itemId || body.paperId || "";
-      const todos = feedbackStore.read(itemId, body.rootName) as any[];
-      const idx = todos.findIndex((t: any) => t.id === body.todoId);
+      // Both arrive off the wire as bare strings and were written through
+      // unchecked; see `parseTodoPriority` on what that cost.
+      const priority = parseTodoPriority(body.priority);
+      const status = parseTodoStatus(body.status);
+      if (priority === INVALID_ENUM || status === INVALID_ENUM) {
+        return Response.json({
+          error: `Invalid update: priority must be one of ${TODO_PRIORITIES.join("|")}, ` +
+            `status one of ${TODO_STATUSES.join("|")}`,
+        }, { status: 400 });
+      }
+      const todos = feedbackStore.read(itemId, body.rootName);
+      const idx = todos.findIndex((t) => t.id === body.todoId);
       if (idx < 0) return Response.json({ error: "Todo not found" }, { status: 404 });
-      if (body.priority !== undefined) todos[idx].priority = body.priority;
-      if (body.status !== undefined) todos[idx].status = body.status;
+      if (priority !== undefined) todos[idx].priority = priority;
+      if (status !== undefined) todos[idx].status = status;
       feedbackStore.write(itemId, body.rootName, todos);
       return Response.json({ ok: true, todo: todos[idx] });
     } catch (e) {
@@ -121,8 +142,8 @@ export async function handleFeedbackPost(
         todoId: string;
       };
       const itemId = body.itemId || body.paperId || "";
-      const todos = feedbackStore.read(itemId, body.rootName) as any[];
-      const idx = todos.findIndex((t: any) => t.id === body.todoId);
+      const todos = feedbackStore.read(itemId, body.rootName);
+      const idx = todos.findIndex((t) => t.id === body.todoId);
       if (idx < 0) return Response.json({ error: "Todo not found" }, { status: 404 });
       todos.splice(idx, 1);
       feedbackStore.write(itemId, body.rootName, todos);
@@ -143,7 +164,7 @@ export async function handleFeedbackPost(
       };
       const itemId = body.itemId || body.paperId || "";
       const todos = feedbackStore.read(itemId, body.rootName);
-      const todo = (todos as any[]).find((t) => t.id === body.todoId);
+      const todo = todos.find((t) => t.id === body.todoId);
       if (!todo) return Response.json({ error: "Todo not found" }, { status: 404 });
 
       const doc = await adapter.getDocument(itemId);

--- a/src/sage-mcp-server.py
+++ b/src/sage-mcp-server.py
@@ -44,7 +44,6 @@ import os
 import shutil
 import subprocess
 import sys
-from pathlib import Path
 
 PROTOCOL_VERSION = "2024-11-05"
 SERVER_INFO = {"name": "sage-mcp", "version": "0.2.0"}

--- a/src/tools/preferences.ts
+++ b/src/tools/preferences.ts
@@ -102,7 +102,12 @@ export function registerPreferenceTools(server: McpServer): void {
       const changed: string[] = [];
       for (const [key, value] of Object.entries(updates)) {
         if (value !== undefined && key in prefs) {
-          (prefs as any)[key] = value;
+          // `Object.entries` decorrelates key from value, so TS cannot
+          // check this assignment however it is written. Narrowing the
+          // target to `Record<string, unknown>` keeps the write dynamic
+          // without reopening the whole object: the `key in prefs` guard
+          // above is what makes it sound.
+          (prefs as Record<string, unknown>)[key] = value;
           changed.push(`${key} = ${JSON.stringify(value)}`);
         }
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,18 +19,22 @@ export const ROLE_LEVELS: Record<UserRole, number> = {
 
 // ── Feedback types ───────────────────────────────────────────────
 
-export interface FeedbackItem {
-  id: string;
-  summary: string;
-  comment?: string;
-  status: "open" | "in_progress" | "blocked" | "resolved" | "wontfix";
-  priority: "low" | "medium" | "high" | "critical";
-  origin: "human" | "agent";
-  author: string;
-  authorEmail: string;
-  assignee: string;
-  createdAt: string;
-}
+/**
+ * Re-exported, not redeclared.
+ *
+ * This was a second, hand-written `FeedbackItem` that had drifted from the one
+ * in `schemas/types.ts` — the one `FeedbackItemSchema` validates against and
+ * the one every feedback file on disk is written as (`satisfies
+ * FeedbackItem[]`). The copy narrowed `origin` to `"human" | "agent"`, so a
+ * `"qc"`-origin item (the validation pipeline's own output, and a documented
+ * `TodoOrigin`) was a type error to pass through this layer; it also made
+ * `comment` optional and `author`/`authorEmail`/`assignee` required, both the
+ * opposite of the schema, and omitted `targetLabel`, `updatedAt`, `updatedBy`,
+ * `data` and `related` entirely. Nothing caught the divergence because every
+ * call site in between was typed `any`.
+ */
+import type { FeedbackItem, PaperMacro } from "../schemas/types.js";
+export type { FeedbackItem };
 
 export interface NewFeedback {
   summary: string;
@@ -116,9 +120,16 @@ export interface ResolvedDocument {
   authors: string[];
   affiliations?: string[];
   date?: string;
-  macros?: Record<string, string>;
+  /** `Paper.macros` is `Record<string, PaperMacro>` — `{ tex, unicode? }`
+   *  objects, which is what the viewer reads (`buildKatexMacros` uses
+   *  `def.tex`). This declared `Record<string, string>`; the values passed
+   *  through untouched so nothing broke at runtime, but the type was a lie and
+   *  any consumer doing string work on them would get "[object Object]". Same
+   *  correction as `PaperOutline` in the MCP resolver; surfaced here once the
+   *  paper import stopped being `as any`. */
+  macros?: Record<string, PaperMacro>;
   chapters: ResolvedChapter[];
-  todos?: unknown[];
+  todos?: FeedbackItem[];
   branch: string;
   /** Flattened O(1) lookup: rootName → block. */
   blocksByName?: Map<string, ResolvedBlock>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,9 @@
  * @module folio-assistant/types
  */
 
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { FeedbackItem, PaperMacro } from "../schemas/types.js";
+
 // ── Role-based access control ────────────────────────────────────
 
 export type UserRole = "viewer" | "collaborator" | "owner";
@@ -33,7 +36,6 @@ export const ROLE_LEVELS: Record<UserRole, number> = {
  * `data` and `related` entirely. Nothing caught the divergence because every
  * call site in between was typed `any`.
  */
-import type { FeedbackItem, PaperMacro } from "../schemas/types.js";
 export type { FeedbackItem };
 
 export interface NewFeedback {
@@ -95,7 +97,7 @@ export interface ResolvedBlock {
   tags?: string[];
   rendered?: Array<{ mime: string; url: string; blockIndex: number; hash?: string }>;
   md: string;
-  todos?: unknown[];
+  todos?: FeedbackItem[];
 }
 
 export interface ResolvedSection {
@@ -111,7 +113,7 @@ export interface ResolvedChapter {
   title: string;
   label?: string;
   sections: ResolvedSection[];
-  todos?: unknown[];
+  todos?: FeedbackItem[];
 }
 
 export interface ResolvedDocument {
@@ -144,7 +146,7 @@ export interface BlockDiff {
   mdDiff?: { base: string; head: string };
   leanDiff?: { base: string; head: string };
   statusDiff?: { base: string; head: string };
-  todos?: unknown[];
+  todos?: FeedbackItem[];
 }
 
 export interface DocumentDiff {
@@ -198,7 +200,7 @@ export interface ChapterDetail {
   label?: string;
   dir: string;
   sections: SectionStub[];
-  todos?: unknown[];
+  todos?: FeedbackItem[];
 }
 
 /**
@@ -284,7 +286,15 @@ export interface ContentAdapter {
   // ── Optional extensions ──────────────────────────────────────
 
   /** Register content-specific MCP tools on the server. */
-  registerMcpTools?(server: unknown): void;
+  /**
+   * Register the adapter's MCP tools.
+   *
+   * `unknown` until now, so the one implementation took `any` and every
+   * `register*Tools(server)` call inside it went unchecked. The only caller
+   * (`FolioServer`) has always passed its `McpServer`, and every callee has
+   * always required one.
+   */
+  registerMcpTools?(server: McpServer): void;
 }
 
 // ── Server config ────────────────────────────────────────────────

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,12 +27,16 @@
   // clean", which was true and meaningless, because the file was not in the
   // program.
   //
-  // `content/**` is NOT yet: 48 errors, 21 of them in `render-latex.ts`.
-  // Tracked in bean `folio-assistant-tsca`. Widen it there once its count is
-  // zero — the same ratchet `eslint.config.mjs` uses, so a red typecheck
-  // always means a regression rather than pre-existing debt. Note that the
-  // parts of `content/pipeline` reachable from `src/` are compiled either
-  // way; the gap is the 63 files nothing in `src/` imports.
-  "include": ["src/**/*.ts", "schemas/**/*.ts"],
+  // `content/**` is in scope now too, drained to zero (bean
+  // `folio-assistant-tsca`). Adding it here is the point of the drain: the
+  // 63 pipeline files nothing in `src/` imports were never compiled, and that
+  // is how `validate.ts` shipped a `ReferenceError` and how six bibliography
+  // entry points sat dead — importing `../../schemas/references`, a path that
+  // does not exist here — without anything reporting it.
+  //
+  // `scripts/**` is NOT yet: ~15 errors, several in test files. Widen it there
+  // once its count is zero — the same ratchet `eslint.config.mjs` uses, so a
+  // red typecheck always means a regression rather than pre-existing debt.
+  "include": ["src/**/*.ts", "schemas/**/*.ts", "content/**/*.ts"],
   "exclude": ["dist", "node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,9 +34,15 @@
   // entry points sat dead — importing `../../schemas/references`, a path that
   // does not exist here — without anything reporting it.
   //
-  // `scripts/**` is NOT yet: ~15 errors, several in test files. Widen it there
-  // once its count is zero — the same ratchet `eslint.config.mjs` uses, so a
-  // red typecheck always means a regression rather than pre-existing debt.
-  "include": ["src/**/*.ts", "schemas/**/*.ts", "content/**/*.ts"],
+  // `scripts/**` is in scope now too, drained to zero. Its 15 errors were not
+  // typing nits: `computeStats(paperDir, contentRoot)` was called with ONE
+  // argument from two scripts, and both read `conjectures.with_lean_file` and
+  // `conjectures.percent_class_axiomatized`, neither of which existed — so the
+  // README and the authors' note were interpolating `undefined`.
+  //
+  // `adapters/**` is the last tree still outside, and the largest: **81
+  // errors**, including the MCP server. Tracked in bean `folio-assistant-adpt`.
+  // Same ratchet — drain to zero, then widen; never widen first.
+  "include": ["src/**/*.ts", "schemas/**/*.ts", "content/**/*.ts", "scripts/**/*.ts"],
   "exclude": ["dist", "node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,9 +40,14 @@
   // `conjectures.percent_class_axiomatized`, neither of which existed — so the
   // README and the authors' note were interpolating `undefined`.
   //
-  // `adapters/**` is the last tree still outside, and the largest: **81
-  // errors**, including the MCP server. Tracked in bean `folio-assistant-adpt`.
-  // Same ratchet — drain to zero, then widen; never widen first.
-  "include": ["src/**/*.ts", "schemas/**/*.ts", "content/**/*.ts", "scripts/**/*.ts"],
+  // `adapters/**` is in scope now too, drained from 81 to zero. Its errors
+  // were not typing nits: 38 catch blocks referenced an `e` binding a lint
+  // drain had stripped (a ReferenceError each, all mine, shipped in 958c29e),
+  // `resolveOutline` had never existed, and `--http` mode used the SDK's NODE
+  // transport for a Bun `Request`.
+  //
+  // Every tree is now compiled. A green `bun run typecheck` finally means what
+  // it says.
+  "include": ["src/**/*.ts", "schemas/**/*.ts", "content/**/*.ts", "scripts/**/*.ts", "adapters/**/*.ts"],
   "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
Seventeen commits with one theme: **checks that pass by finding nothing.**

Every fix here started as a lint warning or a type annotation and ended somewhere more interesting. `tsc` 0 errors over all five trees, 430 tests / 0 fail, `eslint` exit 0, the HTTP server boots.

---

## `no-explicit-any`: 201 → 0, and the rule is now an error

That empties the `warn` tier entirely — every eslint rule is an error now, so a new `any` fails the run instead of adding to a count nobody reads. Verified by planting one.

Not a sweep. Each `any` was a separate typing decision, and typing them surfaced this:

- **The generated skill registry had never validated against its own schema.** 15 issues, all `packages.N.{repo,path,ref} Required`. `SkillRegistry.packages` was declared as *external package references* while the generator has only ever written *local package manifests*. `roleAssignments` was never emitted at all, despite being required and having three rules on disk. Hooks came out in the raw `.claude/settings.json` shape, so `commands[]` held `{matcher, hooks}` records instead of `HookCommand`s. `scripts/tests/registry.test.ts` now runs the generator and validates the result.
- **Two `LifecycleStage` enums**, and the hand-written one was wrong: `develop`/`revise` in place of `plan`/`author`/`retire`. Across 18 skill definitions and 5 manifests, `author` appears 18 times and `develop`/`revise` zero.
- **A second `FeedbackItem`** in `src/types.ts`, drifted four ways — including narrowing `origin` so a `qc`-origin item, the validation pipeline's own output, was a type error to pass through that layer.
- **Feedback status/priority were never validated.** `{"status":"banana"}` was persisted to `main` verbatim and then matched no filter anywhere, so the item vanished from every view of itself.
- **`renderBlock` was handed a `ResolvedBlock`** — the viewer's lossy projection — on the lightning-PDF path, silently dropping every kind-specific field it switches on.
- **PACKAGES.md had always shipped empty**, gated on loose `*.json` files in `skills/` that have never existed. All five packages render now.
- **`blk.status` was a phantom in the paper resolver too**, so its "proved" counter was always 0; and the two resolvers disagreed about which sections carry blocks, so the folio landing page undercounted papers the viewer rendered fine.
- **Five mdast guards could never fire** in the refterm codemod — `code`/`math` are literal nodes with no children to reach.

## The CI gate had never run — not once

`code-quality-gates.yml` is the workflow whose own header says *"the ratchet only works if something runs it"*. It was `workflow_dispatch`-only. `list_workflow_runs` returns `total_count: 0`.

Of 33 workflows here, exactly two auto-trigger and neither touches TypeScript. So everything above was enforced by nothing. **This PR is the first thing that will actually exercise it.**

Flipping the trigger alone would have been the same mistake — three of its four jobs scan trees this repo doesn't have:

| job | scans | present here |
|---|---|---|
| `lean-bare-import` (hard) | `content/**/*.lean` | **0 files** |
| `python-imports` (warn) | `folio-assistant/computations`, `tools` | **neither exists** |
| `rust-wildcard` (warn) | `tools/**/*.rs` | **0 `.rs` files** |
| `typescript` (hard) | `bun test` / lint / tsc | real |

The Lean gate printed `OK — no bare 'import Mathlib'` having looked at nothing. It and the Rust gate now print `SKIP — … Nothing scanned.` — "none found" and "nothing to look at" are different facts, and reporting the first while meaning the second reads as coverage.

The Python job was worse than vacuous: `folio-assistant/computations` is a *folio-relative* path, so here it resolves to `folio-assistant/folio-assistant/…`. ruff **warned** about both missing paths and **exited 0** — `continue-on-error` wasn't even load-bearing. Repointed at the real trees it found 24 live F401s; those are drained, so that job is a hard gate too.

## Five passing tests could not fail

Three were `expect(true).toBe(true)` — one of them named `label prefixes match environment types`, which computed the mismatches, logged every one, and asserted nothing. Two more did `console.log("ℹ Skipped: …"); return;`, which reports as **pass**, not skip. A generated-test loop registered zero tests over an empty array, so its checks vanished from the run with nothing saying so.

And the file they were in had never run a real assertion in *either* repo: `CHAPTERS_DIR` resolved against the platform, but `chapters/*.tex` is `content_build` output and lives in the folio. Measured against a synthetic folio:

```
before   0 pass / 6 skip
after    6 pass / 1 fail    ← correct; the fixture has no Lean source
```

## The recurring split-repo defect, twice more

Code computing a path from its own file location — correct before the repo split, wrong after. `build.ts` had it in both defaults: `--out-dir` wrote a folio's chapters into the platform checkout (CI always passes the flag, but `server.ts` invokes the script twice without it), and the default paper was `../quantum-observable-universe/…` — a specific folio paper named in platform code, resolving to a path present in no checkout.

---

## Reviewing this

Each commit is self-contained with its measurements in the message. The load-bearing ones:

- `ec2b2aa` — `any` to zero, rule promoted
- `1c6c23e` — the registry/schema drift
- `896efdd` — the CI gate
- `3a7c520` — the tests that couldn't fail

Four new test files pin the behaviour (`manifest-entries`, `registry`, `codemod-refterm`, `chapters-dir`), and I checked each new guard bites by deliberately breaking what it protects.

**Two things deliberately left undone**, both needing measurement from a folio rather than a decision here: the label-prefix check stays a report rather than a gate until someone counts its violations (the comment names the line to flip), and the Lean/Rust jobs stay as skips rather than the hard-fail preflight `lean-build.yml` uses — that workflow is entirely folio, this one is mixed, and hard-failing would redden every platform PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LL9F9XMXAvKZzjxxhMs2bQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LL9F9XMXAvKZzjxxhMs2bQ)_