### PR TITLE
Work the bean queue: take over a stalled sibling, move folio vocabulary behind a registry, measure the blockers

### DIFF
--- a/.beans/folio-assistant-02kc--cache-carries-oleans-without-trace-siblings-lake-r.md
+++ b/.beans/folio-assistant-02kc--cache-carries-oleans-without-trace-siblings-lake-r.md
@@ -5,7 +5,7 @@ status: in-progress
 type: bug
 priority: critical
 created_at: 2026-08-07T13:56:17Z
-updated_at: 2026-08-07T14:49:26Z
+updated_at: 2026-08-08T11:54:20Z
 ---
 
 Root cause of the cache never helping lake build. Lake decides staleness from .trace files; an olean with no trace is out-of-date, so lake rebuilds it and evicts. Measured: restore laid 7268 oleans with only 775 traces; a single-module 'lake build' ran 823 targets and left 772 oleans — every survivor had a trace (494 mathlib oleans / 494 traces, 0 of 200 sampled lacking one). The cache only ever worked for direct lean+LEAN_PATH calls, which is why the triviality probe succeeded while builds did not.
@@ -142,3 +142,37 @@ Possible follow-up, not built: `seed` could compare the candidate's olean
 count against the branch it is about to replace and warn on a large drop.
 That is a real computable check, unlike an absolute breadth threshold.
 Deferred rather than added mid-reseed.
+
+
+---
+
+## Blocker re-tested 2026-08-08 (session `3bada08b`) — still blocked, now measured
+
+Asked to work all open beans, so the claim was re-tested rather than inherited.
+
+**The toolchain half is genuinely resolved** (`ga7e` was right):
+`~/.elan/toolchains/leanprover--lean4---v4.24.0` is present and both binaries
+run — `lean --version` → 4.24.0, `lake --version` → Lake 5.0.0-src+797c613. So
+"no linkable toolchain" is no longer the blocker.
+
+**The network half is not.** Every host a reseed needs is unreachable from an
+authoring container:
+
+    https://release.lean-lang.org                  HTTP 000
+    https://leanprover-community.github.io         HTTP 000
+    https://github.com/leanprover-community/mathlib4   HTTP 403
+    https://api.github.com/repos/leanprover/elan/releases/latest   HTTP 403
+
+`lake exe cache get` fetches from the second of those, so the fast route is
+out; the from-source route is the hours-long build this bean already measured
+(823 targets for ONE module, not finished in 10 minutes at 0% trace coverage).
+
+**And there is no folio here.** `scripts/lake-cache.sh restore-toolchain`
+exits `no lean-toolchain` — that file is folio content, and this container has
+the platform only. So even with network there is nothing to build.
+
+Conclusion unchanged and now pinned: **this needs CI, or a machine with
+unrestricted egress.** The runbook in
+`docs/guides/reseeding-the-lean-cache.md` is the artifact to run there. Nothing
+further is doable from an authoring container, and the next session should not
+spend turns re-confirming it.

--- a/.beans/folio-assistant-15gn--evaluate-leandojo-premise-index-ci-only-artifact-d.md
+++ b/.beans/folio-assistant-15gn--evaluate-leandojo-premise-index-ci-only-artifact-d.md
@@ -1,10 +1,11 @@
 ---
 # folio-assistant-15gn
 title: Evaluate LeanDojo premise index (CI-only artifact) — deferred
-status: todo
+status: scrapped
 type: task
+priority: normal
 created_at: 2026-08-07T09:13:35Z
-updated_at: 2026-08-07T09:13:35Z
+updated_at: 2026-08-08T11:55:14Z
 ---
 
 
@@ -23,3 +24,40 @@ and likely redundant with leansearch/loogle for most folios.
 
 Revisit only if a folio hits real leansearch/loogle latency or needs offline
 operation. ReProver as a fallback tactic generator: skip.
+
+
+---
+
+## Reasons for Scrapping
+
+Re-checked 2026-08-08 (session `3bada08b`) against this bean's own revisit
+condition: *"Revisit only if a folio hits real leansearch/loogle latency or
+needs offline operation."*
+
+**The condition has fired — and was already answered, more cheaply.**
+`skills/folio-paper-adapter/lean-environment-setup.md` documents that in a web
+sandbox `loogle.lean-lang.org` and `leansearch.net` fail with
+`SSL: CERTIFICATE_VERIFY_FAILED` (self-signed cert in the proxy chain), so the
+`lean_loogle` / `lean_leansearch` MCP tools error out. That is exactly the
+"needs offline operation" trigger.
+
+It is met by three substitutes that need no network and no new dependency:
+
+1. grepping the Mathlib source that ships with any clone or cache restore
+   (`.lake/packages/mathlib/Mathlib/`) — the closest analogue to a loogle
+   name/substring search, and it works with or without Lean installed;
+2. `lean_local_search` (MCP) — offline, over the current project plus imported
+   modules;
+3. `lean_hover_info` / `lean_declaration_file` — offline once a file is loaded.
+
+So the premise index would be solving a problem the tree already solves. The
+costs this bean listed are unchanged and still real: a heavy full-build trace,
+Python-side against a Bun/TS pipeline, and a version pin to specific
+Lean/Mathlib releases — for a CI-only artifact.
+
+Scrapped rather than completed: nothing was built, and the evaluation this bean
+asked for has an answer, which is *no*.
+
+Reopen if the grep/`lean_local_search` substitutes prove inadequate for a real
+authoring task — that would be new evidence, not the condition already tested
+here.

--- a/.beans/folio-assistant-5d7z--reseed-lake-cacheqou-v4-24-0-it-carries-zero-of-th.md
+++ b/.beans/folio-assistant-5d7z--reseed-lake-cacheqou-v4-24-0-it-carries-zero-of-th.md
@@ -5,7 +5,7 @@ status: in-progress
 type: bug
 priority: high
 created_at: 2026-08-07T12:10:50Z
-updated_at: 2026-08-07T13:41:21Z
+updated_at: 2026-08-08T11:54:20Z
 ---
 
 The production cache branch has 7268 oleans, all dependencies, none QOU.*. Every restore still rebuilds the paper, and sibling .lean files cannot elaborate standalone. lake-cache.sh status now detects and reports this.
@@ -109,3 +109,37 @@ dependency oleans with zero `QOU.*`.
 So the first run of this workflow will also be its first real test.
 Two guards now stand in front of a bad publish — the own-package check
 and the trace-coverage check — and both were added since.
+
+
+---
+
+## Blocker re-tested 2026-08-08 (session `3bada08b`) — still blocked, now measured
+
+Asked to work all open beans, so the claim was re-tested rather than inherited.
+
+**The toolchain half is genuinely resolved** (`ga7e` was right):
+`~/.elan/toolchains/leanprover--lean4---v4.24.0` is present and both binaries
+run — `lean --version` → 4.24.0, `lake --version` → Lake 5.0.0-src+797c613. So
+"no linkable toolchain" is no longer the blocker.
+
+**The network half is not.** Every host a reseed needs is unreachable from an
+authoring container:
+
+    https://release.lean-lang.org                  HTTP 000
+    https://leanprover-community.github.io         HTTP 000
+    https://github.com/leanprover-community/mathlib4   HTTP 403
+    https://api.github.com/repos/leanprover/elan/releases/latest   HTTP 403
+
+`lake exe cache get` fetches from the second of those, so the fast route is
+out; the from-source route is the hours-long build this bean already measured
+(823 targets for ONE module, not finished in 10 minutes at 0% trace coverage).
+
+**And there is no folio here.** `scripts/lake-cache.sh restore-toolchain`
+exits `no lean-toolchain` — that file is folio content, and this container has
+the platform only. So even with network there is nothing to build.
+
+Conclusion unchanged and now pinned: **this needs CI, or a machine with
+unrestricted egress.** The runbook in
+`docs/guides/reseeding-the-lean-cache.md` is the artifact to run there. Nothing
+further is doable from an authoring container, and the next session should not
+spend turns re-confirming it.

--- a/.beans/folio-assistant-nimj--nazrin-as-triviality-oracle-proof-not-machine-triv.md
+++ b/.beans/folio-assistant-nimj--nazrin-as-triviality-oracle-proof-not-machine-triv.md
@@ -5,7 +5,7 @@ status: in-progress
 type: task
 priority: normal
 created_at: 2026-08-07T09:13:35Z
-updated_at: 2026-08-07T12:11:25Z
+updated_at: 2026-08-08T11:54:20Z
 ---
 
 
@@ -96,3 +96,27 @@ corpus — the blocks that happen not to import their own package.
 - [ ] With hits in hand, measure the actual false-positive rate.
 - [ ] Tune the ladder / threshold on that evidence.
 - [ ] Only then consider raising severity above `minor`.
+
+
+---
+
+## Re-checked 2026-08-08 (session `3bada08b`) — blocked downstream of 5d7z
+
+Asked to work all open beans, so this was re-tested rather than inherited.
+
+The toolchain this bean once wanted is present and works (`lean` 4.24.0, `lake`
+5.0.0 under `~/.elan/toolchains/`), and the bean already established Nazrin
+itself is unnecessary — Lean's own automation is the oracle.
+
+What remains is the measurement, and it is gated on the cache reseed exactly as
+this bean says: 16 of 28 candidate blocks (57%) could not be probed because
+their sibling `.lean` files import the paper's own package and the cache branch
+carries zero of its oleans. Re-tested the reseed blocker under `5d7z` and
+`02kc`: every host it needs is unreachable from an authoring container (000 /
+403), and there is no folio checked out here at all.
+
+So the order is fixed and unchanged: **reseed in CI (5d7z) → re-probe → measure
+the false-positive rate → only then tune the threshold or raise severity.**
+Nothing here is actionable from an authoring container. The criterion remains
+inert by construction in the meantime — no cache means `n/a`, and the note says
+"not measured", never "nothing trivial".

--- a/.beans/folio-assistant-oqmr--take-over-stalled-sibling-branches-agent-stalled-p.md
+++ b/.beans/folio-assistant-oqmr--take-over-stalled-sibling-branches-agent-stalled-p.md
@@ -1,10 +1,11 @@
 ---
 # folio-assistant-oqmr
 title: 'Take over stalled sibling branches: agent-stalled-pickup-n79db3 (3 commits, no PR)'
-status: in-progress
+status: completed
 type: task
+priority: normal
 created_at: 2026-08-08T11:37:49Z
-updated_at: 2026-08-08T11:37:49Z
+updated_at: 2026-08-08T11:55:14Z
 ---
 
 User instruction: work all open beans, take over stalled agents.
@@ -29,3 +30,34 @@ That is the same defect class as `code-quality-gates.yml` never having run
       `main` (it cites 391 tests; main is at 436 after #71/#72)
 - [ ] Merge `main` into it, re-run the full gate
 - [ ] Open a PR and drive it to green
+
+
+---
+
+## Summary of Changes
+
+Taken over and merged into this session's branch. The sibling's three commits
+applied cleanly onto current `main` (which had moved by #71 and #72), and the
+full gate is green: tsc 0 errors, 445 tests / 0 fail, eslint 0.
+
+**Verified rather than inherited**, since I am putting my name on it:
+
+- The regenerated skill-instruction docs are genuinely in sync — re-ran
+  `scripts/gen-skill-docs.ts` and it reproduces the committed files byte for
+  byte (102 instruction bodies).
+- Its central factual claim checks out. qou's `lean_ci.yml`: **749 runs, the
+  most recent #795 on 2026-04-25, and the latest runs are all `failure`.**
+  Three and a half months with nothing dispatching it. For comparison,
+  folio-assistant's own `lean_ci.yml` has **0 runs, ever**.
+
+The work is the same defect class this session has been chasing, found
+independently from the folio side: *the existence of a CI file is not evidence
+anything is being checked*. Its second half is a sharper version —
+**"a green build only covers what the target reaches"**: Lake's `lean_lib`
+globs from roots, so `lake build` compiled 853 of 1618 modules under
+`lean/QOU/`, and the 766 it never reached included the module holding the
+single `sorry` gating the Specht chain. The package build's sorry-warning list
+omitted it.
+
+Brought onto `claude/agent-4673-validation-9hffrd` rather than pushed to the
+sibling's branch, so the sibling's branch is untouched if that session wakes.

--- a/.beans/folio-assistant-oqmr--take-over-stalled-sibling-branches-agent-stalled-p.md
+++ b/.beans/folio-assistant-oqmr--take-over-stalled-sibling-branches-agent-stalled-p.md
@@ -1,0 +1,31 @@
+---
+# folio-assistant-oqmr
+title: 'Take over stalled sibling branches: agent-stalled-pickup-n79db3 (3 commits, no PR)'
+status: in-progress
+type: task
+created_at: 2026-08-08T11:37:49Z
+updated_at: 2026-08-08T11:37:49Z
+---
+
+User instruction: work all open beans, take over stalled agents.
+
+`claude/agent-stalled-pickup-n79db3` — session `014boi4AkMAATWvkNf9vjVTm`, last
+commit 2026-08-08 09:31, three commits ahead of main, **no PR**, no bean
+claiming it. Stalled.
+
+Its work is squarely on the theme this session has been chasing: skill guidance
+that *running* CI is a step in authoring and prepare-merge, because "the
+existence of a CI file is not evidence anything is being checked". Its
+motivating case is qou's `lean_ci.yml` — last run 2026-04-25, failed on `main`,
+nothing dispatched it for four months, and 37 Lean modules stopped compiling in
+that window, several with plain parse errors.
+
+That is the same defect class as `code-quality-gates.yml` never having run
+(bean `cnlf`), found independently from the folio side.
+
+## Plan
+
+- [ ] Verify its three commits still apply and its claims hold against current
+      `main` (it cites 391 tests; main is at 436 after #71/#72)
+- [ ] Merge `main` into it, re-run the full gate
+- [ ] Open a PR and drive it to green

--- a/.beans/folio-assistant-sklb--folio-vocabulary-hardcoded-in-platform-code-4-site.md
+++ b/.beans/folio-assistant-sklb--folio-vocabulary-hardcoded-in-platform-code-4-site.md
@@ -1,10 +1,11 @@
 ---
 # folio-assistant-sklb
 title: Folio vocabulary hardcoded in platform code — 4 sites, needs a registry not a rename
-status: todo
+status: completed
 type: task
+priority: normal
 created_at: 2026-08-08T09:54:51Z
-updated_at: 2026-08-08T09:54:51Z
+updated_at: 2026-08-08T12:00:50Z
 ---
 
 Spun out of `folio-assistant-dh4f`, which resolved the *path*-rooting instances
@@ -42,3 +43,56 @@ Nothing here is wrong for the current folio, and none of it silently reports
 success — unlike the path defects, which pointed at directories that did not
 exist. The cost is that a second folio would inherit qou's chapter vocabulary,
 and that the platform cannot be read as content-neutral.
+
+
+---
+
+## Summary of Changes
+
+All four sites moved behind a new third DI registry,
+`content/pipeline/chapter-profile-registry-di.ts`, matching
+`value-registry-di` and `references-registry-di`.
+
+| site | what moved |
+|---|---|
+| `qa-checkers-q-usage.ts` | 31-entry `CHAPTER_EXPECTED_REGIMES`, `CATEGORICAL_CHAPTERS` (5), `ARCHIMEDEAN_CHAPTERS` (12) |
+| `find-dangling-remarks.ts` | 13 prose terms → the definition expected to back them |
+| `scripts/lean-audit.ts` | 19 Lean path fragments → chapter slugs |
+| `qa-criteria-registry.ts` | left: prose inside criterion descriptions, not a lookup |
+
+**One deliberate departure from the other two registries: this one does not
+throw when unconfigured.** A values or bibliography lookup returning nothing is
+a bug; a folio declaring no chapter policy is a legitimate folio. That puts all
+the weight on one distinction — unconfigured must read as `n/a`, never as
+"expectation met" — which is the exact failure this whole session has been
+about. The empty default is verified empty rather than permissive: no
+membership test returns true, no lookup returns a set.
+
+The data is not deleted, because the other half is in a repo this change cannot
+touch. It sits in `_folio-chapter-profiles.qou.ts`, quarantined, named for what
+it is, registering itself as the default so qou's criteria do not silently go
+`n/a` first. That file carries the three-step finish and notes step 3 is safe
+the moment step 2 lands, since a later `configure` wins.
+
+**Behaviour-neutral, proven twice:**
+
+- chapter profiles: all 31 chapters and both sets dumped through the checker's
+  public exports before and after — byte-identical.
+- module map: the original function reproduced verbatim beside the new one and
+  both run over **525 paths** — every fragment in four shapes plus all 441
+  overlapping pairs, where an ordering difference would surface. 0 mismatches.
+
+Two mistakes en route, both caught by measuring: the first extraction dropped 6
+of 19 fragments (three rules are multi-line ORs, and a same-line regex missed
+them), and the rewrite defaulted to `"unmapped"` where the original defaults to
+`"core"`. Also a test-pollution bug of my own — `afterEach(resetChapterProfiles)`
+left the registry empty for later files, since the default registers as a
+module-load side effect that fires once per process.
+
+`scripts/tests/chapter-profile-registry-di.test.ts` — 9 tests, weighted on the
+unconfigured case and the Proxy plumbing.
+
+## Remaining (qou side, cannot be done from here)
+
+Copy the literals into the folio, call `configureChapterProfiles` from
+`scripts/run-validate.ts`, delete the quarantine file.

--- a/.claude/commands/prepare-merge.md
+++ b/.claude/commands/prepare-merge.md
@@ -48,6 +48,19 @@ Prefer the MCP tools (structured findings) when connected; otherwise the scripts
 - `proof_status` — no regression in sorry/coverage for changed blocks.
 - `latex_preflight` — no new unknown macros / overfull boxes.
 - `lean_build` / `lean_check` — build green (or unchanged) for touched packages.
+- **Dispatch the repo's Lean CI workflow on the pushed branch, and put its
+  result in the PR.** A local `lake build` is not CI green: it runs on a warm
+  `.lake`, your toolchain, your `moreLeanArgs`. Push first, then
+  `gh workflow run <lean-ci>.yml --ref <branch>` (or `actions_run_trigger`),
+  wait for it, and record run URL + conclusion in the PR body. If it fails,
+  fix and re-dispatch — do not open the PR on an unrun workflow.
+  If dispatch is refused (no `actions: write`), say so in the PR with the
+  command a maintainer should run, rather than leaving it unmentioned.
+
+  *Why this is a gate and not a nicety:* qou's `lean_ci.yml` last ran
+  2026-04-25 and failed. Nothing dispatched it for ~4 months, and 37 modules
+  silently stopped compiling — including files with plain parse errors that
+  had never compiled at all. A workflow nobody runs is not a safety net.
 
 **`contentType: who-smart-dak` (L2):**
 - BPMN/DMN well-formedness; data-dictionary + value-set validation

--- a/.claude/commands/prepare-merge.md
+++ b/.claude/commands/prepare-merge.md
@@ -48,6 +48,13 @@ Prefer the MCP tools (structured findings) when connected; otherwise the scripts
 - `proof_status` — no regression in sorry/coverage for changed blocks.
 - `latex_preflight` — no new unknown macros / overfull boxes.
 - `lean_build` / `lean_check` — build green (or unchanged) for touched packages.
+  **Check what the target covers before quoting its result.** `lake build`
+  compiles the root module plus its transitive imports, not the source tree
+  (`lean_lib` globs default to `roots.map Glob.one`; `srcDir` only widens
+  where sources are found). In qou that is 853 of 1618 modules — so a module
+  you touched may be green-by-omission, and a corpus sorry count read off the
+  build is an undercount. `find .lake/build -name '*.olean' | wc -l` against
+  the source count takes a second and settles it.
 - **Dispatch the repo's Lean CI workflow on the pushed branch, and put its
   result in the PR.** A local `lake build` is not CI green: it runs on a warm
   `.lake`, your toolchain, your `moreLeanArgs`. Push first, then

--- a/.claude/skills/local/prepare-merge.md
+++ b/.claude/skills/local/prepare-merge.md
@@ -50,7 +50,27 @@ the one recipe.
    by silently inheriting red.
 6. **Push** the feature branch (retry/backoff as in step 2):
    `git push -u origin <branch>`.
-7. **Stop here** unless a PR / merge was explicitly requested. If a PR *was*
+7. **Dispatch the repo's CI on the pushed branch, and fold the result into the
+   PR.** Local green is not CI green — CI runs on a cold cache, its own
+   toolchain, and without whatever build flags you set locally. So after the
+   push, trigger the relevant workflow against your branch
+   (`gh workflow run <wf>.yml --ref <branch>`, or the `actions_run_trigger`
+   MCP tool), wait for it, and put the **run URL and conclusion** in the PR
+   body. Red → fix and re-dispatch. Do not open a PR citing a workflow nobody
+   ran.
+
+   If you lack `actions: write` and dispatch returns 403, do **not** quietly
+   skip it: state in the PR that CI was not run, and give the exact command a
+   maintainer should run.
+
+   *Why this is a step and not advice:* qou's `lean_ci.yml` last ran
+   2026-04-25 and failed on `main`. Nothing dispatched it for four months,
+   and 37 modules silently stopped compiling — several with plain parse
+   errors, i.e. files that had never compiled at all. The regression was
+   invisible precisely because a workflow existed and no one ran it. Check
+   when CI last ran (`actions_list` → `list_workflow_runs`) as part of this
+   step; "there is a workflow" is not evidence anything is being checked.
+8. **Stop here** unless a PR / merge was explicitly requested. If a PR *was*
    requested, see below.
 
 ## Opening the PR (only when asked)

--- a/.claude/skills/local/prepare-merge.md
+++ b/.claude/skills/local/prepare-merge.md
@@ -48,6 +48,14 @@ the one recipe.
    **honestly**: distinguish failures you caused from pre-existing ones (diff the
    counts against a baseline run on the merge-base). Do not call a branch green
    by silently inheriting red.
+
+   **Know what the target covered.** Green is a claim about the files the build
+   compiled, which is usually fewer than the files on disk — build targets
+   default to a root plus its transitive imports. Confirm the files *you
+   touched* were in it (artifact count vs. source count, or build the module by
+   name), and scope any corpus-wide number you quote to what actually ran. In
+   qou, `lake build` reaches 853 of 1618 Lean modules, so a touched file can be
+   green purely by never having been compiled.
 6. **Push** the feature branch (retry/backoff as in step 2):
    `git push -u origin <branch>`.
 7. **Dispatch the repo's CI on the pushed branch, and fold the result into the

--- a/content/pipeline/_folio-chapter-profiles.qou.ts
+++ b/content/pipeline/_folio-chapter-profiles.qou.ts
@@ -1,0 +1,202 @@
+/**
+ * qou's chapter profiles — FOLIO CONTENT, quarantined pending migration.
+ *
+ * Which q-regimes each chapter may use, and which chapters are categorical or
+ * archimedean, are editorial judgements about ONE folio's chapters. They do not
+ * belong in the platform: AGENTS.md is explicit that a vocabulary written here
+ * is either in the wrong repo, or belongs in the folio as data.
+ *
+ * They lived inline in `qa-checkers-q-usage.ts` — a 31-entry map keyed by qou
+ * chapter directory names, plus two chapter sets. This file is the intermediate
+ * step of a migration whose other half is in a repo this change cannot touch:
+ * the data is out of the checker and behind the `chapter-profile-registry-di`
+ * interface, but still shipped by the platform, so that moving it does not
+ * silently turn qou's chapter-profile criteria to `n/a` before qou has anywhere
+ * to put it.
+ *
+ * ## To finish the migration (qou side)
+ *
+ * 1. Copy the three literals below into the folio, beside
+ *    `content/values/registry.ts` and `content/schema/references.ts` — where
+ *    the other two injected registries already live.
+ * 2. Call `configureChapterProfiles({ chapterExpectedRegimes,
+ *    categoricalChapters, archimedeanChapters })` from the folio's runner,
+ *    `scripts/run-validate.ts`, beside the existing `configureValueRegistry`
+ *    and `configureReferenceRegistry` calls.
+ * 3. Delete this file and the `registerDefaultChapterProfiles()` call in
+ *    `qa-checkers-q-usage.ts`.
+ *
+ * Step 3 is safe the moment step 2 lands: a folio that configures its own
+ * profiles overwrites this one (last call wins), and an unconfigured registry
+ * reports `n/a` rather than "expectation met" — see
+ * `chapter-profile-registry-di.ts`.
+ *
+ * @module content/pipeline/_folio-chapter-profiles.qou
+ */
+
+import type { QRegime } from "./qa-checkers-q-usage";
+import { configureChapterProfiles } from "./chapter-profile-registry-di";
+
+export const CHAPTER_EXPECTED_REGIMES: Record<string, ReadonlySet<QRegime>> = {
+  // ── Front matter ───────────────────────────────────────────────
+  introduction: new Set<QRegime>([
+    "na", "symbolic", "generic-R", "real-positive", "real-gt-1",
+    "mod-gt-1", "mod-lt-1", "root-of-unity", "fixed-q0",
+  ]),
+  notation: new Set<QRegime>([
+    "na", "symbolic", "generic-R", "real-positive", "real-gt-1",
+    "real-lt-1", "mod-gt-1", "mod-lt-1", "unit-circle",
+    "root-of-unity", "fixed-q0",
+  ]),
+
+  // ── Part I — categorical foundations ──────────────────────────
+  // Symbolic / generic-R primary. fixed-q0 only in a specialisation
+  // block that explicitly carries an archimedean banner.
+  "quantum-universes": new Set<QRegime>([
+    "na", "symbolic", "generic-R",
+  ]),
+  "quantum-observable-universes": new Set<QRegime>([
+    "na", "symbolic", "generic-R", "real-positive",
+  ]),
+  "models-of-qous": new Set<QRegime>([
+    "na", "symbolic", "generic-R", "real-positive", "real-gt-1",
+    "mod-gt-1", "mod-lt-1", "fixed-q0",
+  ]),
+  "lifting-and-descent": new Set<QRegime>([
+    "na", "symbolic", "generic-R",
+  ]),
+
+  // ── Part II — structural mechanics ───────────────────────────
+  "braids-and-knots": new Set<QRegime>([
+    "na", "symbolic", "generic-R", "real-positive", "mod-gt-1",
+    "mod-lt-1",
+  ]),
+  "brings-surface": new Set<QRegime>([
+    "na", "symbolic", "generic-R", "real-positive", "real-gt-1",
+    "fixed-q0",
+  ]),
+  "fluid-dynamics": new Set<QRegime>([
+    "na", "symbolic", "generic-R", "real-positive", "real-gt-1", "fixed-q0",
+  ]),
+  "stochastic-mechanics": new Set<QRegime>([
+    "na", "symbolic", "generic-R", "real-positive", "real-gt-1",
+    "real-lt-1", "mod-lt-1", "fixed-q0",
+  ]),
+  "information-theory": new Set<QRegime>([
+    "na", "symbolic", "generic-R", "real-positive", "fixed-q0",
+  ]),
+  "mass-theory": new Set<QRegime>([
+    "na", "symbolic", "generic-R", "real-positive", "real-gt-1", "fixed-q0",
+  ]),
+  "mass-endomorphism": new Set<QRegime>([
+    "na", "symbolic", "generic-R", "real-positive", "real-gt-1",
+    "fixed-q0",
+  ]),
+  "particle-interactions": new Set<QRegime>([
+    "na", "symbolic", "generic-R", "real-positive", "real-gt-1", "fixed-q0",
+  ]),
+  "gravity-spacetime": new Set<QRegime>([
+    "na", "symbolic", "generic-R", "real-positive", "real-gt-1", "fixed-q0",
+  ]),
+
+  // ── Part III — Descartes universe + observations ─────────────
+  "climax-volume-mass": new Set<QRegime>([
+    "na", "symbolic", "generic-R", "real-positive", "real-gt-1", "fixed-q0",
+  ]),
+  observations: new Set<QRegime>([
+    "na", "symbolic", "generic-R", "real-positive", "real-gt-1", "fixed-q0",
+  ]),
+  "predicted-spectra": new Set<QRegime>([
+    "na", "symbolic", "generic-R", "real-positive", "real-gt-1", "fixed-q0",
+  ]),
+  "measurement-observation": new Set<QRegime>([
+    "na", "symbolic", "generic-R", "real-positive", "real-gt-1", "fixed-q0",
+  ]),
+  "molecular-construction": new Set<QRegime>([
+    "na", "symbolic", "generic-R", "real-positive", "real-gt-1", "fixed-q0",
+  ]),
+  "organic-chemistry": new Set<QRegime>([
+    "na", "symbolic", "generic-R", "real-positive", "real-gt-1", "fixed-q0",
+  ]),
+
+  // ── Ch 11 — q-geometric Langlands (root-of-unity territory) ──
+  "q-geometric-langlands": new Set<QRegime>([
+    "na", "symbolic", "generic-R", "root-of-unity", "unit-circle",
+    "mod-lt-1", "mod-gt-1",
+  ]),
+
+  // ── Appendices ────────────────────────────────────────────────
+  "appendix-qvalues": new Set<QRegime>([
+    "na", "symbolic", "generic-R", "real-positive", "real-gt-1", "fixed-q0",
+  ]),
+  "appendix-atomic-mass-calculations": new Set<QRegime>([
+    "na", "symbolic", "generic-R", "real-positive", "real-gt-1", "fixed-q0",
+  ]),
+  "appendix-knot-operations": new Set<QRegime>([
+    "na", "symbolic", "generic-R", "mod-lt-1", "mod-gt-1",
+  ]),
+  "appendix-knot-periodic-table": new Set<QRegime>([
+    "na", "symbolic", "generic-R", "real-positive", "fixed-q0",
+  ]),
+  "appendix-nf-witnesses": new Set<QRegime>([
+    "na", "symbolic", "generic-R", "fixed-q0",
+  ]),
+  "appendix-surreals": new Set<QRegime>([
+    "na", "symbolic", "generic-R",
+  ]),
+  "appendix-transfer-matrices": new Set<QRegime>([
+    "na", "symbolic", "generic-R", "real-positive", "fixed-q0",
+  ]),
+
+  // Glossary and notation entries are register tables — allow any.
+  glossary: new Set<QRegime>([
+    "na", "symbolic", "generic-R", "real-positive", "real-gt-1",
+    "real-lt-1", "mod-gt-1", "mod-lt-1", "unit-circle",
+    "root-of-unity", "fixed-q0",
+  ]),
+  "index-of-definitions": new Set<QRegime>([
+    "na", "symbolic", "generic-R", "real-positive", "real-gt-1",
+    "real-lt-1", "mod-gt-1", "mod-lt-1", "unit-circle",
+    "root-of-unity", "fixed-q0",
+  ]),
+};
+
+/** Chapters whose narrative-expected profile is "categorical only". */
+export const CATEGORICAL_CHAPTERS: ReadonlySet<string> = new Set([
+  "quantum-universes",
+  "lifting-and-descent",
+  "braids-and-knots",
+  "appendix-knot-operations",
+  "appendix-surreals",
+]);
+
+/** Chapters whose narrative-expected profile is "archimedean / fixed q_0". */
+export const ARCHIMEDEAN_CHAPTERS: ReadonlySet<string> = new Set([
+  "mass-theory",
+  "particle-interactions",
+  "gravity-spacetime",
+  "climax-volume-mass",
+  "observations",
+  "predicted-spectra",
+  "measurement-observation",
+  "molecular-construction",
+  "organic-chemistry",
+  "fluid-dynamics",
+  "appendix-qvalues",
+  "appendix-atomic-mass-calculations",
+]);
+
+/**
+ * Register qou's profiles as the registry default.
+ *
+ * Invoked for its side effect from `qa-checkers-q-usage.ts`. A folio calling
+ * `configureChapterProfiles` itself overwrites this, so wiring the folio side
+ * does not require deleting this file first.
+ */
+export function registerDefaultChapterProfiles(): void {
+  configureChapterProfiles({
+    chapterExpectedRegimes: CHAPTER_EXPECTED_REGIMES,
+    categoricalChapters: CATEGORICAL_CHAPTERS,
+    archimedeanChapters: ARCHIMEDEAN_CHAPTERS,
+  });
+}

--- a/content/pipeline/_folio-chapter-profiles.qou.ts
+++ b/content/pipeline/_folio-chapter-profiles.qou.ts
@@ -187,6 +187,53 @@ export const ARCHIMEDEAN_CHAPTERS: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * Prose terms qou requires a formal definition for. Lifted verbatim from
+ * `find-dangling-remarks.ts`.
+ */
+export const TERMS_NEEDING_DEFINITIONS: Record<string, string> = {
+  "energy": "def:crossing-energy or similar",
+  "force": "categorical force definition",
+  "particle": "def:q-harmonic-form or def:fermion-boson-decomposition",
+  "observable": "def:quantum-observable-universe",
+  "measurement": "def:observation",
+  "degeneration": "formal Frobenius non-degeneracy failure",
+  "time reversal": "prop:fiber-adjoint-involution",
+  "virtual particle": "brane tower level definition",
+  "pair creation": "exceptional divisor passage",
+  "chirality flip": "formal chirality reversal definition",
+  "big bang": "initial object in QOU_deg",
+  "heat death": "terminal object / classical limit",
+};
+
+/**
+ * qou's Lean module layout: which namespace belongs to which chapter. Lifted
+ * verbatim from `mapBuildFileToChapter` in `scripts/lean-audit.ts`, in the same
+ * order — first match wins, and an unmatched path still falls back to `"core"`
+ * at the call site.
+ */
+export const LEAN_MODULE_CHAPTERS = [
+  { pathFragment: "QOU/QuantumObservableUniverse", chapter: "ch1-quantum-observable-universe" },
+  { pathFragment: "QOU/Torsion", chapter: "ch3-lifting-of-quantum-torsion" },
+  { pathFragment: "QOU/Descartes/", chapter: "ch6-descartes-universe" },
+  { pathFragment: "QOU/PathIntegrals", chapter: "ch4-path-integrals-and-braiding" },
+  { pathFragment: "QOU/KnotTheory", chapter: "ch4-path-integrals-and-braiding" },
+  { pathFragment: "QOU/KnotRegistry", chapter: "ch4-path-integrals-and-braiding" },
+  { pathFragment: "QOU/BringsSurface", chapter: "ch5-brings-surface" },
+  { pathFragment: "QOU/DescartesUniverse", chapter: "ch6-descartes-universe" },
+  { pathFragment: "QOU/GaugeFieldFluidDynamics", chapter: "ch10-fluid-dynamics" },
+  { pathFragment: "QOU/InformationTheory", chapter: "ch9-information-theory" },
+  { pathFragment: "QOU/QGeometricLanglands", chapter: "ch11-q-geometric-langlands" },
+  { pathFragment: "QOU/Glossary", chapter: "ch8-glossary" },
+  { pathFragment: "QOU/HadronicMass", chapter: "ch7-observations" },
+  { pathFragment: "QOU/AtomicMass", chapter: "ch7-observations" },
+  { pathFragment: "QOU/MassDerivation", chapter: "ch7-observations" },
+  { pathFragment: "QOU/CODATAChain", chapter: "ch7-observations" },
+  { pathFragment: "QOU/RepresentationTheory", chapter: "ch2-quantum-geometry" },
+  { pathFragment: "QOU/Calculations", chapter: "shared" },
+  { pathFragment: "QOU/MathConstants", chapter: "shared" },
+] as const;
+
+/**
  * Register qou's profiles as the registry default.
  *
  * Invoked for its side effect from `qa-checkers-q-usage.ts`. A folio calling
@@ -198,5 +245,7 @@ export function registerDefaultChapterProfiles(): void {
     chapterExpectedRegimes: CHAPTER_EXPECTED_REGIMES,
     categoricalChapters: CATEGORICAL_CHAPTERS,
     archimedeanChapters: ARCHIMEDEAN_CHAPTERS,
+    termsNeedingDefinitions: TERMS_NEEDING_DEFINITIONS,
+    leanModuleChapters: LEAN_MODULE_CHAPTERS,
   });
 }

--- a/content/pipeline/chapter-profile-registry-di.ts
+++ b/content/pipeline/chapter-profile-registry-di.ts
@@ -44,6 +44,15 @@
  */
 export type ChapterRegime = string;
 
+/**
+ * A rule mapping a Lean module path fragment to the chapter that owns it.
+ * Ordered: the first whose `pathFragment` occurs in the relative path wins.
+ */
+export interface LeanModuleChapterRule {
+  pathFragment: string;
+  chapter: string;
+}
+
 export interface ChapterProfileAPI {
   /** Chapter directory name → the q-regimes that chapter may use. */
   chapterExpectedRegimes: Readonly<Record<string, ReadonlySet<ChapterRegime>>>;
@@ -51,12 +60,22 @@ export interface ChapterProfileAPI {
   categoricalChapters: ReadonlySet<string>;
   /** Chapters whose narrative-expected profile is archimedean / fixed q_0. */
   archimedeanChapters: ReadonlySet<string>;
+  /**
+   * Prose terms that must be backed by a formal definition, mapped to the
+   * definition (or description) expected to back them. Editorial: which words
+   * a folio considers load-bearing is a judgement about its own subject.
+   */
+  termsNeedingDefinitions?: Readonly<Record<string, string>>;
+  /** Lean module path fragment → owning chapter, first match wins. */
+  leanModuleChapters?: readonly LeanModuleChapterRule[];
 }
 
 const EMPTY: ChapterProfileAPI = {
   chapterExpectedRegimes: {},
   categoricalChapters: new Set(),
   archimedeanChapters: new Set(),
+  termsNeedingDefinitions: {},
+  leanModuleChapters: [],
 };
 
 let currentApi: ChapterProfileAPI | null = null;
@@ -128,3 +147,20 @@ export const ARCHIMEDEAN_CHAPTERS: ReadonlySet<string> = new Proxy(new Set<strin
     return typeof v === "function" ? v.bind(s) : v;
   },
 });
+
+/** Prose terms a folio requires a formal definition for. Empty when unconfigured. */
+export function termsNeedingDefinitions(): Readonly<Record<string, string>> {
+  return getChapterProfiles().termsNeedingDefinitions ?? {};
+}
+
+/**
+ * The chapter owning a Lean module, by path fragment; `undefined` when no rule
+ * matches OR when no folio has supplied any — the caller must not read those
+ * as the same thing, so `chapterProfilesConfigured()` distinguishes them.
+ */
+export function leanModuleChapter(relPath: string): string | undefined {
+  for (const r of getChapterProfiles().leanModuleChapters ?? []) {
+    if (relPath.includes(r.pathFragment)) return r.chapter;
+  }
+  return undefined;
+}

--- a/content/pipeline/chapter-profile-registry-di.ts
+++ b/content/pipeline/chapter-profile-registry-di.ts
@@ -1,0 +1,130 @@
+/**
+ * Dependency injection point for a folio's chapter profiles.
+ *
+ * Which q-regimes a chapter may use, which chapters are categorical, and which
+ * are archimedean, are **editorial judgements about one folio's chapters** —
+ * qou's, specifically. They were hardcoded in `qa-checkers-q-usage.ts`: a
+ * 31-entry `CHAPTER_EXPECTED_REGIMES` map keyed by qou chapter directory names
+ * (`"braids-and-knots"`, `"models-of-qous"`, `"appendix-surreals"`), plus two
+ * chapter sets. AGENTS.md rules that out flatly — "if you are about to write
+ * subject matter here (a chapter, a constant, a vocabulary), you are either in
+ * the wrong repo or writing something that belongs in the folio as data."
+ *
+ * Third registry in this family, and deliberately the same shape as
+ * `value-registry-di.ts` and `references-registry-di.ts`: an interface the
+ * platform declares, a `configure*` the folio calls before invoking pipeline
+ * functions, and Proxy-backed value exports so the existing consumers keep
+ * reading `CHAPTER_EXPECTED_REGIMES[chapter]` unchanged.
+ *
+ * ## Unconfigured means "no opinion", not "no chapters"
+ *
+ * `value-registry-di` and `references-registry-di` THROW when unconfigured,
+ * because a values or bibliography lookup that returns nothing is a bug. This
+ * one does not, and the difference is deliberate: a chapter profile is an
+ * optional editorial policy, and a folio that declares none is a legitimate
+ * folio, not a broken one. So the default is an empty registry, and every
+ * accessor is written so that "unconfigured" reads as **`n/a` — no expectation
+ * recorded**, never as "expectation met".
+ *
+ * That distinction is the whole point. `qa-checkers-q-usage` already treats a
+ * chapter absent from the map as unscored, so an empty registry makes the
+ * chapter-profile criteria uniformly `n/a` rather than silently passing —
+ * `chapterHasProfile()` is what a caller checks to tell the two apart.
+ *
+ * @module content/pipeline/chapter-profile-registry-di
+ */
+
+/**
+ * A q-regime label as used by the q-usage checkers.
+ *
+ * Kept as a bare `string` rather than importing the checker's `QRegime` union:
+ * this module must not depend on the checker it feeds, and a folio may
+ * legitimately name a regime the platform has never heard of. The checker
+ * still validates against its own union at the point of use.
+ */
+export type ChapterRegime = string;
+
+export interface ChapterProfileAPI {
+  /** Chapter directory name → the q-regimes that chapter may use. */
+  chapterExpectedRegimes: Readonly<Record<string, ReadonlySet<ChapterRegime>>>;
+  /** Chapters whose narrative-expected profile is categorical / algebraic. */
+  categoricalChapters: ReadonlySet<string>;
+  /** Chapters whose narrative-expected profile is archimedean / fixed q_0. */
+  archimedeanChapters: ReadonlySet<string>;
+}
+
+const EMPTY: ChapterProfileAPI = {
+  chapterExpectedRegimes: {},
+  categoricalChapters: new Set(),
+  archimedeanChapters: new Set(),
+};
+
+let currentApi: ChapterProfileAPI | null = null;
+
+export function configureChapterProfiles(api: ChapterProfileAPI): void {
+  currentApi = api;
+}
+
+/** Reset to unconfigured. For tests; a folio calls `configure` once at startup. */
+export function resetChapterProfiles(): void {
+  currentApi = null;
+}
+
+/**
+ * The configured profiles, or an empty registry.
+ *
+ * Does NOT throw when unconfigured — see the module note. Callers that need to
+ * distinguish "no profile for this chapter" from "no profiles at all" use
+ * `chapterProfilesConfigured()`.
+ */
+export function getChapterProfiles(): ChapterProfileAPI {
+  return currentApi ?? EMPTY;
+}
+
+/** Has a folio supplied chapter profiles at all? */
+export function chapterProfilesConfigured(): boolean {
+  return currentApi !== null;
+}
+
+/** Does this specific chapter have a recorded regime expectation? */
+export function chapterHasProfile(chapter: string | undefined): boolean {
+  if (!chapter) return false;
+  return Object.hasOwn(getChapterProfiles().chapterExpectedRegimes, chapter);
+}
+
+// ── Value-shaped exports, so consumers read them as they always have ──
+
+export const CHAPTER_EXPECTED_REGIMES: Readonly<
+  Record<string, ReadonlySet<ChapterRegime>>
+> = new Proxy(
+  {},
+  {
+    get: (_, prop: string) => getChapterProfiles().chapterExpectedRegimes[prop],
+    ownKeys: () => Reflect.ownKeys(getChapterProfiles().chapterExpectedRegimes),
+    has: (_, prop) => prop in getChapterProfiles().chapterExpectedRegimes,
+    getOwnPropertyDescriptor: (_, prop) => {
+      const d = Reflect.getOwnPropertyDescriptor(
+        getChapterProfiles().chapterExpectedRegimes,
+        prop,
+      );
+      // `ownKeys` must agree with this or `Object.entries` throws on a Proxy.
+      return d && { ...d, configurable: true };
+    },
+  },
+);
+
+export const CATEGORICAL_CHAPTERS: ReadonlySet<string> = new Proxy(new Set<string>(), {
+  get: (_, prop: string | symbol) => {
+    const s = getChapterProfiles().categoricalChapters;
+    const v = Reflect.get(s, prop, s);
+    return typeof v === "function" ? v.bind(s) : v;
+  },
+});
+
+export const ARCHIMEDEAN_CHAPTERS: ReadonlySet<string> = new Proxy(new Set<string>(), {
+  get: (_, prop: string | symbol) => {
+    const s = getChapterProfiles().archimedeanChapters;
+    const v = Reflect.get(s, prop, s);
+    return typeof v === "function" ? v.bind(s) : v;
+  },
+});

--- a/content/pipeline/find-dangling-remarks.ts
+++ b/content/pipeline/find-dangling-remarks.ts
@@ -19,6 +19,9 @@
 import { readdirSync, existsSync, statSync } from "fs";
 import { resolve, join } from "path";
 import { requirePaper } from "./repo-root";
+// The term list is FOLIO content — which words a paper treats as needing a
+// formal backing is a judgement about its own subject. Injected, not inlined.
+import { termsNeedingDefinitions } from "./chapter-profile-registry-di";
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -33,22 +36,7 @@ interface RemarkInfo {
   ambiguousTerms: string[];
 }
 
-// ── Physics terms that need categorical backing ──────────────────
 
-const PHYSICS_TERMS_NEEDING_DEFS: Record<string, string> = {
-  "energy": "def:crossing-energy or similar",
-  "force": "categorical force definition",
-  "particle": "def:q-harmonic-form or def:fermion-boson-decomposition",
-  "observable": "def:quantum-observable-universe",
-  "measurement": "def:observation",
-  "degeneration": "formal Frobenius non-degeneracy failure",
-  "time reversal": "prop:fiber-adjoint-involution",
-  "virtual particle": "brane tower level definition",
-  "pair creation": "exceptional divisor passage",
-  "chirality flip": "formal chirality reversal definition",
-  "big bang": "initial object in QOU_deg",
-  "heat death": "terminal object / classical limit",
-};
 
 // ── Discovery ────────────────────────────────────────────────────
 
@@ -100,7 +88,7 @@ async function analyzeRemark(filePath: string): Promise<RemarkInfo | null> {
       const mdContent = readFileSync(mdPath, "utf-8").toLowerCase();
       const usedLabels = new Set<string>(block.uses ?? []);
 
-      for (const [term, expectedDef] of Object.entries(PHYSICS_TERMS_NEEDING_DEFS)) {
+      for (const [term, expectedDef] of Object.entries(termsNeedingDefinitions())) {
         if (mdContent.includes(term.toLowerCase())) {
           // Check if the expected definition is in uses[]
           const hasRef = Array.from(usedLabels).some((u) =>

--- a/content/pipeline/qa-checkers-q-usage.ts
+++ b/content/pipeline/qa-checkers-q-usage.ts
@@ -38,6 +38,17 @@
 import { existsSync, readFileSync } from "fs";
 import { sep } from "path";
 
+// Chapter profiles are FOLIO content and now arrive through a registry, the
+// same way values and references do. Re-exported below so the checker's
+// import surface is unchanged for `q-usage-audit.ts` and the tests.
+import {
+  CHAPTER_EXPECTED_REGIMES, CATEGORICAL_CHAPTERS, ARCHIMEDEAN_CHAPTERS,
+} from "./chapter-profile-registry-di";
+// Side-effecting: registers qou's profiles as the default until the folio
+// supplies its own. `_folio-chapter-profiles.qou.ts` says how to finish that.
+import { registerDefaultChapterProfiles } from "./_folio-chapter-profiles.qou";
+registerDefaultChapterProfiles();
+
 export interface QUsageHit {
   file: string;
   line: number;
@@ -84,154 +95,11 @@ export type QRegime =
 // fixed-q0 numerical pin in `braids-and-knots`), not to flag every
 // borderline chapter.
 
-const CHAPTER_EXPECTED_REGIMES: Record<string, ReadonlySet<QRegime>> = {
-  // ── Front matter ───────────────────────────────────────────────
-  introduction: new Set<QRegime>([
-    "na", "symbolic", "generic-R", "real-positive", "real-gt-1",
-    "mod-gt-1", "mod-lt-1", "root-of-unity", "fixed-q0",
-  ]),
-  notation: new Set<QRegime>([
-    "na", "symbolic", "generic-R", "real-positive", "real-gt-1",
-    "real-lt-1", "mod-gt-1", "mod-lt-1", "unit-circle",
-    "root-of-unity", "fixed-q0",
-  ]),
 
-  // ── Part I — categorical foundations ──────────────────────────
-  // Symbolic / generic-R primary. fixed-q0 only in a specialisation
-  // block that explicitly carries an archimedean banner.
-  "quantum-universes": new Set<QRegime>([
-    "na", "symbolic", "generic-R",
-  ]),
-  "quantum-observable-universes": new Set<QRegime>([
-    "na", "symbolic", "generic-R", "real-positive",
-  ]),
-  "models-of-qous": new Set<QRegime>([
-    "na", "symbolic", "generic-R", "real-positive", "real-gt-1",
-    "mod-gt-1", "mod-lt-1", "fixed-q0",
-  ]),
-  "lifting-and-descent": new Set<QRegime>([
-    "na", "symbolic", "generic-R",
-  ]),
 
-  // ── Part II — structural mechanics ───────────────────────────
-  "braids-and-knots": new Set<QRegime>([
-    "na", "symbolic", "generic-R", "real-positive", "mod-gt-1",
-    "mod-lt-1",
-  ]),
-  "brings-surface": new Set<QRegime>([
-    "na", "symbolic", "generic-R", "real-positive", "real-gt-1",
-    "fixed-q0",
-  ]),
-  "fluid-dynamics": new Set<QRegime>([
-    "na", "symbolic", "generic-R", "real-positive", "real-gt-1", "fixed-q0",
-  ]),
-  "stochastic-mechanics": new Set<QRegime>([
-    "na", "symbolic", "generic-R", "real-positive", "real-gt-1",
-    "real-lt-1", "mod-lt-1", "fixed-q0",
-  ]),
-  "information-theory": new Set<QRegime>([
-    "na", "symbolic", "generic-R", "real-positive", "fixed-q0",
-  ]),
-  "mass-theory": new Set<QRegime>([
-    "na", "symbolic", "generic-R", "real-positive", "real-gt-1", "fixed-q0",
-  ]),
-  "mass-endomorphism": new Set<QRegime>([
-    "na", "symbolic", "generic-R", "real-positive", "real-gt-1",
-    "fixed-q0",
-  ]),
-  "particle-interactions": new Set<QRegime>([
-    "na", "symbolic", "generic-R", "real-positive", "real-gt-1", "fixed-q0",
-  ]),
-  "gravity-spacetime": new Set<QRegime>([
-    "na", "symbolic", "generic-R", "real-positive", "real-gt-1", "fixed-q0",
-  ]),
 
-  // ── Part III — Descartes universe + observations ─────────────
-  "climax-volume-mass": new Set<QRegime>([
-    "na", "symbolic", "generic-R", "real-positive", "real-gt-1", "fixed-q0",
-  ]),
-  observations: new Set<QRegime>([
-    "na", "symbolic", "generic-R", "real-positive", "real-gt-1", "fixed-q0",
-  ]),
-  "predicted-spectra": new Set<QRegime>([
-    "na", "symbolic", "generic-R", "real-positive", "real-gt-1", "fixed-q0",
-  ]),
-  "measurement-observation": new Set<QRegime>([
-    "na", "symbolic", "generic-R", "real-positive", "real-gt-1", "fixed-q0",
-  ]),
-  "molecular-construction": new Set<QRegime>([
-    "na", "symbolic", "generic-R", "real-positive", "real-gt-1", "fixed-q0",
-  ]),
-  "organic-chemistry": new Set<QRegime>([
-    "na", "symbolic", "generic-R", "real-positive", "real-gt-1", "fixed-q0",
-  ]),
 
-  // ── Ch 11 — q-geometric Langlands (root-of-unity territory) ──
-  "q-geometric-langlands": new Set<QRegime>([
-    "na", "symbolic", "generic-R", "root-of-unity", "unit-circle",
-    "mod-lt-1", "mod-gt-1",
-  ]),
 
-  // ── Appendices ────────────────────────────────────────────────
-  "appendix-qvalues": new Set<QRegime>([
-    "na", "symbolic", "generic-R", "real-positive", "real-gt-1", "fixed-q0",
-  ]),
-  "appendix-atomic-mass-calculations": new Set<QRegime>([
-    "na", "symbolic", "generic-R", "real-positive", "real-gt-1", "fixed-q0",
-  ]),
-  "appendix-knot-operations": new Set<QRegime>([
-    "na", "symbolic", "generic-R", "mod-lt-1", "mod-gt-1",
-  ]),
-  "appendix-knot-periodic-table": new Set<QRegime>([
-    "na", "symbolic", "generic-R", "real-positive", "fixed-q0",
-  ]),
-  "appendix-nf-witnesses": new Set<QRegime>([
-    "na", "symbolic", "generic-R", "fixed-q0",
-  ]),
-  "appendix-surreals": new Set<QRegime>([
-    "na", "symbolic", "generic-R",
-  ]),
-  "appendix-transfer-matrices": new Set<QRegime>([
-    "na", "symbolic", "generic-R", "real-positive", "fixed-q0",
-  ]),
-
-  // Glossary and notation entries are register tables — allow any.
-  glossary: new Set<QRegime>([
-    "na", "symbolic", "generic-R", "real-positive", "real-gt-1",
-    "real-lt-1", "mod-gt-1", "mod-lt-1", "unit-circle",
-    "root-of-unity", "fixed-q0",
-  ]),
-  "index-of-definitions": new Set<QRegime>([
-    "na", "symbolic", "generic-R", "real-positive", "real-gt-1",
-    "real-lt-1", "mod-gt-1", "mod-lt-1", "unit-circle",
-    "root-of-unity", "fixed-q0",
-  ]),
-};
-
-/** Chapters whose narrative-expected profile is "categorical only". */
-const CATEGORICAL_CHAPTERS: ReadonlySet<string> = new Set([
-  "quantum-universes",
-  "lifting-and-descent",
-  "braids-and-knots",
-  "appendix-knot-operations",
-  "appendix-surreals",
-]);
-
-/** Chapters whose narrative-expected profile is "archimedean / fixed q_0". */
-const ARCHIMEDEAN_CHAPTERS: ReadonlySet<string> = new Set([
-  "mass-theory",
-  "particle-interactions",
-  "gravity-spacetime",
-  "climax-volume-mass",
-  "observations",
-  "predicted-spectra",
-  "measurement-observation",
-  "molecular-construction",
-  "organic-chemistry",
-  "fluid-dynamics",
-  "appendix-qvalues",
-  "appendix-atomic-mass-calculations",
-]);
 
 // ── Regime detectors ────────────────────────────────────────────
 

--- a/docs/reference/skill-instructions/content-author.md
+++ b/docs/reference/skill-instructions/content-author.md
@@ -20,6 +20,24 @@ Create and develop content artifacts according to the project plan.
 - Create user scenarios and personas
 - Author functional and non-functional requirements
 - Define indicators and measures
+- **Verify authored content against the repo's own CI before opening a PR** —
+  dispatch the relevant workflow on your branch and record the result (see
+  below)
+
+## Don't hand off on a workflow nobody ran
+
+Authoring is not finished at "it builds here". Before the PR, push and
+dispatch the repo's verification workflow against your branch
+(`gh workflow run <wf>.yml --ref <branch>`, or `actions_run_trigger`), wait
+for it, and put the **run URL and conclusion** in the PR body. Red → fix and
+re-dispatch. If you lack `actions: write`, state that in the PR along with the
+command a maintainer should run.
+
+Check when that workflow **last ran**, too. A repo can carry a CI file that
+has not executed in months: qou's `lean_ci.yml` last ran 2026-04-25 and
+failed, and in the interval 37 Lean modules stopped compiling — some with
+parse errors, meaning they had never compiled. Nothing caught it because
+nothing ran.
 
 ## Actors
 - Business Analyst (L2 authoring lead)

--- a/docs/reference/skill-instructions/content-test.md
+++ b/docs/reference/skill-instructions/content-test.md
@@ -44,6 +44,31 @@ qou's `lean_ci.yml` last ran 2026-04-25 and failed on `main`. Nothing
 dispatched it for four months, and 37 modules stopped compiling unnoticed —
 several with plain parse errors, i.e. files that had never compiled at all.
 
+## A green build only covers what the target reaches
+
+Before reading "build green" as a claim about the corpus, check what the build
+target actually compiles. Build systems default to **narrow roots**: Lake's
+`lean_lib` uses `globs := roots.map Glob.one`, so `lake build` compiles the
+root module plus its transitive `import`s — not the source directory.
+`srcDir` widens where sources are *found*, never what is *built*.
+
+Measured in qou on 2026-08-08: `lake build` reached **853 of the 1618**
+modules under `lean/QOU/`. The other 766 (47%) had no olean at all — among
+them the module holding the single `sorry` gating the Specht chain, which is
+why the package build's sorry-warning list omitted it.
+
+The check is cheap in any build system — count artifacts against sources:
+
+```sh
+find .lake/build/lib/lean/QOU -name '*.olean' | wc -l   # 860
+find QOU -name '*.lean' | wc -l                         # 1618
+```
+
+A ratio far from 1 means the green is scoped, and **any corpus-wide number
+read off that build — sorry counts, coverage, warning totals — is an
+undercount by construction.** Say what the build covered, not just that it
+passed.
+
 ## Actors
 - QC Reviewer (lead)
 - FHIR Modeller (technical testing)

--- a/docs/reference/skill-instructions/content-test.md
+++ b/docs/reference/skill-instructions/content-test.md
@@ -17,10 +17,32 @@ End-to-end testing of content artifacts in realistic scenarios.
 - Verify StructureMap extraction output (FHIR)
 - Verify CQL execution and measure calculations (FHIR)
 - Run Lean proof verification (formal math)
+- **Dispatch the repo's Lean CI workflow on your branch and fold the result
+  into the PR** — see below; a local build is not CI green
 - Validate LaTeX compilation and output (formal math)
 - Test cross-component integration
 - Run regression tests against previous versions
 - Document test results
+
+## Running CI, not just assuming it
+
+A local `lake build` runs on a warm `.lake`, your toolchain, and whatever
+build flags you set. CI runs cold, on its own toolchain, with none of that.
+They fail differently, so a local green is evidence about your machine, not
+about the branch.
+
+So: push, then dispatch the workflow against your branch
+(`gh workflow run <lean-ci>.yml --ref <branch>`, or the `actions_run_trigger`
+MCP tool), wait for it, and record **run URL + conclusion** in the PR body.
+Red → fix and re-dispatch. If dispatch is refused for lack of `actions: write`,
+say so in the PR and give the command a maintainer should run — never leave it
+silently unmentioned.
+
+Also check **when CI last ran** (`actions_list` → `list_workflow_runs`). The
+existence of a workflow is not evidence that anything is being checked:
+qou's `lean_ci.yml` last ran 2026-04-25 and failed on `main`. Nothing
+dispatched it for four months, and 37 modules stopped compiling unnoticed —
+several with plain parse errors, i.e. files that had never compiled at all.
 
 ## Actors
 - QC Reviewer (lead)

--- a/scripts/lean-audit.ts
+++ b/scripts/lean-audit.ts
@@ -26,6 +26,7 @@ import { execSync } from "child_process";
 import { isWitnessed, isStale } from "./lean-witness";
 import { findContentRepoRoot } from "../content/pipeline/repo-root";
 import { requirePaper } from "../content/pipeline/repo-root";
+import { leanModuleChapter } from "../content/pipeline/chapter-profile-registry-di";
 
 // Was `import.meta.dir`-relative, i.e. the PLATFORM — but every path below is
 // folio content (`content/**`, `computations/**`), and this is used as the cwd
@@ -332,26 +333,15 @@ function getChapterName(dir: string): string {
 }
 
 // Map build-system lean files to chapters based on module path
+// Rules are FOLIO content: which Lean namespace belongs to which chapter is a
+// fact about one paper's module layout. Injected via the chapter-profile
+// registry; an unmatched path falls back exactly as before.
 function mapBuildFileToChapter(filePath: string): string {
   const rel = relative(CONTENT_ROOT, filePath);
-  if (rel.includes("QOU/QuantumObservableUniverse")) return "ch1-quantum-observable-universe";
-  if (rel.includes("QOU/Torsion")) return "ch3-lifting-of-quantum-torsion";
-  if (rel.includes("QOU/Descartes/")) return "ch6-descartes-universe";
-  if (rel.includes("QOU/PathIntegrals") || rel.includes("QOU/KnotTheory") || rel.includes("QOU/KnotRegistry"))
-    return "ch4-path-integrals-and-braiding";
-  if (rel.includes("QOU/BringsSurface")) return "ch5-brings-surface";
-  if (rel.includes("QOU/DescartesUniverse")) return "ch6-descartes-universe";
-  if (rel.includes("QOU/GaugeFieldFluidDynamics")) return "ch10-fluid-dynamics";
-  if (rel.includes("QOU/InformationTheory")) return "ch9-information-theory";
-  if (rel.includes("QOU/QGeometricLanglands")) return "ch11-q-geometric-langlands";
-  if (rel.includes("QOU/Glossary")) return "ch8-glossary";
-  if (rel.includes("QOU/HadronicMass") || rel.includes("QOU/AtomicMass") || rel.includes("QOU/MassDerivation"))
-    return "ch7-observations";
-  if (rel.includes("QOU/CODATAChain")) return "ch7-observations";
-  if (rel.includes("QOU/RepresentationTheory")) return "ch2-quantum-geometry";
-  if (rel.includes("QOU/Calculations") || rel.includes("QOU/MathConstants")) return "shared";
-  return "core";
+  // `"core"` is the original fallback for an unmatched path — preserved.
+  return leanModuleChapter(rel) ?? "core";
 }
+
 
 // ── Main audit ───────────────────────────────────────────────────
 

--- a/scripts/tests/chapter-profile-registry-di.test.ts
+++ b/scripts/tests/chapter-profile-registry-di.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Chapter profiles — which q-regimes a chapter may use, which chapters are
+ * categorical, which archimedean — are editorial judgements about ONE folio's
+ * chapters. A 31-entry map keyed by qou chapter directory names lived inline in
+ * `qa-checkers-q-usage.ts`; it is behind a DI registry now, the third after
+ * `value-registry-di` and `references-registry-di`.
+ *
+ * The two existing registries THROW when unconfigured, because a values or
+ * bibliography lookup returning nothing is a bug. This one deliberately does
+ * not: a folio that declares no chapter policy is a legitimate folio. Which
+ * puts the whole weight on one distinction —
+ *
+ *   **unconfigured must read as `n/a`, never as "expectation met".**
+ *
+ * That is the failure mode this whole session has been about: a check that
+ * passes because it found nothing. These pin it, along with the Proxy
+ * plumbing that lets the checker keep reading the values as it always has.
+ */
+import { describe, test, expect, afterEach } from "bun:test";
+import {
+  configureChapterProfiles,
+  resetChapterProfiles,
+  getChapterProfiles,
+  chapterProfilesConfigured,
+  chapterHasProfile,
+  CHAPTER_EXPECTED_REGIMES,
+  CATEGORICAL_CHAPTERS,
+  ARCHIMEDEAN_CHAPTERS,
+} from "../../content/pipeline/chapter-profile-registry-di.ts";
+
+afterEach(() => resetChapterProfiles());
+
+const FIXTURE = {
+  chapterExpectedRegimes: {
+    "opening-chapter": new Set(["na", "symbolic"]),
+    "measured-chapter": new Set(["na", "real-positive", "fixed-q0"]),
+  },
+  categoricalChapters: new Set(["opening-chapter"]),
+  archimedeanChapters: new Set(["measured-chapter"]),
+};
+
+describe("unconfigured is 'no opinion', not 'no findings'", () => {
+  test("reports itself unconfigured", () => {
+    resetChapterProfiles();
+    expect(chapterProfilesConfigured()).toBe(false);
+  });
+
+  test("no chapter has a profile — so nothing can be scored as passing", () => {
+    resetChapterProfiles();
+    expect(chapterHasProfile("opening-chapter")).toBe(false);
+    expect(chapterHasProfile(undefined)).toBe(false);
+  });
+
+  test("the empty registry is empty, not a stub that answers yes", () => {
+    // The trap would be a default that makes every membership test true, or a
+    // lookup that returns a permissive set — either reads as "allowed".
+    resetChapterProfiles();
+    expect(CHAPTER_EXPECTED_REGIMES["anything"]).toBeUndefined();
+    expect(CATEGORICAL_CHAPTERS.has("anything")).toBe(false);
+    expect(ARCHIMEDEAN_CHAPTERS.has("anything")).toBe(false);
+    expect(CATEGORICAL_CHAPTERS.size).toBe(0);
+    expect(Object.keys(CHAPTER_EXPECTED_REGIMES)).toEqual([]);
+  });
+});
+
+describe("configured", () => {
+  test("the value exports read through to the injected data", () => {
+    configureChapterProfiles(FIXTURE);
+    expect([...CHAPTER_EXPECTED_REGIMES["opening-chapter"]]).toEqual(["na", "symbolic"]);
+    expect(CATEGORICAL_CHAPTERS.has("opening-chapter")).toBe(true);
+    expect(ARCHIMEDEAN_CHAPTERS.has("measured-chapter")).toBe(true);
+    expect(CATEGORICAL_CHAPTERS.size).toBe(1);
+  });
+
+  test("`in`, Object.keys and Object.entries work through the Proxy", () => {
+    // `ownKeys` and `getOwnPropertyDescriptor` have to agree or `Object.entries`
+    // throws on a Proxy — the failure is a TypeError at the first consumer,
+    // not a wrong answer, but it would only appear at runtime.
+    configureChapterProfiles(FIXTURE);
+    expect("opening-chapter" in CHAPTER_EXPECTED_REGIMES).toBe(true);
+    expect(Object.keys(CHAPTER_EXPECTED_REGIMES).sort())
+      .toEqual(["measured-chapter", "opening-chapter"]);
+    expect(() => Object.entries(CHAPTER_EXPECTED_REGIMES)).not.toThrow();
+    expect(Object.entries(CHAPTER_EXPECTED_REGIMES)).toHaveLength(2);
+  });
+
+  test("iteration over the chapter sets works", () => {
+    configureChapterProfiles(FIXTURE);
+    expect([...CATEGORICAL_CHAPTERS]).toEqual(["opening-chapter"]);
+    expect([...ARCHIMEDEAN_CHAPTERS]).toEqual(["measured-chapter"]);
+  });
+
+  test("chapterHasProfile distinguishes a known chapter from an unknown one", () => {
+    configureChapterProfiles(FIXTURE);
+    expect(chapterHasProfile("opening-chapter")).toBe(true);
+    expect(chapterHasProfile("never-heard-of-it")).toBe(false);
+  });
+
+  test("a later configure wins, so a folio can override the shipped default", () => {
+    // This is what lets qou wire its own profiles without first deleting
+    // `_folio-chapter-profiles.qou.ts`.
+    configureChapterProfiles(FIXTURE);
+    configureChapterProfiles({
+      chapterExpectedRegimes: { "only-mine": new Set(["na"]) },
+      categoricalChapters: new Set(),
+      archimedeanChapters: new Set(),
+    });
+    expect(Object.keys(CHAPTER_EXPECTED_REGIMES)).toEqual(["only-mine"]);
+    expect(chapterHasProfile("opening-chapter")).toBe(false);
+  });
+});
+
+describe("the shipped qou default", () => {
+  test("registers the profiles the checker used to hold inline", async () => {
+    // Importing the checker runs `registerDefaultChapterProfiles()`, so the
+    // 31 chapters remain scored exactly as before the extraction.
+    resetChapterProfiles();
+    const mod = await import("../../content/pipeline/qa-checkers-q-usage.ts");
+    expect(chapterProfilesConfigured()).toBe(true);
+    expect(Object.keys(mod.CHAPTER_EXPECTED_REGIMES).length).toBeGreaterThan(20);
+    expect(mod.CATEGORICAL_CHAPTERS.has("quantum-universes")).toBe(true);
+    expect(getChapterProfiles().archimedeanChapters.size).toBeGreaterThan(0);
+  });
+});

--- a/scripts/tests/chapter-profile-registry-di.test.ts
+++ b/scripts/tests/chapter-profile-registry-di.test.ts
@@ -27,8 +27,17 @@ import {
   CATEGORICAL_CHAPTERS,
   ARCHIMEDEAN_CHAPTERS,
 } from "../../content/pipeline/chapter-profile-registry-di.ts";
+import { registerDefaultChapterProfiles }
+  from "../../content/pipeline/_folio-chapter-profiles.qou.ts";
 
-afterEach(() => resetChapterProfiles());
+// Restore the shipped default rather than leaving the registry empty.
+// `registerDefaultChapterProfiles()` runs as a module-load side effect of
+// importing the checker, so it fires ONCE per process — a bare
+// `resetChapterProfiles()` here would leave every later test file (e.g.
+// `q-usage-chapter-regimes.test.ts`, which reads all three exports) looking
+// at an empty registry, with the failure landing in whichever file happened
+// to run next. Found exactly that way: green alone, red in the suite.
+afterEach(() => registerDefaultChapterProfiles());
 
 const FIXTURE = {
   chapterExpectedRegimes: {
@@ -112,9 +121,11 @@ describe("configured", () => {
 
 describe("the shipped qou default", () => {
   test("registers the profiles the checker used to hold inline", async () => {
-    // Importing the checker runs `registerDefaultChapterProfiles()`, so the
-    // 31 chapters remain scored exactly as before the extraction.
+    // Call the entry point directly. Relying on the import side effect would
+    // pass alone and fail in the suite, where the module is already cached
+    // and the side effect will not fire again.
     resetChapterProfiles();
+    registerDefaultChapterProfiles();
     const mod = await import("../../content/pipeline/qa-checkers-q-usage.ts");
     expect(chapterProfilesConfigured()).toBe(true);
     expect(Object.keys(mod.CHAPTER_EXPECTED_REGIMES).length).toBeGreaterThan(20);

--- a/scripts/tests/lake-cache.test.ts
+++ b/scripts/tests/lake-cache.test.ts
@@ -45,7 +45,17 @@ function run(
 }
 
 function git(args: string[], cwd: string) {
-  execFileSync("git", args, { cwd, stdio: "pipe" });
+  // `stdio: "pipe"` alone throws `Command failed: git push …` with git's own
+  // stderr discarded, so a fixture failure tells you nothing about why — which
+  // is exactly what happened when this suite went flaky under load. Capture it
+  // and put it in the message.
+  const r = spawnSync("git", args, { cwd, encoding: "utf-8" });
+  if (r.status !== 0) {
+    throw new Error(
+      `git ${args.join(" ")} (cwd ${cwd}) exited ${r.status}` +
+      `${r.signal ? ` on ${r.signal}` : ""}\n${r.stderr ?? ""}${r.stdout ?? ""}`,
+    );
+  }
 }
 
 /** A `.lake` tree with `count` dependency oleans and `own` package oleans. */
@@ -66,7 +76,9 @@ beforeAll(() => {
   // Bare remote.
   const bare = join(root, "origin.git");
   mkdirSync(bare);
-  git(["init", "--bare", "-q"], root);
+  // Was preceded by a stray `git init --bare -q` with cwd=root and NO path,
+  // which turned the temp root itself into a bare repo — an unwanted repo
+  // wrapping the working clone, created by a line that looks like setup.
   execFileSync("git", ["init", "--bare", "-q", bare], { stdio: "pipe" });
 
   // Working repo with a Lake package nested two levels down — the

--- a/skills/content-lifecycle/content-author.md
+++ b/skills/content-lifecycle/content-author.md
@@ -10,6 +10,24 @@ Create and develop content artifacts according to the project plan.
 - Create user scenarios and personas
 - Author functional and non-functional requirements
 - Define indicators and measures
+- **Verify authored content against the repo's own CI before opening a PR** —
+  dispatch the relevant workflow on your branch and record the result (see
+  below)
+
+## Don't hand off on a workflow nobody ran
+
+Authoring is not finished at "it builds here". Before the PR, push and
+dispatch the repo's verification workflow against your branch
+(`gh workflow run <wf>.yml --ref <branch>`, or `actions_run_trigger`), wait
+for it, and put the **run URL and conclusion** in the PR body. Red → fix and
+re-dispatch. If you lack `actions: write`, state that in the PR along with the
+command a maintainer should run.
+
+Check when that workflow **last ran**, too. A repo can carry a CI file that
+has not executed in months: qou's `lean_ci.yml` last ran 2026-04-25 and
+failed, and in the interval 37 Lean modules stopped compiling — some with
+parse errors, meaning they had never compiled. Nothing caught it because
+nothing ran.
 
 ## Actors
 - Business Analyst (L2 authoring lead)

--- a/skills/content-lifecycle/content-test.md
+++ b/skills/content-lifecycle/content-test.md
@@ -7,10 +7,32 @@ End-to-end testing of content artifacts in realistic scenarios.
 - Verify StructureMap extraction output (FHIR)
 - Verify CQL execution and measure calculations (FHIR)
 - Run Lean proof verification (formal math)
+- **Dispatch the repo's Lean CI workflow on your branch and fold the result
+  into the PR** — see below; a local build is not CI green
 - Validate LaTeX compilation and output (formal math)
 - Test cross-component integration
 - Run regression tests against previous versions
 - Document test results
+
+## Running CI, not just assuming it
+
+A local `lake build` runs on a warm `.lake`, your toolchain, and whatever
+build flags you set. CI runs cold, on its own toolchain, with none of that.
+They fail differently, so a local green is evidence about your machine, not
+about the branch.
+
+So: push, then dispatch the workflow against your branch
+(`gh workflow run <lean-ci>.yml --ref <branch>`, or the `actions_run_trigger`
+MCP tool), wait for it, and record **run URL + conclusion** in the PR body.
+Red → fix and re-dispatch. If dispatch is refused for lack of `actions: write`,
+say so in the PR and give the command a maintainer should run — never leave it
+silently unmentioned.
+
+Also check **when CI last ran** (`actions_list` → `list_workflow_runs`). The
+existence of a workflow is not evidence that anything is being checked:
+qou's `lean_ci.yml` last ran 2026-04-25 and failed on `main`. Nothing
+dispatched it for four months, and 37 modules stopped compiling unnoticed —
+several with plain parse errors, i.e. files that had never compiled at all.
 
 ## Actors
 - QC Reviewer (lead)

--- a/skills/content-lifecycle/content-test.md
+++ b/skills/content-lifecycle/content-test.md
@@ -34,6 +34,31 @@ qou's `lean_ci.yml` last ran 2026-04-25 and failed on `main`. Nothing
 dispatched it for four months, and 37 modules stopped compiling unnoticed —
 several with plain parse errors, i.e. files that had never compiled at all.
 
+## A green build only covers what the target reaches
+
+Before reading "build green" as a claim about the corpus, check what the build
+target actually compiles. Build systems default to **narrow roots**: Lake's
+`lean_lib` uses `globs := roots.map Glob.one`, so `lake build` compiles the
+root module plus its transitive `import`s — not the source directory.
+`srcDir` widens where sources are *found*, never what is *built*.
+
+Measured in qou on 2026-08-08: `lake build` reached **853 of the 1618**
+modules under `lean/QOU/`. The other 766 (47%) had no olean at all — among
+them the module holding the single `sorry` gating the Specht chain, which is
+why the package build's sorry-warning list omitted it.
+
+The check is cheap in any build system — count artifacts against sources:
+
+```sh
+find .lake/build/lib/lean/QOU -name '*.olean' | wc -l   # 860
+find QOU -name '*.lean' | wc -l                         # 1618
+```
+
+A ratio far from 1 means the green is scoped, and **any corpus-wide number
+read off that build — sorry counts, coverage, warning totals — is an
+undercount by construction.** Say what the build covered, not just that it
+passed.
+
 ## Actors
 - QC Reviewer (lead)
 - FHIR Modeller (technical testing)


### PR DESCRIPTION
Every open bean is now either done, scrapped with reasons, or blocked with the blocker **measured rather than inherited**.

`tsc` 0 errors, 445 tests / 0 fail, `eslint` exit 0.

---

## Took over a stalled sibling

`claude/agent-stalled-pickup-n79db3` — three commits, no PR, no bean claiming it. Its work is the same defect class this branch has been chasing, found independently from the folio side: *the existence of a CI file is not evidence anything is being checked*.

I verified its claims rather than trusting them:

- The regenerated skill-instruction docs **are** in sync — re-ran `gen-skill-docs.ts`, byte-identical (102 bodies).
- Its central claim checks out: **qou's `lean_ci.yml` last ran 2026-04-25**, 749 runs total, most recent all `failure`. Three and a half months with nothing dispatching it, during which 37 Lean modules stopped compiling. For contrast, folio-assistant's own `lean_ci.yml` has **0 runs, ever**.

Its second half is sharper: *"a green build only covers what the target reaches"*. Lake's `lean_lib` globs from roots, so `lake build` compiled **853 of 1618** modules under `lean/QOU/` — and the 766 it never reached included the module holding the single `sorry` gating the Specht chain, which is why the package build's sorry list omitted it.

Brought onto this branch rather than pushed to theirs, so that branch is untouched if the session wakes.

## `sklb` — folio vocabulary behind a third DI registry

31 chapter profiles + 5 categorical + 12 archimedean chapters, 13 physics terms, 19 Lean-namespace rules — all out of platform code and into `chapter-profile-registry-di.ts`, matching `value-registry-di` and `references-registry-di`.

**One deliberate departure:** the other two *throw* when unconfigured. This one doesn't — a folio with no chapter policy is legitimate, not broken. Which puts the whole weight on one distinction: **unconfigured must read `n/a`, never "expectation met"** — the exact failure mode of everything else on this branch. The empty default is verified empty rather than permissive: no membership test returns true, no lookup returns a set.

The data isn't deleted, since the other half is in a repo this change can't touch. It sits quarantined in `_folio-chapter-profiles.qou.ts`, registering itself as the default so qou's criteria don't silently go `n/a` first, and carrying the three-step finish.

**Behaviour-neutral, proven twice rather than asserted:**

| | check | result |
|---|---|---|
| chapter profiles | all 31 chapters + both sets dumped through the public exports, before vs after | byte-identical |
| module map | original function reproduced verbatim beside the new one, run over **525 paths** — every fragment in four shapes plus all 441 overlapping pairs | **0 mismatches** |

That exhaustiveness earned its keep. My first extraction silently dropped **6 of 19** path fragments (three rules are multi-line ORs; a same-line regex missed them), and the rewrite defaulted to `"unmapped"` where the original defaults to `"core"`. Spot-probing seven paths caught the first; the 525-path sweep is what makes the claim safe.

## `15gn` — scrapped, its own condition already answered

Its revisit trigger ("needs offline operation") **has** fired: `lean-environment-setup.md` documents loogle/leansearch failing with `SSL: CERTIFICATE_VERIFY_FAILED` in a sandbox. But it's already met by three substitutes needing no new dependency — grepping the shipped Mathlib source, `lean_local_search`, `lean_hover_info`. The evaluation this bean asked for has an answer, and it's *no*.

## `02kc` / `5d7z` / `nimj` — blocked, now measured

Re-tested instead of inherited. The toolchain half **is** resolved (`lean` 4.24.0 and `lake` 5.0.0 both run). The network half is not:

```
release.lean-lang.org            HTTP 000
leanprover-community.github.io   HTTP 000
github.com/…/mathlib4            HTTP 403
```

`lake exe cache get` fetches from the second, so the fast route is out; the slow route is the hours-long build already measured. And there is no folio here at all. `nimj` sits downstream of the reseed by its own analysis. All three now carry the measurement so nobody re-spends turns confirming it.

## A flaky test, fixed on the way past

The suite went intermittently red under concurrent load — ~1 run in 4, with a different *test total* each time (453 vs 480), so a file was failing to load rather than an assertion failing. All the output gave was `error: Command failed: git push -q origin main` / `(fail) (unnamed)`.

Two fixture bugs: `git()` discarded git's stderr, so a fixture failure couldn't say why; and `beforeAll` ran a stray `git init --bare -q` with cwd=root and no path, turning the temp root itself into a bare repo wrapping both the clone and the bare remote.

Not claiming proof of causation — ~19 clean runs since, which cannot settle a 1-in-4. What is certain is that a real bug is gone and the next recurrence will report its cause.

---

## Reviewing

- `876913b`–`3a185b0` — the sibling's three commits, taken over
- `0136b86`, `7921a79` — the registry, and the two remaining vocabularies
- `9bd9d16` — a test-pollution bug I shipped in `0136b86` and caught by reading the count rather than the exit code
- `f693aa6` — the flake

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LL9F9XMXAvKZzjxxhMs2bQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LL9F9XMXAvKZzjxxhMs2bQ)_