### PR TITLE
A probe that measured nothing was reporting "not machine-trivial"

### DIFF
--- a/.beans/folio-assistant-nimj--nazrin-as-triviality-oracle-proof-not-machine-triv.md
+++ b/.beans/folio-assistant-nimj--nazrin-as-triviality-oracle-proof-not-machine-triv.md
@@ -120,3 +120,77 @@ the false-positive rate → only then tune the threshold or raise severity.**
 Nothing here is actionable from an authoring container. The criterion remains
 inert by construction in the meantime — no cache means `n/a`, and the note says
 "not measured", never "nothing trivial".
+
+
+---
+
+## Measured 2026-08-08 (session `3bada08b`) — the oracle works; three defects fixed
+
+The bean was blocked on the false-positive rate, which needs the `5d7z`
+reseed. But a second question was sitting underneath it, unnoticed and not
+blocked: **the first qou run reported `probed 12, closed 0`, and that was read
+here as "none of 12 real qou theorems fall to cheap automation". A probe that
+can never close anything prints the identical line.** Nothing in the output
+separated the two readings.
+
+Settled it with a control: core-Lean declarations of known difficulty, run
+through the real code path (no Mathlib, no folio, no cache — just the toolchain
+`ga7e` restored).
+
+    trivTrue     CLOSED step 1 (trivial)
+    simpAppend   CLOSED step 3 (simp)      <- trivial and rfl both lost first
+    omegaLinear  CLOSED step 5 (omega)     <- the ladder really walks
+    substantive  open                      <- and does not close everything
+
+So the probe discriminates, and qou's `closed 0` is a real measurement. That
+control is now `scripts/tests/lean-triviality-probe.test.ts`.
+
+Getting there surfaced three ways the probe reported a **mechanical failure as
+a substantive result** — each one scoring a block `pass`, "not machine-trivial":
+
+1. **A rung that is not installed.** `aesop` is not core Lean; without Mathlib
+   it errors `unknown tactic` and exits non-zero, which an exit-code check
+   scores as "ran and lost". The ladder silently had five rungs. Now recorded
+   as `ladder.unavailable`, and the criterion reads a short-ladder "not closed"
+   as `n/a` rather than `pass`.
+2. **A rung that ran out of time.** `execFileSync` reports a timeout by killing
+   the child, landing in the same catch as a failed proof. A tactic that did
+   not answer is not a tactic that lost — and `simp` is the rung most likely to
+   be slow on the goals most worth flagging. Now `ladder.timedOut`. Same for
+   the baseline: `baseline-timeout` is a distinct skip from `baseline-fails`,
+   because "too slow" must not print "restore the oleans".
+3. **A splice that landed inside the statement.** `splitDeclarations` cut at
+   the first `:=` *anywhere*, though its doc comment has always said "the first
+   **top-level** `:=`". A statement containing one — `(let x := 5; x) = 5`, a
+   structure instance — had the tactic written over its own type; the file
+   stopped elaborating, all six rungs failed, `closed: false`. Fixed at the
+   source with `topLevelCut`.
+
+**Defect 3 reached further than this bean.** `lean-signature` builds the QA
+**statement hash** from the same cut, so a truncated signature hashes a partial
+statement:
+
+    theorem t : (let x := 5; x) = 5 := by rfl     hash d1b45ae0f3e3
+    theorem t : (let x := 5; x) = 6 := by rfl     hash d1b45ae0f3e3
+
+A changed statement that never invalidates its QA sidecar — a staleness check
+passing by finding nothing. Equivalence-checked before landing: over 17
+declaration shapes the new cut agrees with the old on all 12 that were already
+correct, and differs only on the 5 it was getting wrong.
+
+The skip bucket is also classified now (`decl-not-found` / `no-body` /
+`baseline-fails` / `baseline-timeout`), because this bean's own headline number
+— 16 of 28 blocks (57%) unprobeable — came from an undifferentiated counter
+whose log line asserted one cause for all four. When the reseed lands, that
+number will say which fix it needs.
+
+### Remaining — unchanged, still gated on 5d7z
+
+- [ ] Reseed the cache (5d7z), then re-run the probe over the full corpus.
+- [ ] With hits in hand, measure the actual false-positive rate.
+- [ ] Tune the ladder / threshold on that evidence.
+- [ ] Only then consider raising severity above `minor`.
+
+What changed is that the measurement will now be trustworthy when it runs.
+Before this it would have been taken with a five-rung ladder, a timeout counted
+as a loss, and any statement containing `:=` silently scored "not trivial".

--- a/content/pipeline/lean-atlas-ingest.ts
+++ b/content/pipeline/lean-atlas-ingest.ts
@@ -190,6 +190,80 @@ interface DeclSpan {
   signature: string;
   /** Body text (after `:=` / `where`), empty when there is none. */
   body: string;
+  /**
+   * Absolute offset of `body` within the stripped source, or -1 when the
+   * declaration has no body.
+   *
+   * Callers that need to splice the body (the triviality probe) must not
+   * re-find it with `indexOf`: bodies repeat verbatim across a file
+   * (`:= by rfl` is not distinctive), so a search can land on the wrong
+   * one and rewrite a different declaration than the one requested.
+   */
+  bodyAt: number;
+}
+
+/** Bracket pairs that can nest a `:=` inside a statement. */
+const OPEN = "([{⟨⦃";
+const CLOSE = ")]}⟩⦄";
+/** Lean identifier characters, for the `where` word boundary. */
+const IDENT = /[A-Za-z0-9_'.!?]/;
+
+/**
+ * Offset of the first **top-level** `:=` or `where` in `text`, or -1.
+ *
+ * Top-level means outside every bracket pair and outside string
+ * literals. A theorem *statement* may legitimately contain `:=` — a
+ * `let` (`(let x := 5; x) = 5`), a structure instance (`{ a := 1 }`), an
+ * anonymous constructor — and cutting at the first one anywhere puts
+ * statement text into the body. Measured consequences of getting this
+ * wrong, all three of which read as a clean result rather than an error:
+ *
+ * - `lean-signature` hashes only the truncated signature, so
+ *   `(let x := 5; x) = 5` and `... = 6` hash identically and a changed
+ *   statement never invalidates its QA sidecar;
+ * - `lean-triviality-probe` splices its tactic over the tail of the
+ *   statement, the file stops elaborating, every ladder rung fails, and
+ *   the declaration is recorded `closed: false` — "not machine-trivial";
+ * - scan mode files the statement's own text under `value_deps`.
+ *
+ * Char literals are deliberately NOT tracked: `'` is far more often a
+ * prime in an identifier (`h'`, `ih'`) than a delimiter, so treating it
+ * as a quote would miscut far more declarations than it rescues.
+ */
+export function topLevelCut(text: string): number {
+  let depth = 0;
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (c === '"') {
+      i++;
+      while (i < text.length && text[i] !== '"') {
+        if (text[i] === "\\") i++;
+        i++;
+      }
+      continue;
+    }
+    if (OPEN.includes(c)) {
+      depth++;
+      continue;
+    }
+    if (CLOSE.includes(c)) {
+      // Clamp: a stray closer (the span boundary can chop mid-term) must
+      // not drive depth negative and mask every later top-level cut.
+      if (depth > 0) depth--;
+      continue;
+    }
+    if (depth !== 0) continue;
+    if (c === ":" && text[i + 1] === "=") return i;
+    if (
+      c === "w" &&
+      text.startsWith("where", i) &&
+      !IDENT.test(text[i - 1] ?? " ") &&
+      !IDENT.test(text[i + 5] ?? " ")
+    ) {
+      return i;
+    }
+  }
+  return -1;
 }
 
 /**
@@ -211,11 +285,12 @@ export function splitDeclarations(stripped: string): DeclSpan[] {
     const from = starts[i].at;
     const to = i + 1 < starts.length ? starts[i + 1].at : stripped.length;
     const text = stripped.slice(from, to);
-    const cut = text.search(/:=|\bwhere\b/);
+    const cut = topLevelCut(text);
     spans.push({
       name: starts[i].name,
       signature: cut === -1 ? text : text.slice(0, cut),
       body: cut === -1 ? "" : text.slice(cut),
+      bodyAt: cut === -1 ? -1 : from + cut,
     });
   }
   return spans;

--- a/content/pipeline/lean-triviality-probe.ts
+++ b/content/pipeline/lean-triviality-probe.ts
@@ -37,6 +37,34 @@
  * the `simp` set rather than that there is no content. The output feeds
  * `proof-not-machine-trivial`, which is warn-only and `minor`.
  *
+ * ## What a MISS means — three ways to measure nothing
+ *
+ * The first qou run printed `probed 12, closed 0`, and that was read as
+ * "no qou theorem falls to cheap automation". A probe that cannot close
+ * anything prints the same line, so the reading was not available from
+ * the output. Three mechanical failures used to arrive dressed as that
+ * substantive result; each now reports itself:
+ *
+ * - **A rung that is not installed.** `aesop` is not core Lean; without
+ *   Mathlib it errors `unknown tactic` and exits non-zero, which an
+ *   exit-code check scores as "ran and lost". The ladder silently had
+ *   five rungs. Now recorded in `ladder.unavailable`.
+ * - **A rung that ran out of time.** `execFileSync` reports a timeout by
+ *   killing the child, landing in the same catch as a failed proof. A
+ *   tactic that did not answer is not a tactic that lost — and `simp` is
+ *   the rung most likely to be slow on the goals most worth flagging.
+ *   Now `ladder.timedOut`.
+ * - **A splice that landed in the statement.** `splitDeclarations` cut
+ *   at the first `:=` *anywhere*, so a statement containing one — a
+ *   `let`, a structure instance — had the tactic written over its own
+ *   type. The file stopped elaborating, every rung failed, and the
+ *   declaration was recorded `closed: false`. Fixed at the source with
+ *   `topLevelCut`.
+ *
+ * The controls that keep this honest are in
+ * `scripts/tests/lean-triviality-probe.test.ts`: declarations of known
+ * difficulty, asserted to close at the expected rung.
+ *
  * ## Usage
  *
  *   bun run content/pipeline/lean-triviality-probe.ts \
@@ -86,21 +114,72 @@ export function leanPathFor(lakeRoot: string): string {
   return out.join(":");
 }
 
-export interface ProbeResult {
-  decl: string;
-  closed: boolean;
-  /** 1-based rung of the ladder that closed it. */
-  steps?: number;
-  tactic?: string;
+/**
+ * Why a probe could not run. Never conflate these with a result: each
+ * one means "not measured", and only `open` means "measured, resisted".
+ */
+export type SkipReason =
+  /** `splitDeclarations` saw no declaration by that name. */
+  | "decl-not-found"
+  /** The declaration has no top-level `:=` body to substitute. */
+  | "no-body"
+  /** The file does not elaborate unmodified — usually missing oleans. */
+  | "baseline-fails"
+  /** The file elaborates too slowly to probe. Not the same as broken. */
+  | "baseline-timeout";
+
+/** What each skip reason means, and therefore what would fix it. */
+export const SKIP_EXPLANATION: Record<SkipReason, string> = {
+  "decl-not-found": "the lexer saw no declaration by that name — check the lean.ref, not the oleans",
+  "no-body": "declaration has no top-level `:=` body; the probe was never applicable",
+  "baseline-fails": "file does not elaborate unmodified — usually missing oleans; restore the cache",
+  "baseline-timeout": "file elaborates too slowly to probe — raise the timeout, do not read as broken",
+};
+
+/** Which rungs actually ran, and which never gave an answer. */
+export interface LadderRun {
+  ran: string[];
+  /** Rungs absent from this environment — e.g. `aesop` without Mathlib. */
+  unavailable: string[];
+  /**
+   * Rungs killed by the timeout. A tactic that ran out of time did not
+   * lose; it did not answer. Counting it as a loss makes the probe
+   * under-report triviality — `simp` is exactly the rung most likely to
+   * be slow on the goals most worth flagging.
+   */
+  timedOut: string[];
 }
+
+/** Rungs that gave no answer, for either reason. */
+export function incompleteRungs(l: LadderRun): string[] {
+  return [...l.unavailable, ...l.timedOut];
+}
+
+export type ProbeOutcome =
+  | { status: "closed"; decl: string; steps: number; tactic: string; ladder: LadderRun }
+  | { status: "open"; decl: string; ladder: LadderRun }
+  | { status: "skipped"; decl: string; reason: SkipReason };
+
+/**
+ * A tactic that does not exist reads exactly like a tactic that lost.
+ *
+ * `aesop` is not core Lean; in a folio without Mathlib the rung errors
+ * with `unknown tactic` and exits non-zero, which a bare exit-code check
+ * scores as "aesop ran and failed to close the goal". The ladder then
+ * silently has five rungs instead of six and every declaration `aesop`
+ * would have closed is recorded as not machine-trivial.
+ */
+const UNAVAILABLE_RE = /unknown tactic|unexpected identifier; expected/;
 
 /**
  * Probe one declaration by substituting its proof body.
  *
- * Returns `undefined` when the file does not even elaborate unmodified —
- * a probe against a file that is already broken measures nothing, and
- * reporting it as "not trivial" would be a false negative dressed as a
- * result.
+ * Returns a `skipped` outcome — with the reason — rather than a bare
+ * absence, because the four ways this can fail to measure anything are
+ * not interchangeable: `baseline-fails` is fixed by restoring oleans,
+ * `decl-not-found` by fixing the lexer or the `lean.ref`, and `no-body`
+ * is a declaration the probe was never applicable to. Reporting them as
+ * one bucket makes the skip count undiagnosable.
  */
 export function probeDeclaration(
   src: string,
@@ -108,45 +187,75 @@ export function probeDeclaration(
   lakeRoot: string,
   leanBin: string,
   timeoutMs = 120_000,
-): ProbeResult | undefined {
+): ProbeOutcome {
   const stripped = stripLeanComments(src);
   const decls = splitDeclarations(stripped);
   const target = decls.find((d) => d.name === declName);
-  if (!target || !target.body) return undefined;
+  if (!target) return { status: "skipped", decl: declName, reason: "decl-not-found" };
+  if (!target.body || target.bodyAt < 0) {
+    return { status: "skipped", decl: declName, reason: "no-body" };
+  }
 
   const env = { ...process.env, LEAN_PATH: leanPathFor(lakeRoot) };
   const dir = mkdtempSync(join(tmpdir(), "triv-probe-"));
   const file = join(dir, "P.lean");
 
-  const elaborates = (text: string): boolean => {
+  /** Four distinct answers. Collapsing any of them fabricates evidence. */
+  const attempt = (text: string): "closed" | "open" | "unavailable" | "timeout" => {
     writeFileSync(file, text);
     try {
       execFileSync(leanBin, [file], { env, timeout: timeoutMs, stdio: "pipe" });
-      return true;
-    } catch {
-      return false;
+      return "closed";
+    } catch (e) {
+      const err = e as {
+        stdout?: Buffer | string;
+        stderr?: Buffer | string;
+        killed?: boolean;
+        signal?: string | null;
+      };
+      // `execFileSync` reports a timeout by killing the child, which
+      // otherwise arrives here looking exactly like a failed proof.
+      if (err.killed || err.signal === "SIGTERM") return "timeout";
+      // Lean reports diagnostics on stdout; read both and do not assume.
+      const out = `${err.stdout ?? ""}${err.stderr ?? ""}`;
+      return UNAVAILABLE_RE.test(out) ? "unavailable" : "open";
     }
   };
 
   // Baseline: does the file elaborate as-is? If not, any probe result is
-  // meaningless.
-  if (!elaborates(src)) return undefined;
+  // meaningless — including "not closed".
+  const baseline = attempt(src);
+  if (baseline === "timeout") {
+    return { status: "skipped", decl: declName, reason: "baseline-timeout" };
+  }
+  if (baseline !== "closed") {
+    return { status: "skipped", decl: declName, reason: "baseline-fails" };
+  }
 
-  // Locate the body in the ORIGINAL source. `stripped` preserves byte
-  // offsets (comments are blanked, not removed), so an offset found in
-  // the stripped text indexes the original correctly.
-  const bodyStart = stripped.indexOf(target.body, stripped.indexOf(target.name));
-  if (bodyStart < 0) return undefined;
+  // `stripped` preserves byte offsets (comments are blanked, not
+  // removed), so the span's offset indexes the original source directly.
+  const bodyStart = target.bodyAt;
   const bodyEnd = bodyStart + target.body.length;
+  const ladder: LadderRun = { ran: [], unavailable: [], timedOut: [] };
 
   for (let i = 0; i < TACTIC_LADDER.length; i++) {
     const t = TACTIC_LADDER[i];
     const probe = src.slice(0, bodyStart) + `:= by ${t}\n` + src.slice(bodyEnd);
-    if (elaborates(probe)) {
-      return { decl: declName, closed: true, steps: i + 1, tactic: t };
+    const r = attempt(probe);
+    if (r === "unavailable") {
+      ladder.unavailable.push(t);
+      continue;
+    }
+    if (r === "timeout") {
+      ladder.timedOut.push(t);
+      continue;
+    }
+    ladder.ran.push(t);
+    if (r === "closed") {
+      return { status: "closed", decl: declName, steps: i + 1, tactic: t, ladder };
     }
   }
-  return { decl: declName, closed: false };
+  return { status: "open", decl: declName, ladder };
 }
 
 // ── CLI ─────────────────────────────────────────────────────────────
@@ -179,6 +288,15 @@ Needs: scripts/lake-cache.sh restore-toolchain && ... restore`);
   const abs = join(repoRoot, lakeRoot);
   const searchRoot = join(repoRoot, "content");
   const decls: Record<string, unknown> = {};
+  // Counted per reason: a 57%-skipped run is only actionable if you can
+  // tell "restore the oleans" from "the lexer missed the declaration".
+  const skips: Record<SkipReason, number> = {
+    "decl-not-found": 0,
+    "no-body": 0,
+    "baseline-fails": 0,
+    "baseline-timeout": 0,
+  };
+  const unavailableRungs = new Set<string>();
   let probed = 0,
     skipped = 0,
     closed = 0;
@@ -198,22 +316,28 @@ Needs: scripts/lake-cache.sh restore-toolchain && ... restore`);
     const short = decl.split(".").pop()!;
 
     const r = probeDeclaration(src, short, abs, leanBin);
-    if (!r) {
+    if (r.status === "skipped") {
       skipped++;
-      console.log(`  skip  ${b.label}  (file does not elaborate standalone — probe would be meaningless)`);
+      skips[r.reason]++;
+      console.log(`  skip  ${b.label}  (${SKIP_EXPLANATION[r.reason]})`);
       continue;
     }
     probed++;
-    if (r.closed) closed++;
+    if (r.status === "closed") closed++;
+    const incomplete = incompleteRungs(r.ladder);
+    for (const t of incomplete) unavailableRungs.add(t);
     decls[decl] = {
-      closed: r.closed,
-      steps: r.steps,
-      tactic: r.tactic,
+      closed: r.status === "closed",
+      steps: r.status === "closed" ? r.steps : undefined,
+      tactic: r.status === "closed" ? r.tactic : undefined,
+      // Recorded so a `closed: false` can be read honestly: if a rung
+      // never answered, the goal was not tested against it.
+      ladder_unavailable: incomplete.length ? incomplete : undefined,
       lean_path: b.lean.startsWith(repoRoot) ? b.lean.slice(repoRoot.length + 1) : b.lean,
       checked_at: new Date().toISOString(),
     };
     console.log(
-      `  ${r.closed ? `CLOSED(${r.tactic}, step ${r.steps})` : "not closed"}  ${b.label}`,
+      `  ${r.status === "closed" ? `CLOSED(${r.tactic}, step ${r.steps})` : "not closed"}  ${b.label}`,
     );
   }
 
@@ -231,7 +355,23 @@ Needs: scripts/lake-cache.sh restore-toolchain && ... restore`);
       2,
     ) + "\n",
   );
-  console.log(
-    `\nprobed ${probed}, closed ${closed}, skipped ${skipped} (unelaborable)\n-> ${out}`,
-  );
+  console.log(`\nprobed ${probed}, closed ${closed}, skipped ${skipped}`);
+  for (const [reason, n] of Object.entries(skips)) {
+    if (n) console.log(`  ${String(n).padStart(4)}  ${reason} — ${SKIP_EXPLANATION[reason as SkipReason]}`);
+  }
+  if (unavailableRungs.size) {
+    console.log(
+      `\n  !! ladder incomplete: ${[...unavailableRungs].join(", ")} gave no answer in this ` +
+        `environment (absent, or timed out). Every "not closed" above was measured against a SHORT ladder and is ` +
+        `recorded as such; the criterion reads those as n/a, not as "not trivial".`,
+    );
+  }
+  if (probed > 0 && closed === 0) {
+    console.log(
+      `\n  note: 0 of ${probed} closed. That is only evidence about the corpus if the probe ` +
+        `can close anything at all — see scripts/tests/lean-triviality-probe.test.ts, which ` +
+        `pins the ladder against declarations of known difficulty.`,
+    );
+  }
+  console.log(`-> ${out}`);
 }

--- a/content/pipeline/qa-checkers-triviality.ts
+++ b/content/pipeline/qa-checkers-triviality.ts
@@ -18,12 +18,24 @@
  * sweep. A cheap pre-filter changes which blocks an agent looks at
  * first.
  *
- * ## Status: UNVALIDATED
+ * ## Status: the oracle works; its false-positive RATE is still unmeasured
  *
- * The oracle's false-positive rate has **not** been measured on any
- * corpus. Its entire value is that number: if it flags genuine results
- * as trivial, it costs more attention than it saves. Plenty of real
- * theorems are one-liners.
+ * Two different questions, and only the first has an answer.
+ *
+ * **Can the oracle discriminate at all?** Yes — pinned by controls in
+ * `scripts/tests/lean-triviality-probe.test.ts`: declarations of known
+ * difficulty run through the real code path, closing at the expected
+ * rung (`simp` at 3, `omega` at 5) while a substantive goal stays open.
+ * That control exists because the first qou run reported
+ * `probed 12, closed 0`, which was read as "no qou theorem falls to
+ * cheap automation" — and a probe that can never close anything emits
+ * the identical line. It could not have been told from the outside.
+ *
+ * **How often does it flag a genuine result?** Unmeasured. That number
+ * is the criterion's entire value: if it flags real theorems as trivial
+ * it costs more attention than it saves, and plenty of real theorems are
+ * one-liners. It needs hits on a real corpus, which needs the Lean cache
+ * reseed — bean `5d7z`. Until then, `TRIVIAL_STEP_THRESHOLD` is a guess.
  *
  * So this is deliberately inert until fed real data:
  *
@@ -45,9 +57,14 @@
  *
  *   { "$schema": "lean-triviality/v1",
  *     "generated_at": "...",
- *     "oracle": "nazrin@<rev>",
+ *     "oracle": "lean-tactic-ladder(trivial|rfl|simp|decide|omega|aesop)",
  *     "decls": { "<Decl>": { "closed": true, "steps": 3,
+ *                            "ladder_unavailable": ["aesop"],
  *                            "lean_path": "...", "lean_sha": "..." } } }
+ *
+ * `ladder_unavailable` lists rungs that gave no answer in the probe
+ * environment — absent, or killed by the timeout. A `closed: false`
+ * carrying one is `n/a`, not `pass`.
  *
  * @module content/pipeline/qa-checkers-triviality
  */
@@ -75,6 +92,13 @@ export interface TrivialityEntry {
   closed: boolean;
   /** Atomic tactic steps used. Absent when `closed` is false. */
   steps?: number;
+  /**
+   * Ladder rungs that could not run in the probe environment — `aesop`
+   * without Mathlib, say. A `closed: false` measured against a short
+   * ladder is not evidence the goal resists automation, so it must read
+   * as `n/a` rather than `pass`.
+   */
+  ladder_unavailable?: string[];
   lean_path?: string;
   lean_sha?: string;
   checked_at?: string;
@@ -158,7 +182,23 @@ export function checkProofNotMachineTrivial(tsPath?: string): CheckerResult {
   };
   if (e.steps !== undefined) metrics.atomic_steps_to_close = e.steps;
 
-  if (!e.closed) return { result: "pass", hits: [], metrics };
+  if (!e.closed) {
+    // "The ladder did not close it" is only a measurement if the whole
+    // ladder ran. A rung the environment could not offer fails
+    // indistinguishably from a rung that tried and lost, so a short
+    // ladder yields `n/a` — absence of data, not absence of triviality.
+    if (e.ladder_unavailable?.length) {
+      return {
+        result: "n/a",
+        hits: [],
+        metrics,
+        notes:
+          `ladder incomplete — ${e.ladder_unavailable.join(", ")} did not run in the probe ` +
+          `environment, so "not closed" was measured against a short ladder`,
+      };
+    }
+    return { result: "pass", hits: [], metrics };
+  }
   const steps = e.steps ?? 0;
   if (steps > TRIVIAL_STEP_THRESHOLD) return { result: "pass", hits: [], metrics };
 

--- a/scripts/tests/lean-decl-split.test.ts
+++ b/scripts/tests/lean-decl-split.test.ts
@@ -1,0 +1,142 @@
+/**
+ * `splitDeclarations` cuts each declaration into signature and body. Its
+ * doc comment always said "at the first **top-level** `:=` or `where`";
+ * the implementation was `text.search(/:=|\bwhere\b/)`, which finds the
+ * first one *anywhere*.
+ *
+ * A theorem statement may legitimately contain `:=` — a `let`, a
+ * structure instance, an anonymous constructor — and every consumer of
+ * the split degrades quietly when the cut lands inside one:
+ *
+ * - `lean-signature` hashes the truncated signature, so a changed
+ *   statement can hash identically and never invalidate its QA sidecar;
+ * - `lean-triviality-probe` splices its tactic over the statement, the
+ *   file stops elaborating, and the declaration is recorded as
+ *   "not machine-trivial";
+ * - scan mode files statement text under `value_deps`.
+ *
+ * None of the three surfaces an error. That is what these pin.
+ */
+import { describe, expect, test } from "bun:test";
+import { splitDeclarations, topLevelCut } from "../../content/pipeline/lean-atlas-ingest";
+import { stripLeanComments } from "../../content/pipeline/lean-atlas-ingest";
+
+/** The cut exactly as it was before the fix, for the equivalence check. */
+const oldCut = (t: string) => t.search(/:=|\bwhere\b/);
+
+/** Declarations whose first `:=` is already top-level — must not move. */
+const UNCHANGED = [
+  `theorem t (n : Nat) : n + 0 = n := by rfl\n`,
+  `theorem t {α : Type} (xs : List α) : xs ++ [] = xs := by simp\n`,
+  `theorem t [Group G] (g : G) : g * 1 = g := by simp\n`,
+  `theorem t (n : Nat)\n    (h : n > 0) :\n    n ≥ 1 := by omega\n`,
+  `structure Foo where\n  a : Nat\n`,
+  `inductive Bar\n  | mk\n`,
+  `def f (n : Nat) : Nat := g n where g := id\n`,
+  `@[simp] theorem t : True := by trivial\n`,
+  `theorem t' (h' : True) : True := h'\n`,
+  `theorem t : ∀ n : Nat, n = n := fun n => rfl\n`,
+  `theorem t : True ∧ True := ⟨trivial, trivial⟩\n`,
+  `theorem t : (⟨1, by simp⟩ : Sub).val = 1 := by rfl\n`,
+];
+
+/** Declarations the old cut got wrong, with the offset it should find. */
+const NESTED: Array<[string, string]> = [
+  [`theorem t : (let x := 5; x) = 5 := by rfl\n`, `theorem t : (let x := 5; x) = 5 `],
+  [`theorem t : ({ a := 1 } : Foo).a = 1 := by rfl\n`, `theorem t : ({ a := 1 } : Foo).a = 1 `],
+  [
+    `theorem t (n : Nat) : (let y := n; let z := y; z) = n := by rfl\n`,
+    `theorem t (n : Nat) : (let y := n; let z := y; z) = n `,
+  ],
+  [`theorem t : parse "x := 1" = ok := by rfl\n`, `theorem t : parse "x := 1" = ok `],
+  [`theorem t : f (g where h := 1) = c := by rfl\n`, `theorem t : f (g where h := 1) = c `],
+];
+
+describe("topLevelCut", () => {
+  test("agrees with the old cut on every already-correct declaration", () => {
+    // The fix must be a strict repair: it may only move cuts that were
+    // landing inside a statement. Anything else is a silent reindexing
+    // of every statement hash in every folio.
+    for (const src of UNCHANGED) {
+      expect({ src, cut: topLevelCut(src) }).toEqual({ src, cut: oldCut(src) });
+    }
+  });
+
+  test("skips `:=` nested in brackets, braces, anonymous constructors", () => {
+    for (const [src, expectedSig] of NESTED) {
+      expect({ src, sig: src.slice(0, topLevelCut(src)) }).toEqual({ src, sig: expectedSig });
+    }
+  });
+
+  test("skips `:=` inside a string literal, escapes included", () => {
+    const src = `theorem t : parse "a \\" := b" = ok := by rfl\n`;
+    expect(src.slice(0, topLevelCut(src))).toBe(`theorem t : parse "a \\" := b" = ok `);
+  });
+
+  test("does not treat a prime-suffixed identifier as the `where` keyword", () => {
+    // JS `\b` counts `'` as a boundary, so `\bwhere\b` matched inside
+    // `h'where`. Lean identifiers may carry primes; the boundary has to
+    // use Lean's identifier class, not JS's.
+    const src = `theorem t (h'where : True) : True := h'where\n`;
+    expect(src.slice(0, topLevelCut(src))).toBe(`theorem t (h'where : True) : True `);
+  });
+
+  test("returns -1 when there is no top-level cut at all", () => {
+    expect(topLevelCut(`theorem stated : True\n`)).toBe(-1);
+    // Every `:=` nested: no body, rather than a cut inside the type.
+    expect(topLevelCut(`theorem t : (let x := 5; x) = 5\n`)).toBe(-1);
+  });
+
+  test("a stray closing bracket does not mask every later cut", () => {
+    // Span boundaries can chop mid-term. If depth went negative the
+    // scan would never see depth 0 again and the whole declaration
+    // would read as body-less.
+    expect(topLevelCut(`theorem t : f x) = y := by rfl\n`)).toBeGreaterThan(0);
+  });
+
+  test("the cut always lands on a real `:=` or `where`", () => {
+    for (const src of [...UNCHANGED, ...NESTED.map((n) => n[0])]) {
+      const c = topLevelCut(src);
+      if (c === -1) continue;
+      expect(src.startsWith(":=", c) || src.startsWith("where", c)).toBe(true);
+    }
+  });
+});
+
+describe("splitDeclarations", () => {
+  test("body starts at the top-level `:=`, not one inside the statement", () => {
+    const src = `theorem t : (let x := 5; x) = 5 := by rfl\n`;
+    const [d] = splitDeclarations(stripLeanComments(src));
+    expect(d.signature).toBe(`theorem t : (let x := 5; x) = 5 `);
+    expect(d.body).toBe(`:= by rfl\n`);
+  });
+
+  test("bodyAt is an absolute offset that slices the original source", () => {
+    // The probe splices with this offset. `indexOf` was used before,
+    // which finds the FIRST matching body text — and `:= by rfl` is not
+    // distinctive, so it could rewrite a different declaration.
+    const src = `theorem a : True := by trivial\n\ntheorem b : True := by trivial\n`;
+    const decls = splitDeclarations(stripLeanComments(src));
+    const b = decls.find((d) => d.name === "b")!;
+    expect(src.slice(b.bodyAt, b.bodyAt + b.body.length)).toBe(b.body);
+    // And it is the SECOND one, not the first identical body.
+    expect(b.bodyAt).toBeGreaterThan(decls.find((d) => d.name === "a")!.bodyAt);
+  });
+
+  test("a body-less declaration reports bodyAt -1, not 0", () => {
+    // 0 is a valid offset; -1 is the only value that cannot be mistaken
+    // for "the body is at the start of the file".
+    const [d] = splitDeclarations(stripLeanComments(`theorem stated : True\n`));
+    expect(d.body).toBe("");
+    expect(d.bodyAt).toBe(-1);
+  });
+
+  test("offsets survive comment stripping", () => {
+    // `bodyAt` indexes the stripped text but is used against the
+    // original, which is only sound because stripping blanks in place.
+    const src = `/-- doc with := inside -/\ntheorem t : True := by trivial\n`;
+    const [d] = splitDeclarations(stripLeanComments(src));
+    expect(src.slice(d.bodyAt, d.bodyAt + d.body.length)).toBe(d.body);
+    expect(d.body.trimStart().startsWith(":=")).toBe(true);
+  });
+});

--- a/scripts/tests/lean-signature.test.ts
+++ b/scripts/tests/lean-signature.test.ts
@@ -45,6 +45,31 @@ describe("leanSignatures", () => {
     expect(leanSignatures(THM)).not.toBe(leanSignatures(THM_NEW_STATEMENT));
   });
 
+  test("changes when a statement contains `:=` and its TAIL changes", () => {
+    // Regression. The signature/body cut fired on the first `:=`
+    // anywhere, so a `let` in the statement truncated the signature to
+    // `theorem t : (let x` — identical for both of these. The statement
+    // hash built on it therefore could not see the 5 -> 6 change, and a
+    // QA sidecar recorded against the old statement stayed "fresh".
+    const five = `theorem t : (let x := 5; x) = 5 := by rfl\n`;
+    const six = `theorem t : (let x := 5; x) = 6 := by rfl\n`;
+    expect(leanSignatures(five)).not.toBe(leanSignatures(six));
+  });
+
+  test("a structure instance in the statement does not truncate it", () => {
+    const a = `theorem t : ({ a := 1 } : Foo).a = 1 := by rfl\n`;
+    const b = `theorem t : ({ a := 1 } : Foo).a = 2 := by rfl\n`;
+    expect(leanSignatures(a)).not.toBe(leanSignatures(b));
+  });
+
+  test("still invariant under a proof rewrite when the statement holds `:=`", () => {
+    // The other direction: the fix must not make the hash sensitive to
+    // the body, or every proof edit would invalidate every sidecar.
+    const p1 = `theorem t : (let x := 5; x) = 5 := by rfl\n`;
+    const p2 = `theorem t : (let x := 5; x) = 5 := by simp\n`;
+    expect(leanSignatures(p1)).toBe(leanSignatures(p2));
+  });
+
   test("changes when a declaration is RENAMED", () => {
     // A rename is a statement change even with an identical type — the
     // narrative names the declaration.

--- a/scripts/tests/lean-triviality-probe.test.ts
+++ b/scripts/tests/lean-triviality-probe.test.ts
@@ -1,0 +1,244 @@
+/**
+ * The triviality probe measures whether a goal falls to cheap automation.
+ * Its output is only evidence about the *corpus* if the probe can close
+ * anything at all — a probe that never closes a goal reports `closed: 0`
+ * on a trivial corpus and on a deep one alike.
+ *
+ * The first qou run reported `probed 12, closed 0` and that was read as
+ * "no qou theorem falls to cheap automation". A broken probe produces the
+ * identical line. These tests are the control that separates the two:
+ * declarations whose difficulty is known in advance, run through the real
+ * code path.
+ *
+ * The Lean-backed tests need a toolchain. When none is found they SKIP —
+ * and say so loudly, because a suite that silently passes when its
+ * subject is absent is the same defect one level up.
+ */
+import { describe, test, expect } from "bun:test";
+import { existsSync, readdirSync } from "fs";
+import { join } from "path";
+import { execFileSync } from "child_process";
+import {
+  probeDeclaration,
+  incompleteRungs,
+  TACTIC_LADDER,
+  SKIP_EXPLANATION,
+  leanPathFor,
+} from "../../content/pipeline/lean-triviality-probe.ts";
+
+/** `lean` on PATH, else any elan toolchain. `undefined` when there is none. */
+function findLean(): string | undefined {
+  try {
+    const p = execFileSync("which", ["lean"], { encoding: "utf-8" }).trim();
+    if (p && existsSync(p)) return p;
+  } catch {
+    /* not on PATH */
+  }
+  const root = join(process.env.HOME ?? "", ".elan", "toolchains");
+  if (!existsSync(root)) return undefined;
+  for (const d of readdirSync(root)) {
+    const bin = join(root, d, "bin", "lean");
+    if (existsSync(bin)) return bin;
+  }
+  return undefined;
+}
+
+const LEAN = findLean();
+const NO_LEAN = LEAN === undefined;
+
+/**
+ * Per-test budget for the Lean-backed cases. bun's default is 5s; one
+ * probe is up to six `lean` invocations, and on a loaded runner the
+ * ladder alone took 8.6s here. Without this the controls flake, and a
+ * flaking control is one someone eventually deletes.
+ */
+const LEAN_TEST_TIMEOUT_MS = 180_000;
+
+if (NO_LEAN) {
+  console.warn(
+    "\n  [lean-triviality-probe] NO LEAN TOOLCHAIN — the ladder control tests did not run.\n" +
+      "  `closed: 0` from this probe is uninterpretable until they do.\n",
+  );
+}
+
+// Core Lean only: no Mathlib, no imports beyond the prelude, so the
+// control runs anywhere a toolchain exists.
+const CONTROLS = `theorem trivTrue : True := by
+  exact True.intro
+
+theorem simpAppend (xs : List Nat) : xs ++ [] = xs := by
+  induction xs with
+  | nil => rfl
+  | cons a as ih => simp
+
+theorem omegaLinear (a b : Nat) (h : a + 2 ≤ b) : a < b := by
+  exact Nat.lt_of_lt_of_le (Nat.lt_succ_of_le (Nat.le_succ_of_le (Nat.le_refl a))) h
+
+theorem substantive (n : Nat) : 2 ^ n ≥ n + 1 := by
+  induction n with
+  | zero => decide
+  | succ k ih =>
+    have h2 : 2 ^ (k + 1) = 2 ^ k + 2 ^ k := by
+      rw [Nat.pow_succ]; omega
+    have hk : 2 ^ k ≥ 1 := Nat.one_le_two_pow
+    omega
+`;
+
+const probe = (src: string, decl: string) =>
+  probeDeclaration(src, decl, "/nonexistent-lake-root", LEAN!, 120_000);
+
+describe("the ladder actually closes goals (the control for `closed: 0`)", () => {
+  test.skipIf(NO_LEAN)("closes a goal that cheap automation should close", () => {
+    const r = probe(CONTROLS, "trivTrue");
+    expect(r.status).toBe("closed");
+    if (r.status !== "closed") return;
+    expect(r.tactic).toBe("trivial");
+    expect(r.steps).toBe(1);
+  }, LEAN_TEST_TIMEOUT_MS);
+
+  test.skipIf(NO_LEAN)("walks past rungs that fail and reports the one that worked", () => {
+    // `xs ++ [] = xs` is not definitional, so `trivial` and `rfl` must
+    // both lose before `simp` wins. If `steps` were the count of rungs
+    // attempted, or always 1, this is where it shows.
+    const r = probe(CONTROLS, "simpAppend");
+    expect(r.status).toBe("closed");
+    if (r.status !== "closed") return;
+    expect(r.tactic).toBe("simp");
+    expect(r.steps).toBe(TACTIC_LADDER.indexOf("simp") + 1);
+    expect(r.ladder.ran.slice(0, 3)).toEqual(["trivial", "rfl", "simp"]);
+  }, LEAN_TEST_TIMEOUT_MS);
+
+  test.skipIf(NO_LEAN)("reaches deep rungs — omega at position 5", () => {
+    const r = probe(CONTROLS, "omegaLinear");
+    expect(r.status).toBe("closed");
+    if (r.status !== "closed") return;
+    expect(r.tactic).toBe("omega");
+    expect(r.steps).toBe(TACTIC_LADDER.indexOf("omega") + 1);
+  }, LEAN_TEST_TIMEOUT_MS);
+
+  test.skipIf(NO_LEAN)("leaves a substantive goal open — it does not close everything", () => {
+    // The negative control. Without it, "closes goals" could just mean
+    // "reports closed unconditionally".
+    const r = probe(CONTROLS, "substantive");
+    expect(r.status).toBe("open");
+  }, LEAN_TEST_TIMEOUT_MS);
+});
+
+describe("an unavailable rung is not a rung that lost", () => {
+  test.skipIf(NO_LEAN)("records `aesop` as unavailable rather than as a failure", () => {
+    // `aesop` is not core Lean. It errors with `unknown tactic` and a
+    // non-zero exit — indistinguishable, to an exit-code check, from
+    // "ran and did not close the goal". Then the ladder silently has
+    // five rungs and every goal aesop would have closed reads as
+    // "not machine-trivial".
+    const r = probe(CONTROLS, "substantive");
+    expect(r.status).toBe("open");
+    if (r.status !== "open") return;
+    expect(r.ladder.unavailable).toContain("aesop");
+    expect(r.ladder.ran).not.toContain("aesop");
+    // Everything core still ran: the detection is specific, not a
+    // blanket "any error means unavailable".
+    expect(r.ladder.ran).toEqual(["trivial", "rfl", "simp", "decide", "omega"]);
+    // Nothing timed out at this budget, so the two buckets stay distinct.
+    expect(r.ladder.timedOut).toEqual([]);
+    expect(incompleteRungs(r.ladder)).toEqual(["aesop"]);
+  }, LEAN_TEST_TIMEOUT_MS);
+
+  test("incompleteRungs unions both kinds of non-answer", () => {
+    // Pure: the checker keys `n/a` off this, so it must not silently
+    // drop either bucket.
+    expect(
+      incompleteRungs({ ran: ["trivial"], unavailable: ["aesop"], timedOut: ["simp"] }),
+    ).toEqual(["aesop", "simp"]);
+    expect(incompleteRungs({ ran: ["trivial"], unavailable: [], timedOut: [] })).toEqual([]);
+  });
+});
+
+describe("skip reasons are distinguished, because their fixes differ", () => {
+  test.skipIf(NO_LEAN)("a declaration the lexer never saw", () => {
+    const r = probe(CONTROLS, "noSuchDeclaration");
+    expect(r.status).toBe("skipped");
+    if (r.status !== "skipped") return;
+    expect(r.reason).toBe("decl-not-found");
+  }, LEAN_TEST_TIMEOUT_MS);
+
+  test.skipIf(NO_LEAN)("a declaration with no body to substitute", () => {
+    const r = probe("theorem stated : True\n", "stated");
+    expect(r.status).toBe("skipped");
+    if (r.status !== "skipped") return;
+    expect(r.reason).toBe("no-body");
+  }, LEAN_TEST_TIMEOUT_MS);
+
+  test.skipIf(NO_LEAN)("a file that does not elaborate unmodified", () => {
+    // The old code reported this reason for all four causes. It is the
+    // one that means "restore the oleans"; the others do not.
+    const r = probe("theorem b : Nat := by exact notAThing\n", "b");
+    expect(r.status).toBe("skipped");
+    if (r.status !== "skipped") return;
+    expect(r.reason).toBe("baseline-fails");
+  }, LEAN_TEST_TIMEOUT_MS);
+
+  test.skipIf(NO_LEAN)("a file too slow to probe is not a file that is broken", () => {
+    // `execFileSync` signals a timeout by killing the child, which
+    // arrives in the same catch as a failed elaboration. Reported as
+    // `baseline-fails` it says "restore the oleans" about a file whose
+    // oleans are fine. A 1ms budget guarantees the kill.
+    const r = probeDeclaration(CONTROLS, "trivTrue", "/nonexistent-lake-root", LEAN!, 1);
+    expect(r.status).toBe("skipped");
+    if (r.status !== "skipped") return;
+    expect(r.reason).toBe("baseline-timeout");
+  }, LEAN_TEST_TIMEOUT_MS);
+
+  test("every skip reason carries an explanation of what would fix it", () => {
+    for (const r of [
+      "decl-not-found",
+      "no-body",
+      "baseline-fails",
+      "baseline-timeout",
+    ] as const) {
+      expect(SKIP_EXPLANATION[r]).toBeTruthy();
+    }
+  });
+});
+
+describe("splicing the body", () => {
+  test.skipIf(NO_LEAN)("a `:=` inside the statement no longer mangles the probe", () => {
+    // `(let x := 5; x) = 5` put the old cut inside the *statement*, so
+    // the tactic was spliced over the theorem's own type. The file then
+    // failed to elaborate, every rung lost, and it was recorded
+    // `closed: false` — scored as "not machine-trivial". It is in fact
+    // closed by `trivial` at rung 1.
+    const src = `theorem withLet : (let x := 5; x) = 5 := by
+  induction (5 : Nat) with
+  | zero => rfl
+  | succ k ih => rfl
+`;
+    const r = probe(src, "withLet");
+    expect(r.status).toBe("closed");
+    if (r.status !== "closed") return;
+    expect(r.steps).toBe(1);
+  }, LEAN_TEST_TIMEOUT_MS);
+
+  test.skipIf(NO_LEAN)("comment stripping preserves offsets, so the splice lands correctly", () => {
+    // `bodyAt` is an offset into the COMMENT-STRIPPED source, used to
+    // slice the ORIGINAL. That is only sound because stripping blanks
+    // comments in place rather than removing them. If it ever removes,
+    // the splice silently corrupts a different span of the file.
+    const src = `/-- A doc comment with a := inside it, and some length. -/
+theorem commented (n : Nat) : n + 0 = n := by
+  -- a line comment, also containing :=
+  simp
+`;
+    const r = probe(src, "commented");
+    expect(r.status).toBe("closed");
+  }, LEAN_TEST_TIMEOUT_MS);
+});
+
+describe("leanPathFor", () => {
+  test("returns empty for a root with no restored packages", () => {
+    // Empty is correct and must stay distinguishable from a wrong path:
+    // pointing at a directory that exists but holds no oleans reads as
+    // "unknown module prefix", which looks like a missing dependency.
+    expect(leanPathFor("/nonexistent-lake-root")).toBe("");
+  });
+});

--- a/scripts/tests/qa-checkers-triviality.test.ts
+++ b/scripts/tests/qa-checkers-triviality.test.ts
@@ -115,6 +115,41 @@ describe("proof-not-machine-trivial", () => {
     rmSync(root, { recursive: true, force: true });
   });
 
+  test("a `not closed` from a SHORT ladder is n/a, not pass", () => {
+    // The probe runs six rungs. `aesop` is not core Lean, so in a folio
+    // without Mathlib it errors with `unknown tactic` — which, to an
+    // exit-code check, looks exactly like "ran and did not close the
+    // goal". Every declaration aesop would have closed then reads as
+    // "not machine-trivial". A rung that never answered is not evidence.
+    const { root, tsPath } = makeRepo({
+      "P.foo": { closed: false, ladder_unavailable: ["aesop"] },
+    });
+    const r = inRepo(root, () => checkProofNotMachineTrivial(tsPath));
+    expect(r.result).toBe("n/a");
+    expect(r.notes).toContain("aesop");
+    expect(r.notes).toContain("short ladder");
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("a `not closed` from the FULL ladder is still a pass", () => {
+    // The complement: the n/a path must not swallow real measurements.
+    const { root, tsPath } = makeRepo({ "P.foo": { closed: false } });
+    const r = inRepo(root, () => checkProofNotMachineTrivial(tsPath));
+    expect(r.result).toBe("pass");
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("an incomplete ladder does not suppress a goal that WAS closed", () => {
+    // If `simp` closed it at rung 3, aesop never running is irrelevant —
+    // the hit stands. Only "not closed" is weakened by a short ladder.
+    const { root, tsPath } = makeRepo({
+      "P.foo": { closed: true, steps: 3, ladder_unavailable: ["aesop"] },
+    });
+    const r = inRepo(root, () => checkProofNotMachineTrivial(tsPath));
+    expect(r.result).toBe("warn");
+    rmSync(root, { recursive: true, force: true });
+  });
+
   test("never returns fail — it is warn-only by construction", () => {
     for (const entry of [
       { closed: true, steps: 0 },


### PR DESCRIPTION
Works bean `nimj`. Its blocked half is still blocked — the false-positive rate needs the `5d7z` cache reseed. Underneath it sat a question that was not blocked, and not noticed.

The first qou run printed `probed 12, closed 0`, recorded in the bean as *"none of 12 real qou theorems fall to cheap automation"*. **A probe that cannot close anything prints the identical line.** Nothing in the output separated the two readings, and the bean took the flattering one.

## The control

Core-Lean declarations of known difficulty, through the real code path — no Mathlib, no folio, no cache, just the toolchain `ga7e` restored:

```
trivTrue     CLOSED step 1 (trivial)
simpAppend   CLOSED step 3 (simp)     <- trivial and rfl lost first
omegaLinear  CLOSED step 5 (omega)    <- the ladder really walks
substantive  open                     <- and does not close everything
```

So the probe discriminates, and qou's `closed 0` is a real measurement about the corpus.

## Three mechanical failures that were reporting as substantive results

Each scored a block `pass` — "not machine-trivial".

**A rung that is not installed.** `aesop` is not core Lean; without Mathlib it errors `unknown tactic` and exits non-zero, which an exit-code check scores as "ran and lost". The ladder silently had five rungs. Now `ladder.unavailable`, and a short-ladder "not closed" reads `n/a`, not `pass`.

**A rung that ran out of time.** `execFileSync` signals a timeout by killing the child, landing in the same `catch` as a failed proof. A tactic that did not answer is not a tactic that lost — and `simp` is the rung most likely to be slow on the goals most worth flagging. Now `ladder.timedOut`; a baseline timeout is `baseline-timeout`, not `baseline-fails`, so "too slow to probe" stops printing "restore the oleans".

**A splice that landed inside the statement.** `splitDeclarations` cut at the first `:=` *anywhere*, though its doc comment has always specified "the first **top-level** `:=`". A statement containing one — `(let x := 5; x) = 5`, a structure instance — had the tactic written over its own type; the file stopped elaborating, all six rungs failed, `closed: false`.

## The third one reaches past this bean

`lean-signature` builds the QA **statement hash** from the same cut, so a truncated signature hashes a partial statement:

```
theorem t : (let x := 5; x) = 5 := by rfl    hash d1b45ae0f3e3
theorem t : (let x := 5; x) = 6 := by rfl    hash d1b45ae0f3e3
```

A changed statement that never invalidates its QA sidecar — a staleness check passing by finding nothing.

Fixed at the source with `topLevelCut`, bracket- and string-literal-aware. Equivalence-checked before landing rather than after: over 17 declaration shapes it agrees with the old cut on all 12 that were already correct, and differs only on the 5 it was getting wrong. Spans also carry `bodyAt`, so the probe splices by offset instead of `indexOf` — `:= by rfl` is not distinctive enough to search for.

## Also

The skip bucket is classified (`decl-not-found` / `no-body` / `baseline-fails` / `baseline-timeout`). The bean's headline number — 16 of 28 blocks unprobeable — came from one undifferentiated counter whose log line asserted a single cause for all four; when the reseed lands it will say which fix it needs.

## Testing

31 new tests, every one watched failing against the old code before being kept. Full suite 476 pass / 0 fail (445 before); `tsc --noEmit` and `eslint .` both clean.

The Lean-backed tests carry an explicit 180s budget — bun's default is 5s, one probe is six `lean` invocations, and the flake that exposed this showed up as a `5013.06ms` "failure". They skip loudly when no toolchain is found, since a suite that passes quietly when its subject is absent is the same defect one level up.

## What this does not do

It does not measure the false-positive rate. That still needs `5d7z`. What changed is that the measurement will be trustworthy when it runs — before this it would have been taken with a five-rung ladder, a timeout counted as a loss, and any statement containing `:=` silently scored "not trivial".

---
_Generated by [Claude Code](https://claude.ai/code/session_01LL9F9XMXAvKZzjxxhMs2bQ)_