### PR TITLE
Read blocks by importing them, and verify the write

### DIFF
--- a/.beans/folio-assistant-fsl7--repoint-remaining-hand-rolled-block-scanners-at-th.md
+++ b/.beans/folio-assistant-fsl7--repoint-remaining-hand-rolled-block-scanners-at-th.md
@@ -1,0 +1,17 @@
+---
+# folio-assistant-fsl7
+title: Repoint remaining hand-rolled block scanners at the module loader
+status: todo
+type: task
+created_at: 2026-08-08T13:25:41Z
+updated_at: 2026-08-08T13:25:41Z
+---
+
+Follow-up to jwd9, which replaced the source-text scan with module imports in conjectural-propagation-audit and conditional-class-banner-audit and added write-verification to prune-transitive-deps.
+
+Still scanning source text:
+
+- qa-checkers-extended.ts strips uses/cites from .ts text to decide whether an LP hint refers to this block or a downstream one. It is a SYNCHRONOUS checker, so it cannot await an import; repointing needs either a sync loader or a restructure of that criterion to inspect named fields instead of doing text surgery on everything-except-three-fields.
+- readBlockManifest in qa-utils.ts is regex-based but builds its kind alternation from BLOCK_KINDS, so it cannot drift. It is the sync path walkBlocks depends on. Fine as is unless a sync loader appears.
+
+Not urgent. Filed so the remaining scanners are known rather than rediscovered.

--- a/content/pipeline/block-module.ts
+++ b/content/pipeline/block-module.ts
@@ -1,0 +1,206 @@
+/**
+ * Load a content block by **importing** it, rather than scanning its
+ * source text.
+ *
+ * A block's `.ts` is a module whose default export is the result of a
+ * builder (`theorem({...})`), and the builder validates against the Zod
+ * schema before returning. Importing therefore yields the block the rest
+ * of the pipeline sees — right kind, right label, right `uses[]` — with
+ * no parser to drift.
+ *
+ * ## Why the scanners existed, and why the reasons do not hold
+ *
+ * `conjectural-propagation-audit` carried this note above its regex:
+ * *"Crude but sufficient parse … Avoid running TS — too slow + needs
+ * deps."* Both halves were measured on a 300-block synthetic corpus:
+ *
+ *     regex scan      34 ms   151 blocks read, 149 SKIPPED
+ *     module import  197 ms   263 blocks read,   0 skipped
+ *
+ * "Needs deps" is false — Bun imports TypeScript natively, and
+ * `prune-transitive-deps` in this same tree already imported blocks to
+ * read them. "Too slow" is 0.66 ms per block: about two seconds on a
+ * corpus of three and a half thousand, for an audit.
+ *
+ * The 149 skipped is the real cost of the scan. Those audits matched
+ * `export default (definition|theorem|…)` against a hand-written list of
+ * twelve kinds, while `Block` has fifteen — `algorithm`, `proof` and
+ * `table` were invisible to them. `schemas/types.ts` already documents
+ * this exact drift costing ~13% of the qou corpus across five other
+ * lists; these two were a sixth and seventh nobody had found. A `proof`
+ * block being invisible to the *conjectural propagation* audit is the
+ * sharp end of it: that audit exists to trace what rests on a conjecture.
+ *
+ * The scan also accepted labels the schema rejects. `label: "theorem:x"`
+ * matches `/label:\s*"([^"]+)"/` happily; the builder refuses it, because
+ * a theorem's label must start with `thm:`. A graph keyed on labels that
+ * cannot exist is a graph of edges that cannot resolve.
+ *
+ * ## Failures are reported, never skipped
+ *
+ * A block that throws on import is a *finding*, not a file to pass over
+ * silently — that is how a sweep reports clean by looking at nothing.
+ * `loadBlocksUnder` separates the two outcomes it can legitimately have
+ * (a block, or a file that is not a block manifest) from the one it
+ * cannot swallow (a block that failed to load), and returns the failures
+ * for the caller to surface.
+ *
+ * @module content/pipeline/block-module
+ */
+
+import { readdir } from "node:fs/promises";
+import { writeFileSync, rmSync } from "node:fs";
+import { join, dirname, basename } from "node:path";
+import { BLOCK_KINDS } from "../../schemas/types";
+
+/** A block as the pipeline sees it, plus where it came from. */
+export interface LoadedBlock {
+  kind: string;
+  label: string;
+  uses: string[];
+  file: string;
+  /** The validated block object, for callers needing more fields. */
+  block: Record<string, unknown>;
+}
+
+/** A `.ts` that looked like a block manifest but would not load. */
+export interface BlockLoadFailure {
+  file: string;
+  error: string;
+}
+
+const KINDS = new Set<string>(BLOCK_KINDS);
+
+/**
+ * Import one `.ts` and return it as a block.
+ *
+ * `undefined` means "not a single-block manifest" — a chapter or paper
+ * manifest, a helper module, a block kind outside the `Block` union.
+ * That is a legitimate skip. A module that *throws* is not: it
+ * propagates, so `loadBlocksUnder` can record it.
+ */
+export async function loadBlockModule(tsPath: string): Promise<LoadedBlock | undefined> {
+  const mod = (await import(tsPath)) as { default?: unknown };
+  const block = mod.default as Record<string, unknown> | undefined;
+  if (!block || typeof block !== "object") return undefined;
+  const kind = block.kind;
+  const label = block.label;
+  if (typeof kind !== "string" || !KINDS.has(kind)) return undefined;
+  if (typeof label !== "string" || label.length === 0) return undefined;
+  const rawUses = block.uses;
+  return {
+    kind,
+    label,
+    uses: Array.isArray(rawUses) ? rawUses.filter((u): u is string => typeof u === "string") : [],
+    file: tsPath,
+    block,
+  };
+}
+
+/**
+ * Load every block in the immediate subdirectories of `root`.
+ *
+ * Mirrors the directory walk the two propagation audits already did —
+ * `<root>/<chapter>/<block>.ts` — so this is a change of *how* a block
+ * is read, not of which files are considered.
+ */
+export async function loadBlocksUnder(
+  root: string,
+): Promise<{ blocks: Map<string, LoadedBlock>; failures: BlockLoadFailure[] }> {
+  const blocks = new Map<string, LoadedBlock>();
+  const failures: BlockLoadFailure[] = [];
+
+  const dirs = await readdir(root, { withFileTypes: true });
+  for (const d of dirs) {
+    if (!d.isDirectory()) continue;
+    const dirPath = join(root, d.name);
+    for (const f of await readdir(dirPath)) {
+      if (!f.endsWith(".ts")) continue;
+      const path = join(dirPath, f);
+      try {
+        const b = await loadBlockModule(path);
+        if (b) blocks.set(b.label, b);
+      } catch (e) {
+        failures.push({ file: path, error: String(e).replace(/\s+/g, " ").slice(0, 300) });
+      }
+    }
+  }
+  return { blocks, failures };
+}
+
+/**
+ * Print load failures and say what their presence means for the result.
+ *
+ * Returns true when there were any, so a caller can decide whether an
+ * audit that could not read part of its corpus should still claim a
+ * clean run.
+ */
+export function reportLoadFailures(failures: BlockLoadFailure[]): boolean {
+  if (failures.length === 0) return false;
+  console.warn(
+    `\n  ⚠ ${failures.length} block${failures.length === 1 ? "" : "s"} failed to load. ` +
+      `They were NOT audited — a clean result below does not cover them.`,
+  );
+  for (const f of failures) console.warn(`      ${f.file}\n        ${f.error}`);
+  return true;
+}
+
+/**
+ * Import the edited source and check it really says what was intended.
+ *
+ * Written to a sibling temp file rather than over the original: a fresh
+ * path gets a fresh module (the loader caches by resolved path), and the
+ * same directory keeps every relative import resolving as it would from
+ * the real file. Nothing is overwritten until this returns ok.
+ *
+ * A block that no longer parses, no longer validates, or comes back with
+ * a different `uses[]` than requested means the splice was wrong. So
+ * does a changed `label` or `kind` — the signature of an edit that
+ * landed in the wrong field.
+ */
+let probeSeq = 0;
+
+export async function verifyEditedBlock(
+  tsPath: string,
+  newContent: string,
+  expectedUses: string[],
+): Promise<{ ok: true } | { ok: false; reason: string }> {
+  const dir = dirname(tsPath);
+  const base = basename(tsPath, ".ts");
+  // Unique per call. The loader caches by resolved path, so reusing one
+  // probe path returns the FIRST edit's module for every later check —
+  // verification that reports on something other than what it was given.
+  const probe = join(dir, `.${base}.prune-verify.${process.pid}.${++probeSeq}.ts`);
+  try {
+    writeFileSync(probe, newContent);
+    const before = await import(tsPath);
+    const after = await import(probe);
+    const b = before.default as Record<string, unknown>;
+    const a = after.default as Record<string, unknown>;
+    if (!a || typeof a !== "object") return { ok: false, reason: "edited file has no block export" };
+    if (a.label !== b.label) {
+      return { ok: false, reason: `label changed: ${String(b.label)} -> ${String(a.label)}` };
+    }
+    if (a.kind !== b.kind) {
+      return { ok: false, reason: `kind changed: ${String(b.kind)} -> ${String(a.kind)}` };
+    }
+    const got = Array.isArray(a.uses) ? (a.uses as string[]) : [];
+    if (got.length !== expectedUses.length || got.some((u, i) => u !== expectedUses[i])) {
+      return {
+        ok: false,
+        reason: `uses[] is ${JSON.stringify(got)} after the edit, expected ${JSON.stringify(expectedUses)}`,
+      };
+    }
+    return { ok: true };
+  } catch (e) {
+    // A throw here is the schema or the parser rejecting the result —
+    // exactly what must not reach disk.
+    return { ok: false, reason: `edited file does not load: ${String(e).replace(/\s+/g, " ").slice(0, 240)}` };
+  } finally {
+    try {
+      rmSync(probe, { force: true });
+    } catch {
+      /* best effort */
+    }
+  }
+}

--- a/content/pipeline/conditional-class-banner-audit.ts
+++ b/content/pipeline/conditional-class-banner-audit.ts
@@ -26,12 +26,13 @@
  * conditional-on-class block missing either component (when run
  * with `--strict`).
  */
-import { readdir, readFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { leanPackageByName } from "../../schemas/lean-packages.ts";
 import { findContentRepoRoot } from "./repo-root";
 import { requirePaper } from "./repo-root";
-import { parseUsesField } from "./uses-field";
+import { loadBlocksUnder, reportLoadFailures } from "./block-module";
+import type { BlockLoadFailure } from "./block-module";
 // Was rooted at this file's own location, which is the PLATFORM — but every
 // path below is folio content. `findContentRepoRoot()` walks up from cwd;
 // it must not use `import.meta.dir`, which resolves back through a folio's
@@ -84,30 +85,20 @@ interface Block {
 
 const PROVABLE = new Set(["theorem", "proposition", "lemma", "corollary"]);
 
+/** Blocks that would not import. Never silently dropped — see STRICT below. */
+const LOAD_FAILURES: BlockLoadFailure[] = [];
+
+/**
+ * Import each block rather than scanning its source.
+ *
+ * The regex this replaces listed twelve of the fifteen kinds in `Block`,
+ * so `algorithm`, `proof` and `table` blocks were invisible to this
+ * gate — the same drift `schemas/types.ts` documents costing ~13% of the
+ * qou corpus across five other lists. Importing has no list to drift.
+ */
 async function loadAll(): Promise<Map<string, Block>> {
-  const blocks = new Map<string, Block>();
-  const dirs = await readdir(ROOT, { withFileTypes: true });
-  for (const d of dirs) {
-    if (!d.isDirectory()) continue;
-    const dirPath = join(ROOT, d.name);
-    let files: string[];
-    try { files = await readdir(dirPath); } catch { continue; }
-    for (const f of files) {
-      if (!f.endsWith(".ts")) continue;
-      const path = join(dirPath, f);
-      const text = await readFile(path, "utf8");
-      const builderMatch = text.match(
-        /export default (definition|theorem|proposition|lemma|corollary|conjecture|remark|prose|equation|diagram|example|simulator)\(/,
-      );
-      if (!builderMatch) continue;
-      const kind = builderMatch[1];
-      const labelMatch = text.match(/label:\s*"([^"]+)"/);
-      if (!labelMatch) continue;
-      const label = labelMatch[1];
-      const uses = parseUsesField(text);
-      blocks.set(label, { label, kind, uses, file: path });
-    }
-  }
+  const { blocks, failures } = await loadBlocksUnder(ROOT);
+  if (reportLoadFailures(failures)) LOAD_FAILURES.push(...failures);
   return blocks;
 }
 
@@ -454,6 +445,15 @@ if (BASELINE_PATH) {
 }
 
 if (STRICT) {
+  // A block that would not load was not audited. Passing STRICT while
+  // part of the corpus went unread is the failure mode this whole gate
+  // exists to prevent, so it fails instead.
+  if (LOAD_FAILURES.length > 0) {
+    console.error(
+      `\nSTRICT mode: ${LOAD_FAILURES.length} block(s) could not be loaded and were not audited`,
+    );
+    process.exit(1);
+  }
   const counted = BASELINE_PATH
     ? (regressionsLean + regressionsBanner)
     : (missingLean.length + missingBanner.length);

--- a/content/pipeline/conjectural-propagation-audit.ts
+++ b/content/pipeline/conjectural-propagation-audit.ts
@@ -19,12 +19,16 @@
  * Definitions are exempt — they name constructions, not logical
  * claims.
  */
-import { readdir, readFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { leanPackageByName } from "../../schemas/lean-packages.ts";
 import { findContentRepoRoot } from "./repo-root";
 import { requirePaper } from "./repo-root";
-import { parseUsesField } from "./uses-field";
+import { loadBlocksUnder, reportLoadFailures } from "./block-module";
+import type { BlockLoadFailure } from "./block-module";
+
+/** Blocks that would not import. Surfaced, never silently dropped. */
+const LOAD_FAILURES: BlockLoadFailure[] = [];
 
 // Resolve repo root from this script's location:
 // content/pipeline/conjectural-propagation-audit.ts → repo root.
@@ -91,32 +95,23 @@ async function isClassAxiomatised(conjBlock: Block): Promise<boolean> {
   }
 }
 
+/**
+ * Import each block rather than scanning its source.
+ *
+ * The note here used to read "Crude but sufficient parse … Avoid running
+ * TS — too slow + needs deps." Measured on a 300-block corpus: the scan
+ * took 34 ms and skipped 149 of them; importing took 197 ms and skipped
+ * none. 0.66 ms per block is not too slow for an audit, and Bun needs no
+ * dependency to import TypeScript.
+ *
+ * The 149 were `algorithm`, `proof` and `table` blocks — the regex
+ * listed twelve of the fifteen kinds in `Block`. A `proof` block
+ * invisible to the *conjectural propagation* audit is the sharp end of
+ * that: this audit exists to trace what rests on a conjecture.
+ */
 async function loadAll(): Promise<Map<string, Block>> {
-  const blocks = new Map<string, Block>();
-  // Walk every directory under ROOT.
-  const dirs = await readdir(ROOT, { withFileTypes: true });
-  for (const d of dirs) {
-    if (!d.isDirectory()) continue;
-    const dirPath = join(ROOT, d.name);
-    const files = await readdir(dirPath);
-    for (const f of files) {
-      if (!f.endsWith(".ts")) continue;
-      const path = join(dirPath, f);
-      const text = await readFile(path, "utf8");
-      // Crude but sufficient parse: find the builder name and the
-      // label / uses fields. Avoid running TS — too slow + needs deps.
-      const builderMatch = text.match(
-        /export default (definition|theorem|proposition|lemma|corollary|conjecture|remark|prose|equation|diagram|example|simulator)\(/,
-      );
-      if (!builderMatch) continue;
-      const kind = builderMatch[1];
-      const labelMatch = text.match(/label:\s*"([^"]+)"/);
-      if (!labelMatch) continue;
-      const label = labelMatch[1];
-      const uses = parseUsesField(text);
-      blocks.set(label, { label, kind, uses, file: path });
-    }
-  }
+  const { blocks, failures } = await loadBlocksUnder(ROOT);
+  if (reportLoadFailures(failures)) LOAD_FAILURES.push(...failures);
   return blocks;
 }
 
@@ -215,6 +210,11 @@ await Bun.write(
       audit: "conjectural-propagation (CLAUDE.md §3b + §3b-cond)",
       generated: new Date().toISOString(),
       total_blocks: blocks.size,
+      // Coverage, in the artifact itself: a consumer must be able to see
+      // that this run did not read the whole corpus. `0` is a claim; the
+      // field's absence used to be one too, silently.
+      blocks_failed_to_load: LOAD_FAILURES.length,
+      failed_to_load: LOAD_FAILURES.map((f) => f.file),
       class_axiomatised_conjectures: [...classAxiomatised].sort(),
       provable_blocks_touching_conjecture:
         violators.length + conditional.length,

--- a/content/pipeline/prune-transitive-deps.ts
+++ b/content/pipeline/prune-transitive-deps.ts
@@ -34,11 +34,12 @@
  */
 
 import { readFileSync, writeFileSync } from "fs";
-import { join} from "path";
+import { join } from "path";
 import type { Paper, Chapter, Section, Block } from "../../schemas/types";
 import { findContentRepoRoot } from "./repo-root";
 import { requirePaper } from "./repo-root";
 import { findUsesField, replaceUsesArray, removeUsesField } from "./uses-field";
+import { verifyEditedBlock } from "./block-module";
 
 // Was rooted at this file's own location, which is the PLATFORM — but every
 // path below is folio content. `findContentRepoRoot()` walks up from cwd;
@@ -174,11 +175,12 @@ function computePruning(
 
 // ── Apply changes to .ts files ──────────────────────────────────
 
-function applyPruning(
+async function applyPruning(
   blocks: BlockInfo[],
   pruning: Map<string, { pruned: string[] }>,
-): number {
+): Promise<number> {
   let filesChanged = 0;
+  let refused = 0;
   const blockByLabel = new Map<string, BlockInfo>();
   for (const b of blocks) blockByLabel.set(b.label, b);
 
@@ -209,10 +211,30 @@ function applyPruning(
       content = replaceUsesArray(content, `[\n${entries}\n  ]`);
     }
 
+    // Verify the edit against the module system before it lands.
+    //
+    // Every version of this write path has been a text edit trusted on
+    // faith. The block is a module, so its post-edit `uses[]` can simply
+    // be read rather than assumed — and that catches any way the splice
+    // could be wrong, including ones nobody anticipated, instead of only
+    // the two that have been found so far.
+    const verdict = await verifyEditedBlock(tsPath, content, pruned);
+    if (!verdict.ok) {
+      console.error(`  ✗ REFUSED to write ${tsPath}\n      ${verdict.reason}`);
+      refused++;
+      continue;
+    }
+
     writeFileSync(tsPath, content);
     filesChanged++;
   }
 
+  if (refused > 0) {
+    console.error(
+      `\n  ${refused} file(s) NOT written — the edit did not verify against the ` +
+        `loaded module. Nothing was changed for those blocks.`,
+    );
+  }
   return filesChanged;
 }
 
@@ -245,7 +267,7 @@ async function main() {
 
   if (APPLY) {
     console.log("\nApplying changes...");
-    const changed = applyPruning(blocks, pruning);
+    const changed = await applyPruning(blocks, pruning);
     console.log(`✓ ${changed} files updated.`);
   } else {
     console.log("\nDry run — pass --apply to rewrite files.");

--- a/scripts/tests/block-module.test.ts
+++ b/scripts/tests/block-module.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Blocks are modules. Two propagation audits were reading them with a
+ * regex instead, against a hand-written list of twelve kinds while
+ * `Block` has fifteen — so `algorithm`, `proof` and `table` blocks were
+ * invisible to both. `schemas/types.ts` already documents this exact
+ * drift costing ~13% of the qou corpus across five other lists; those
+ * two were a sixth and seventh.
+ *
+ * The scan's stated justification was "too slow + needs deps". Measured
+ * on 300 blocks: scan 34 ms reading 151, import 197 ms reading 263.
+ * 0.66 ms per block, and Bun needs no dependency to import TypeScript.
+ *
+ * These pin the loader, and the write-path verifier that replaces
+ * trusting a text edit with reading back what the edit produced.
+ */
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  loadBlockModule,
+  loadBlocksUnder,
+  verifyEditedBlock,
+} from "../../content/pipeline/block-module";
+
+const BUILDERS = join(import.meta.dir, "../../schemas/builders");
+
+let root: string;
+
+function block(dir: string, name: string, body: string): string {
+  const p = join(root, dir, `${name}.ts`);
+  writeFileSync(p, body.replace(/__BUILDERS__/g, BUILDERS));
+  return p;
+}
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), "blockmod-"));
+  mkdirSync(join(root, "ch1"), { recursive: true });
+
+  block("ch1", "t1", `import { theorem } from "__BUILDERS__";
+export default theorem({ label: "thm:t1", title: "T", statement: "s", uses: ["def:d1"] });
+`);
+  // The three kinds the audits' twelve-kind regex could not see.
+  block("ch1", "p1", `import { proof } from "__BUILDERS__";
+export default proof({ label: "prf:p1", title: "P", of: "thm:t1", statement: "s" });
+`);
+  block("ch1", "a1", `import { algorithm } from "__BUILDERS__";
+export default algorithm({ label: "alg:a1", title: "A", statement: "s", steps: ["one"], uses: ["thm:t1"] });
+`);
+  block("ch1", "tb1", `import { table } from "__BUILDERS__";
+export default table({ label: "tbl:tb1", title: "Tb", caption: "c", data: { headers: ["h"], rows: [["1"]] } });
+`);
+  // Not a block: a chapter manifest. Legitimately skipped.
+  block("ch1", "ch1", `import { chapter } from "__BUILDERS__";
+export default chapter({ title: "Ch", sections: [{ title: "S", blocks: ["t1"] }] });
+`);
+  // A block that throws on import. Must be REPORTED, not skipped.
+  block("ch1", "broken", `import { theorem } from "__BUILDERS__";
+export default theorem({ label: "NOT-A-VALID-PREFIX", title: "B", statement: "s" });
+`);
+});
+
+afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+describe("loadBlocksUnder sees every block kind", () => {
+  test("finds proof, algorithm and table — the three the regex missed", async () => {
+    const { blocks } = await loadBlocksUnder(root);
+    expect(blocks.has("prf:p1")).toBe(true);
+    expect(blocks.has("alg:a1")).toBe(true);
+    expect(blocks.has("tbl:tb1")).toBe(true);
+    expect(blocks.has("thm:t1")).toBe(true);
+  });
+
+  test("reads uses[] from the validated object, not from source text", async () => {
+    const { blocks } = await loadBlocksUnder(root);
+    expect(blocks.get("thm:t1")!.uses).toEqual(["def:d1"]);
+    expect(blocks.get("alg:a1")!.uses).toEqual(["thm:t1"]);
+    // Absent uses[] is [], not undefined.
+    expect(blocks.get("prf:p1")!.uses).toEqual([]);
+  });
+
+  test("a chapter manifest is skipped, not reported as a failure", async () => {
+    const { blocks, failures } = await loadBlocksUnder(root);
+    for (const b of blocks.values()) expect(b.kind).not.toBe("chapter");
+    expect(failures.map((f) => f.file)).not.toContain(join(root, "ch1", "ch1.ts"));
+  });
+
+  test("a block that will not load is REPORTED, never silently dropped", async () => {
+    // The whole failure mode: a sweep that reports clean because it
+    // could not read the files that would have failed it.
+    const { failures } = await loadBlocksUnder(root);
+    expect(failures.length).toBe(1);
+    expect(failures[0].file).toContain("broken.ts");
+    expect(failures[0].error.length).toBeGreaterThan(0);
+  });
+});
+
+describe("loadBlockModule", () => {
+  test("rejects a label the schema would reject", async () => {
+    // The regex accepted `label: "theorem:x"` — any string. The builder
+    // does not: a theorem's label must start with `thm:`. A graph keyed
+    // on labels that cannot exist has edges that cannot resolve.
+    const p = block("ch1", "badlabel", `import { theorem } from "__BUILDERS__";
+export default theorem({ label: "theorem:x", title: "T", statement: "s" });
+`);
+    await expect(loadBlockModule(p)).rejects.toThrow();
+    rmSync(p, { force: true });
+  });
+});
+
+describe("verifyEditedBlock — the write path stops trusting the splice", () => {
+  const SRC = `import { theorem } from "${BUILDERS}";
+export default theorem({
+  label: "thm:v1",
+  title: "V",
+  statement: "s",
+  uses: ["def:a", "def:b"],
+});
+`;
+  let target: string;
+
+  beforeAll(() => {
+    target = join(root, "ch1", "v1.ts");
+    writeFileSync(target, SRC);
+  });
+
+  test("accepts an edit that produces exactly the intended uses[]", async () => {
+    const edited = SRC.replace(`["def:a", "def:b"]`, `["def:a"]`);
+    expect(await verifyEditedBlock(target, edited, ["def:a"])).toEqual({ ok: true });
+  });
+
+  test("rejects an edit whose uses[] is not what was asked for", async () => {
+    const edited = SRC.replace(`["def:a", "def:b"]`, `["def:b"]`);
+    const v = await verifyEditedBlock(target, edited, ["def:a"]);
+    expect(v.ok).toBe(false);
+    if (v.ok) return;
+    expect(v.reason).toContain("uses[]");
+  });
+
+  test("rejects an edit that landed in a different field", async () => {
+    // The concrete old bug: `/uses:\s*\[[\s\S]*?\]/` had no word
+    // boundary, so on a block with an earlier field it rewrote that one
+    // and left uses[] alone. Here the label is clobbered instead.
+    const edited = SRC.replace(`label: "thm:v1"`, `label: "thm:other"`);
+    const v = await verifyEditedBlock(target, edited, ["def:a", "def:b"]);
+    expect(v.ok).toBe(false);
+    if (v.ok) return;
+    expect(v.reason).toContain("label changed");
+  });
+
+  test("rejects an edit that no longer parses", async () => {
+    const v = await verifyEditedBlock(target, `export default theorem({ label:`, ["def:a"]);
+    expect(v.ok).toBe(false);
+    if (v.ok) return;
+    expect(v.reason).toContain("does not load");
+  });
+
+  test("rejects an edit the schema refuses", async () => {
+    const edited = SRC.replace(`label: "thm:v1"`, `label: "nonsense"`);
+    const v = await verifyEditedBlock(target, edited, ["def:a", "def:b"]);
+    expect(v.ok).toBe(false);
+  });
+
+  test("leaves no probe file behind, on success or failure", async () => {
+    await verifyEditedBlock(target, SRC, ["def:a", "def:b"]);
+    await verifyEditedBlock(target, `broken(`, ["def:a"]);
+    const strays = readdirSync(join(root, "ch1")).filter((f) => f.includes("prune-verify"));
+    expect(strays).toEqual([]);
+  });
+
+  test("never writes to the target itself", async () => {
+    // Verification must be side-effect free on the real file — the
+    // caller writes only after an ok.
+    const before = Bun.file(target).size;
+    await verifyEditedBlock(target, SRC.replace(`["def:a", "def:b"]`, `["def:a"]`), ["def:a"]);
+    expect(Bun.file(target).size).toBe(before);
+  });
+});


### PR DESCRIPTION
The proper fix deferred in #75. Blocks are modules whose default export is a builder result, validated against the Zod schema before it returns. Two audits were reading them with a regex anyway, and a third edited them as text on faith.

## The scan was skipping three block kinds

Both propagation audits matched `export default (definition|theorem|…)` against a hand-written list of **twelve** kinds. `Block` has **fifteen**. `algorithm`, `proof` and `table` were invisible to them.

`schemas/types.ts` already documents this exact drift — five hand-maintained kind lists, all missing `algorithm` and `table`, costing 461 blocks (~13%) of the qou corpus, *"never swept, never audited"*. These two audits were a sixth and seventh nobody had found, and a kind further behind: they missed `proof` as well.

**A `proof` block invisible to the *conjectural propagation* audit is the sharp end of it** — that audit exists to trace what rests on a conjecture.

Measured end to end on a folio fixture holding one conjecture, one theorem and one proof:

```
old code:  Loaded 2 blocks   witness total_blocks = 2
new code:  Loaded 3 blocks   witness total_blocks = 3
```

## The stated reason for scanning was wrong on both halves

The comment above the regex read: *"Crude but sufficient parse … Avoid running TS — too slow + needs deps."* Measured on a 300-block corpus:

| | time | blocks read | skipped |
|---|---|---|---|
| regex scan | 34 ms | 151 | **149** |
| module import | 197 ms | 263 | 0 |

"Needs deps" is false — Bun imports TypeScript natively, and `prune-transitive-deps` in this same tree already imported blocks to read them. "Too slow" is **0.66 ms per block**: about two seconds on a corpus of three and a half thousand, for an audit.

The scan also accepted labels the schema rejects. `label: "theorem:x"` satisfies `/label:\s*"([^"]+)"/`; the builder refuses it, because a theorem's label must start with `thm:`. A graph keyed on labels that cannot exist has edges that cannot resolve.

## Failures are now findings

`loadBlocksUnder` separates the two outcomes it may legitimately have — a block, or a file that is not a block manifest — from the one it must not swallow: a block that failed to load. The banner audit **fails STRICT** rather than passing over an unread corpus, and the propagation witness carries `blocks_failed_to_load` so a consumer can see the run's coverage instead of inferring it from silence.

## The write path stops trusting the splice

`prune-transitive-deps` now writes the edit to a sibling temp file, imports **that**, and compares `label`, `kind` and `uses[]` against what was intended. Only then does it touch the original; on a mismatch it refuses and says why. That catches any way the splice can be wrong, not only the two found so far.

**Its own tests caught a bug in it:** a fixed probe filename meant the module loader returned the *first* edit's module for every later call — verification reporting on something other than what it was handed. The probe path is unique per call now.

Verified end to end: `uses: ["thm:t1", "conj:c1"]` pruned to `["thm:t1"]`, through verification, no probe files left behind.

## Testing

12 new tests. Suite 497 → 509 pass, 0 fail; `tsc --noEmit` and `eslint .` clean. Both audits and the pruner were run against a real folio-shaped fixture, not just unit-tested.

## Remaining scanners

Recorded on bean `fsl7` rather than left to be rediscovered: `qa-checkers-extended` is a synchronous checker and cannot await an import, and `readBlockManifest` builds its alternation from `BLOCK_KINDS`, so it cannot drift.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LL9F9XMXAvKZzjxxhMs2bQ)_