### PR TITLE
Four hand-rolled uses[] parsers become one

### DIFF
--- a/.beans/folio-assistant-jwd9--uses-parsed-four-different-hand-rolled-ways-two-ca.md
+++ b/.beans/folio-assistant-jwd9--uses-parsed-four-different-hand-rolled-ways-two-ca.md
@@ -1,0 +1,70 @@
+---
+# folio-assistant-jwd9
+title: uses[] parsed four different hand-rolled ways; two can target the wrong field
+status: completed
+type: bug
+priority: normal
+created_at: 2026-08-08T13:07:50Z
+updated_at: 2026-08-08T13:11:52Z
+---
+
+The editorial relation every ordering metric is computed from is extracted from .ts source text by four independent hand-rolled parsers. Measured 3 of 5 plausible inputs wrong in the audits' version.
+
+- conditional-class-banner-audit.ts (a CI gate in witness-pipeline.yml) and conjectural-propagation-audit.ts share a verbatim copy using text.indexOf("uses:") with NO word boundary, then indexOf("]") for the end. A field named causes: matches, and the parser then returns THAT array's strings as dependencies. A ] inside any entry silently yields [].
+- prune-transitive-deps.ts uses /uses:\s*\[[\s\S]*?\]/ — also no word boundary — and this is the WRITE path (content.replace(usesPattern, newUses)), so it can rewrite the wrong field in a content file.
+- qa-checkers-extended.ts strips with \buses\s*:\s*\[[\s\S]*?\] — has the boundary, still non-greedy to the first ].
+
+Fix: one shared, tested parser (word-boundary-correct field match, bracket- and string-aware scan to the matching ]) plus a span helper for the write path; repoint all four. Same defect family as the topLevelCut fix in PR #74.
+
+
+## Summary of Changes
+
+One parser (`content/pipeline/uses-field.ts`), four call sites repointed:
+`conditional-class-banner-audit`, `conjectural-propagation-audit` (which held
+verbatim copies of the same code), `prune-transitive-deps` (read + write), and
+the `uses`/`cites` strip in `qa-checkers-extended`. 21 tests.
+
+Correct means two things the old copies did not do: match `uses` as a whole
+field name rather than a substring, and scan to the *matching* `]` with bracket
+depth and string awareness rather than stopping at the first one.
+
+### How live is this? Latent, and worth saying so plainly
+
+The failing inputs were measured, but checked against `schemas/types.ts`
+afterwards: **no schema field name contains `uses`**, so the `causes:`-style
+collision cannot fire on schema-conformant content today. What can fire, on
+content that breaks nothing:
+
+- a prose field (`caption`, `summary`, `authorNotes`, `title`) containing the
+  literal text `uses:` *before* the real field — `indexOf("uses:")` lands in
+  the prose and the following `indexOf("[")` walks to whatever array comes
+  next, typically `tags:`. That yields a plausible-looking dependency list
+  made of tag strings.
+- an entry containing `]`, which truncates the array and yields `[]` — a block
+  that reads as having no editorial dependencies.
+
+Neither was observed on real content; there is no folio in this container to
+check against. So this is a latent-correctness fix in a CI gate
+(`witness-pipeline.yml`) and a content-rewriting tool, not a repair of observed
+damage. The consolidation is the durable part: four hand-rolled parsers of the
+relation AGENTS.md calls the signal every ordering metric is computed from, now
+one with tests.
+
+### The write path was the worst of the four
+
+`prune-transitive-deps` matched `/uses:\s*\[[\s\S]*?\]/` — no word boundary —
+and then `content.replace(...)`. Demonstrated on a block carrying a
+`causes: ["keep-me"]` field before `uses`:
+
+    OLD replace:  causes: ["a"]        <- wrong field rewritten, uses[] left unpruned
+    OLD remove:   "  ca"               <- truncated mid-token, invalid TypeScript
+    NEW:          both correct
+
+### Deferred
+
+These parse TypeScript source with a scanner when the blocks are modules that
+could simply be imported — `prune-transitive-deps` already imports them for
+*reading* (`loadAllBlocks`) and only scans for *writing*. Replacing the scan
+with a real edit against the loaded module is the better end state and a larger
+change than this bug warranted. Worth a follow-up bean if the scanner bites
+again.

--- a/content/pipeline/conditional-class-banner-audit.ts
+++ b/content/pipeline/conditional-class-banner-audit.ts
@@ -31,6 +31,7 @@ import { join, resolve } from "node:path";
 import { leanPackageByName } from "../../schemas/lean-packages.ts";
 import { findContentRepoRoot } from "./repo-root";
 import { requirePaper } from "./repo-root";
+import { parseUsesField } from "./uses-field";
 // Was rooted at this file's own location, which is the PLATFORM — but every
 // path below is folio content. `findContentRepoRoot()` walks up from cwd;
 // it must not use `import.meta.dir`, which resolves back through a folio's
@@ -103,17 +104,7 @@ async function loadAll(): Promise<Map<string, Block>> {
       const labelMatch = text.match(/label:\s*"([^"]+)"/);
       if (!labelMatch) continue;
       const label = labelMatch[1];
-      const usesIdx = text.indexOf("uses:");
-      let uses: string[] = [];
-      if (usesIdx >= 0) {
-        const afterUses = text.slice(usesIdx);
-        const arrStart = afterUses.indexOf("[");
-        const arrEnd = afterUses.indexOf("]", arrStart);
-        if (arrStart >= 0 && arrEnd > arrStart) {
-          const arr = afterUses.slice(arrStart + 1, arrEnd);
-          uses = [...arr.matchAll(/"([^"]+)"/g)].map((m) => m[1]);
-        }
-      }
+      const uses = parseUsesField(text);
       blocks.set(label, { label, kind, uses, file: path });
     }
   }

--- a/content/pipeline/conjectural-propagation-audit.ts
+++ b/content/pipeline/conjectural-propagation-audit.ts
@@ -24,6 +24,7 @@ import { join } from "node:path";
 import { leanPackageByName } from "../../schemas/lean-packages.ts";
 import { findContentRepoRoot } from "./repo-root";
 import { requirePaper } from "./repo-root";
+import { parseUsesField } from "./uses-field";
 
 // Resolve repo root from this script's location:
 // content/pipeline/conjectural-propagation-audit.ts → repo root.
@@ -112,18 +113,7 @@ async function loadAll(): Promise<Map<string, Block>> {
       const labelMatch = text.match(/label:\s*"([^"]+)"/);
       if (!labelMatch) continue;
       const label = labelMatch[1];
-      // Extract uses[] — find first `uses: [` and read until matching `]`.
-      const usesIdx = text.indexOf("uses:");
-      let uses: string[] = [];
-      if (usesIdx >= 0) {
-        const afterUses = text.slice(usesIdx);
-        const arrStart = afterUses.indexOf("[");
-        const arrEnd = afterUses.indexOf("]", arrStart);
-        if (arrStart >= 0 && arrEnd > arrStart) {
-          const arr = afterUses.slice(arrStart + 1, arrEnd);
-          uses = [...arr.matchAll(/"([^"]+)"/g)].map((m) => m[1]);
-        }
-      }
+      const uses = parseUsesField(text);
       blocks.set(label, { label, kind, uses, file: path });
     }
   }

--- a/content/pipeline/prune-transitive-deps.ts
+++ b/content/pipeline/prune-transitive-deps.ts
@@ -38,6 +38,7 @@ import { join} from "path";
 import type { Paper, Chapter, Section, Block } from "../../schemas/types";
 import { findContentRepoRoot } from "./repo-root";
 import { requirePaper } from "./repo-root";
+import { findUsesField, replaceUsesArray, removeUsesField } from "./uses-field";
 
 // Was rooted at this file's own location, which is the PLATFORM — but every
 // path below is folio content. `findContentRepoRoot()` walks up from cwd;
@@ -188,29 +189,24 @@ function applyPruning(
     const tsPath = block.tsPath;
     let content = readFileSync(tsPath, "utf-8");
 
-    // Match the uses array in the .ts file and replace it
-    // Pattern: uses: [ ... ] (possibly multiline)
-    const usesPattern = /uses:\s*\[[\s\S]*?\]/;
-    const match = content.match(usesPattern);
-    if (!match) {
+    // Locate the uses[] field. The previous pattern was
+    // `/uses:\s*\[[\s\S]*?\]/` — no word boundary, so on a block with a
+    // `causes:` field earlier in the object this WROTE OVER THAT FIELD,
+    // and non-greedy, so an entry containing `]` truncated the match
+    // mid-array. This is the write path; both mistakes edit content.
+    if (!findUsesField(content)) {
       console.warn(`  ⚠ Could not find uses[] in ${tsPath}`);
       continue;
     }
 
-    let newUses: string;
     if (pruned.length === 0) {
-      // Remove the uses field entirely
-      // Match uses: [...], with optional trailing comma
-      const removePattern = /\s*uses:\s*\[[\s\S]*?\],?\n?/;
-      content = content.replace(removePattern, "\n");
+      content = removeUsesField(content);
     } else if (pruned.length === 1) {
-      newUses = `uses: ["${pruned[0]}"]`;
-      content = content.replace(usesPattern, newUses);
+      content = replaceUsesArray(content, `["${pruned[0]}"]`);
     } else {
       const indent = "    ";
-      const entries = pruned.map(u => `${indent}"${u}",`).join("\n");
-      newUses = `uses: [\n${entries}\n  ]`;
-      content = content.replace(usesPattern, newUses);
+      const entries = pruned.map((u) => `${indent}"${u}",`).join("\n");
+      content = replaceUsesArray(content, `[\n${entries}\n  ]`);
     }
 
     writeFileSync(tsPath, content);

--- a/content/pipeline/qa-checkers-extended.ts
+++ b/content/pipeline/qa-checkers-extended.ts
@@ -28,6 +28,7 @@ import { fileURLToPath } from "url";
 import { Q_USAGE_AUTOMATED_CHECKERS } from "./qa-checkers-q-usage";
 import { hashFile } from "./qa-utils";
 import { findContentRepoRoot, findPapers } from "./repo-root";
+import { stripArrayField } from "./uses-field";
 
 const __filename = fileURLToPath(import.meta.url);
 // Resolve content-repo paths (witnesses under <repo>/computations, Lean
@@ -632,10 +633,14 @@ export function checkComputeLpDualPresent(
   // do not imply the block's OWN witness must carry LP dual fields.
   // Strip uses: array + cites: array + interprets: field — these are
   // downstream references, not evidence the block computes LP duals.
-  const tsStripped = ts
-    .replace(/\buses\s*:\s*\[[\s\S]*?\]/g, "")
-    .replace(/\bcites\s*:\s*\[[\s\S]*?\]/g, "")
-    .replace(/\binterprets\s*:\s*"[^"]*"/g, "");
+  // Non-greedy `[\s\S]*?\]` stopped at the FIRST `]`, so an entry
+  // containing one (`"def:family[0]"`) left the rest of the array in
+  // place — and a stray LP hint inside it then read as evidence about
+  // this block. `stripArrayField` scans to the matching bracket.
+  const tsStripped = stripArrayField(stripArrayField(ts, "uses"), "cites").replace(
+    /\binterprets\s*:\s*"[^"]*"/g,
+    "",
+  );
   if (!LP_DUAL_HINT_RE.test(tsStripped)) {
     return { result: "pass", hits: [] };
   }

--- a/content/pipeline/uses-field.ts
+++ b/content/pipeline/uses-field.ts
@@ -1,0 +1,184 @@
+/**
+ * One parser for the `uses:` field of a block's `.ts` source.
+ *
+ * `uses[]` is the **editorial** relation — what a reader must have read
+ * to follow a block — and AGENTS.md makes it the signal every ordering
+ * metric is computed from. It was being extracted from source text by
+ * four independent hand-rolled parsers, two of which could return a
+ * *different field's* array as the block's dependencies:
+ *
+ * - `conditional-class-banner-audit` (a CI gate) and
+ *   `conjectural-propagation-audit` shared a verbatim copy built on
+ *   `text.indexOf("uses:")` with no word boundary, so a field named
+ *   `causes:` matched — and the following `indexOf("[")` then walked to
+ *   whatever array came next.
+ * - `prune-transitive-deps` matched `/uses:\s*\[[\s\S]*?\]/`, also
+ *   without a boundary, on its **write** path.
+ * - `qa-checkers-extended` had the boundary but still stopped at the
+ *   first `]`.
+ *
+ * Two failure shapes, both silent. Stopping at the first `]` drops an
+ * entry containing one and yields `[]` — a block with no dependencies.
+ * Matching the wrong field yields a plausible-looking list of labels
+ * that were never dependencies at all.
+ *
+ * Parsing TypeScript source with a scanner is not ideal; the blocks are
+ * modules and could be imported. That is a larger change than the bug
+ * warrants, and every existing caller already works on text — so this
+ * consolidates the scanning rather than replacing it. See bean `jwd9`.
+ *
+ * @module content/pipeline/uses-field
+ */
+
+/** Identifier characters, for deciding what is a whole field name. */
+const IDENT = /[A-Za-z0-9_$]/;
+
+export interface UsesField {
+  /** Offset of the `u` in `uses:`. */
+  fieldStart: number;
+  /** Offset of the opening `[`. */
+  arrayStart: number;
+  /** Offset just past the matching `]`. */
+  arrayEnd: number;
+  /** String entries, in source order. */
+  entries: string[];
+}
+
+/**
+ * Offset of the `uses` **field** — a `uses` not preceded by an
+ * identifier character, followed by optional space and a `:`.
+ *
+ * The boundary is what keeps `causes:`, `misuses:` and `reuses:` out.
+ * JS `\b` is not enough on its own here because the old code used a
+ * bare `indexOf`, and `\b` would also accept `$uses`.
+ */
+function findFieldStart(text: string, name: string, from = 0): number {
+  let i = from;
+  for (;;) {
+    i = text.indexOf(name, i);
+    if (i < 0) return -1;
+    const before = i > 0 ? text[i - 1] : " ";
+    if (!IDENT.test(before)) {
+      // Allow whitespace between the name and its colon.
+      let j = i + name.length;
+      while (j < text.length && (text[j] === " " || text[j] === "\t")) j++;
+      if (text[j] === ":") return i;
+    }
+    i += name.length;
+  }
+}
+
+/**
+ * Offset just past the `]` matching the `[` at `open`, or -1.
+ *
+ * Depth-counting and string-aware: an entry may legitimately contain a
+ * bracket (`"def:family[0]"`), and stopping at the first `]` turns that
+ * block into one with no dependencies.
+ */
+function matchingBracket(text: string, open: number): number {
+  let depth = 0;
+  for (let i = open; i < text.length; i++) {
+    const c = text[i];
+    if (c === '"' || c === "'" || c === "`") {
+      const quote = c;
+      i++;
+      while (i < text.length && text[i] !== quote) {
+        if (text[i] === "\\") i++;
+        i++;
+      }
+      continue;
+    }
+    if (c === "[") depth++;
+    else if (c === "]") {
+      depth--;
+      if (depth === 0) return i + 1;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Locate the `uses: [...]` field, or `undefined` when there is none.
+ *
+ * Returns `undefined` rather than an empty result when the field is
+ * absent, so a caller can tell "no `uses` field" from "`uses: []`".
+ * Writers depend on that: rewriting a field that is not there would
+ * append one.
+ */
+export function findArrayField(text: string, name: string): UsesField | undefined {
+  let from = 0;
+  for (;;) {
+    const fieldStart = findFieldStart(text, name, from);
+    if (fieldStart < 0) return undefined;
+    // Skip past the name + optional spaces + `:` to the value.
+    let i = fieldStart + name.length;
+    while (i < text.length && text[i] !== ":") i++;
+    i++;
+    while (i < text.length && /\s/.test(text[i])) i++;
+    if (text[i] !== "[") {
+      // A field that is not an array literal — a spread, a variable.
+      // Not something this scanner can read; keep looking rather than
+      // silently reporting the next array along.
+      from = fieldStart + name.length;
+      continue;
+    }
+    const arrayEnd = matchingBracket(text, i);
+    if (arrayEnd < 0) return undefined;
+    const inner = text.slice(i + 1, arrayEnd - 1);
+    const entries = [...inner.matchAll(/"([^"]*)"|'([^']*)'/g)].map((m) => m[1] ?? m[2]);
+    return { fieldStart, arrayStart: i, arrayEnd, entries };
+  }
+}
+
+/** Locate the `uses: [...]` field specifically. */
+export function findUsesField(text: string): UsesField | undefined {
+  return findArrayField(text, "uses");
+}
+
+/**
+ * Remove an array field's `name: [...]` text entirely, leaving the rest
+ * intact. Used to blank downstream-reference fields before scanning the
+ * remaining source for evidence about the block itself.
+ */
+export function stripArrayField(text: string, name: string): string {
+  for (;;) {
+    const f = findArrayField(text, name);
+    if (!f) return text;
+    text = text.slice(0, f.fieldStart) + text.slice(f.arrayEnd);
+  }
+}
+
+/** The block's `uses[]` entries; `[]` when the field is absent. */
+export function parseUsesField(text: string): string[] {
+  return findUsesField(text)?.entries ?? [];
+}
+
+/**
+ * Replace the `uses: [...]` field's array literal with `replacement`.
+ *
+ * Returns the text unchanged when there is no `uses` field — callers
+ * that must know use `findUsesField` first.
+ */
+export function replaceUsesArray(text: string, replacement: string): string {
+  const f = findUsesField(text);
+  if (!f) return text;
+  return text.slice(0, f.arrayStart) + replacement + text.slice(f.arrayEnd);
+}
+
+/**
+ * Remove the whole `uses: [...]` field, plus a trailing comma and the
+ * whitespace that would otherwise be left behind.
+ */
+export function removeUsesField(text: string): string {
+  const f = findUsesField(text);
+  if (!f) return text;
+  let end = f.arrayEnd;
+  if (text[end] === ",") end++;
+  // Take the preceding indentation with it, so the field's line does
+  // not survive as a blank one.
+  let start = f.fieldStart;
+  while (start > 0 && (text[start - 1] === " " || text[start - 1] === "\t")) start--;
+  if (text[end] === "\n") end++;
+  else if (start > 0 && text[start - 1] === "\n") start--;
+  return text.slice(0, start) + text.slice(end);
+}

--- a/scripts/tests/uses-field.test.ts
+++ b/scripts/tests/uses-field.test.ts
@@ -1,0 +1,200 @@
+/**
+ * `uses[]` is the editorial relation AGENTS.md makes every ordering
+ * metric depend on. It was read out of `.ts` source by four independent
+ * hand-rolled parsers; measured against five plausible inputs, the
+ * audits' copy got three wrong — and two of those three did something
+ * worse than return nothing:
+ *
+ *   uses: ["def:x[0]", "thm:y"]                  ->  []
+ *   causes: ["not-a-dep"], uses: ["def:real"]    ->  ["not-a-dep"]
+ *
+ * The first is a block that silently loses its dependencies. The second
+ * is a block that silently acquires someone else's — a plausible-looking
+ * list of labels that were never dependencies at all.
+ *
+ * Both shapes reach content: `prune-transitive-deps` used the same
+ * boundary-less pattern on its WRITE path, so it could rewrite a
+ * `causes:` field as `uses:`.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  parseUsesField,
+  findUsesField,
+  findArrayField,
+  replaceUsesArray,
+  removeUsesField,
+  stripArrayField,
+} from "../../content/pipeline/uses-field";
+
+const BLOCK = (fields: string) => `export default theorem({ label: "thm:a", ${fields} });\n`;
+
+describe("parseUsesField", () => {
+  test("reads a plain array", () => {
+    expect(parseUsesField(BLOCK(`uses: ["def:x", "thm:y"]`))).toEqual(["def:x", "thm:y"]);
+  });
+
+  test("keeps an entry containing a bracket", () => {
+    // Stopping at the first `]` yielded [] — the block read as having
+    // no editorial dependencies at all.
+    expect(parseUsesField(BLOCK(`uses: ["def:x[0]", "thm:y"]`))).toEqual([
+      "def:x[0]",
+      "thm:y",
+    ]);
+  });
+
+  test("does not match a field whose name merely ENDS in `uses`", () => {
+    // `indexOf("uses:")` matched inside `causes:` and then returned that
+    // array. This is the false-edge case, and it is worse than a miss:
+    // the result looks like a real dependency list.
+    expect(parseUsesField(BLOCK(`causes: ["not-a-dep"], uses: ["def:real"]`))).toEqual([
+      "def:real",
+    ]);
+    expect(parseUsesField(BLOCK(`misuses: ["nope"], uses: ["def:real"]`))).toEqual([
+      "def:real",
+    ]);
+    expect(parseUsesField(BLOCK(`reuses: ["nope"], uses: ["def:real"]`))).toEqual([
+      "def:real",
+    ]);
+  });
+
+  test("is not fooled by `uses:` appearing inside a string", () => {
+    expect(
+      parseUsesField(BLOCK(`statement: "this uses: nothing", tags: ["wrong"], uses: ["def:real"]`)),
+    ).toEqual(["def:real"]);
+  });
+
+  test("an empty array stays empty and does not borrow a later one", () => {
+    expect(parseUsesField(BLOCK(`uses: [], tags: ["not-a-dep"]`))).toEqual([]);
+  });
+
+  test("multiline arrays, trailing commas, single quotes", () => {
+    expect(
+      parseUsesField(`export default theorem({
+  label: "thm:a",
+  uses: [
+    "def:x",
+    'thm:y',
+  ],
+});
+`),
+    ).toEqual(["def:x", "thm:y"]);
+  });
+
+  test("no `uses` field at all yields []", () => {
+    expect(parseUsesField(BLOCK(`tags: ["t"]`))).toEqual([]);
+  });
+
+  test("a non-literal `uses` value does not borrow the next array", () => {
+    // `uses: SHARED` is not readable by a scanner. Reporting the next
+    // array along would invent dependencies; skipping to a real
+    // `uses: [...]` later, or reporting none, is honest.
+    expect(parseUsesField(BLOCK(`uses: SHARED_DEPS, tags: ["not-a-dep"]`))).toEqual([]);
+  });
+});
+
+describe("findUsesField", () => {
+  test("distinguishes an absent field from an empty one", () => {
+    // A writer must not append a field that was never there.
+    expect(findUsesField(BLOCK(`tags: ["t"]`))).toBeUndefined();
+    expect(findUsesField(BLOCK(`uses: []`))?.entries).toEqual([]);
+  });
+
+  test("offsets bound exactly the array literal", () => {
+    const src = BLOCK(`uses: ["def:x[0]"]`);
+    const f = findUsesField(src)!;
+    expect(src.slice(f.arrayStart, f.arrayEnd)).toBe(`["def:x[0]"]`);
+    expect(src.slice(f.fieldStart, f.fieldStart + 4)).toBe("uses");
+  });
+});
+
+describe("replaceUsesArray — the write path", () => {
+  test("rewrites uses[] and leaves a `causes:` field untouched", () => {
+    // The regression that matters: `/uses:\s*\[[\s\S]*?\]/` matched
+    // `causes: [...]` first, so applying a pruning REWROTE THAT FIELD.
+    const src = BLOCK(`causes: ["keep-me"], uses: ["a", "b"]`);
+    const out = replaceUsesArray(src, `["a"]`);
+    expect(out).toContain(`causes: ["keep-me"]`);
+    expect(out).toContain(`uses: ["a"]`);
+    expect(parseUsesField(out)).toEqual(["a"]);
+  });
+
+  test("does not truncate an array whose entry holds a bracket", () => {
+    const src = BLOCK(`uses: ["def:x[0]", "thm:y"], tags: ["t"]`);
+    const out = replaceUsesArray(src, `["def:x[0]"]`);
+    expect(out).toContain(`tags: ["t"]`);
+    expect(parseUsesField(out)).toEqual(["def:x[0]"]);
+  });
+
+  test("leaves text unchanged when there is no uses field", () => {
+    const src = BLOCK(`tags: ["t"]`);
+    expect(replaceUsesArray(src, `["x"]`)).toBe(src);
+  });
+
+  test("a replace round-trip is stable", () => {
+    const src = BLOCK(`uses: ["a", "b"]`);
+    const once = replaceUsesArray(src, `["a"]`);
+    expect(replaceUsesArray(once, `["a"]`)).toBe(once);
+  });
+});
+
+describe("removeUsesField", () => {
+  test("removes the field and its trailing comma", () => {
+    const src = `export default theorem({
+  label: "thm:a",
+  uses: ["def:x"],
+  tags: ["t"],
+});
+`;
+    const out = removeUsesField(src);
+    expect(findUsesField(out)).toBeUndefined();
+    expect(out).toContain(`label: "thm:a"`);
+    expect(out).toContain(`tags: ["t"]`);
+    // No orphaned blank line where the field used to be.
+    expect(out).not.toMatch(/\n\s*\n\s*tags/);
+  });
+
+  test("removes only the uses field, not a similarly named one", () => {
+    const src = `export default theorem({
+  causes: ["keep-me"],
+  uses: ["def:x"],
+});
+`;
+    const out = removeUsesField(src);
+    expect(out).toContain(`causes: ["keep-me"]`);
+    expect(findUsesField(out)).toBeUndefined();
+  });
+});
+
+describe("stripArrayField", () => {
+  test("strips the whole array, including entries holding brackets", () => {
+    const src = BLOCK(`uses: ["def:x[0]", "lp-dual"], script: "s.py"`);
+    const out = stripArrayField(src, "uses");
+    expect(out).not.toContain("lp-dual");
+    expect(out).toContain(`script: "s.py"`);
+  });
+
+  test("strips every occurrence and terminates", () => {
+    const src = `a: ["1"], cites: ["x"], b: 2, cites: ["y"], c: 3`;
+    const out = stripArrayField(src, "cites");
+    expect(out).not.toContain('"x"');
+    expect(out).not.toContain('"y"');
+    expect(out).toContain('a: ["1"]');
+  });
+
+  test("leaves a similarly named field alone", () => {
+    const src = `recites: ["keep"], cites: ["drop"]`;
+    const out = stripArrayField(src, "cites");
+    expect(out).toContain('recites: ["keep"]');
+    expect(out).not.toContain('"drop"');
+  });
+});
+
+describe("findArrayField generalises without loosening the boundary", () => {
+  test("finds a named field", () => {
+    expect(findArrayField(BLOCK(`cites: ["bib:x"]`), "cites")?.entries).toEqual(["bib:x"]);
+  });
+
+  test("a field name that is a suffix of another is not matched", () => {
+    expect(findArrayField(BLOCK(`recites: ["nope"]`), "cites")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Found by sweeping for the shape fixed in #74 — a delimiter located by a flat scan that ignores nesting and quoting.

`uses[]` is the editorial relation AGENTS.md calls *the signal every ordering metric is computed from*. It was being read out of `.ts` source by four independent parsers. Two were verbatim copies of each other; one of those is a **CI gate** (`witness-pipeline.yml`), and a third is a **content-rewriting tool**.

Measured against five plausible inputs, the audits' copy got three wrong:

```
uses: ["def:x[0]", "thm:y"]                 ->  []
causes: ["not-a-dep"], uses: ["def:real"]   ->  ["not-a-dep"]
statement: "this uses: nothing",
  tags: ["wrong"], uses: ["def:real"]       ->  ["wrong"]
```

The first loses a block's dependencies. The other two are worse than a miss — they return a plausible-looking list of labels that were never dependencies at all.

Both causes are the #74 shape: `indexOf("uses:")` has no word boundary, so it matches inside another identifier or inside prose, and the following `indexOf("[")` walks to whatever array comes next; `indexOf("]")` stops at the first bracket rather than the matching one.

## How live is this — latent, and worth saying plainly

The inputs above were measured, but I checked `schemas/types.ts` afterwards: **no schema field name contains `uses`**, so the `causes:` collision cannot fire on schema-conformant content today. What *can* fire, on content that breaks no rule:

- a prose field (`caption`, `summary`, `authorNotes`) containing the literal `uses:` **before** the real field — *"Figure 2 uses: the construction of §3"* — which hands back `tags:` as the dependency list;
- an entry containing `]`, which truncates the array to `[]`.

Neither was observed on real content; there is no folio in this container to check against. **So this is a latent-correctness fix in a CI gate and a write path, not a repair of observed damage.** The consolidation is the durable part.

## The write path was the worst of the four

`prune-transitive-deps` matched `/uses:\s*\[[\s\S]*?\]/` — no boundary — and fed it straight to `content.replace()`. On a block carrying a `causes:` field before `uses`:

```
OLD replace:  causes: ["a"]   <- wrong field rewritten, uses[] left unpruned
OLD remove:   "  ca"          <- truncated mid-token, invalid TypeScript
NEW:          both correct
```

## What replaces them

`content/pipeline/uses-field.ts` — match the field name with a real identifier boundary, scan to the matching `]` with bracket-depth and string awareness.

`findUsesField` returns `undefined` for an absent field but a zero-entry result for `uses: []`, because a writer must not append a field that was never there. A `uses:` whose value is not an array literal is skipped rather than resolved to the next array along — inventing a dependency is worse than reporting none.

## Testing

21 new tests, each watched failing against the old parsers first. Suite 476 → 497 pass, 0 fail; `tsc --noEmit` and `eslint .` clean.

## Deferred

These scan TypeScript source when the blocks are modules that could be imported — `prune-transitive-deps` already imports them for *reading* and only scans for *writing*. Editing against the loaded module is the better end state and a larger change than this bug warranted. Noted on bean `jwd9`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LL9F9XMXAvKZzjxxhMs2bQ)_