### PR TITLE
lake-cache: `status` manufactured the alarm `seed` exempts

### DIFF
--- a/.beans/folio-assistant-5d7z--reseed-lake-cacheqou-v4-24-0-it-carries-zero-of-th.md
+++ b/.beans/folio-assistant-5d7z--reseed-lake-cacheqou-v4-24-0-it-carries-zero-of-th.md
@@ -5,7 +5,7 @@ status: in-progress
 type: bug
 priority: high
 created_at: 2026-08-07T12:10:50Z
-updated_at: 2026-08-08T11:54:20Z
+updated_at: 2026-08-08T15:10:00Z
 ---
 
 The production cache branch has 7268 oleans, all dependencies, none QOU.*. Every restore still rebuilds the paper, and sibling .lean files cannot elaborate standalone. lake-cache.sh status now detects and reports this.
@@ -143,3 +143,76 @@ unrestricted egress.** The runbook in
 `docs/guides/reseeding-the-lean-cache.md` is the artifact to run there. Nothing
 further is doable from an authoring container, and the next session should not
 spend turns re-confirming it.
+
+---
+
+## 2026-08-08 — CORRECTION: the opening measurement is the *mathlib* family's
+
+Not resolving this bean — a sibling holds it. But its premise needs correcting
+before anyone spends a CI run on the stated justification.
+
+`lake-cache.sh status` run **without** `--lake-root`, from a `qou` checkout,
+resolves to the roster's first entry and prints:
+
+    lake root:  /workspace/qou
+    package:    mathlib
+    branch:     lake-cache/mathlib-v4-24-0
+    oleans:     7268  (deps + own)
+    own pkg:    0
+    ! but ZERO belong to this package — only its dependencies are cached.
+
+Those are the numbers this bean opens with. They belong to
+`lake-cache/mathlib-v4-24-0`, not `lake-cache/qou-v4-24-0`, and for that family
+the alarm is a **false positive**: lake-root is `.`, the "own package" is the
+workspace-root shim, and its `.lake/build/lib` is empty by construction. `seed`
+has always exempted `mathlib` for exactly this reason; `status` did not. Fixed
+in `own_oleans_expected` (bean `folio-assistant-zq4t`), with tests.
+
+Pointed at the paper's own lake-root, the same command reports:
+
+    lake root:  /workspace/qou/content/quantum-observable-universe/lean
+    package:    qou
+    branch:     lake-cache/qou-v4-24-0
+    oleans:     950  (deps + own)
+    own pkg:    945
+
+### The oleans were not built here
+
+- 942 of the 945 carry mtimes spread over 2026-06-09 … 2026-08-06 — preserved
+  from build time, which a local build cannot produce. The other three are
+  modules I rebuilt today.
+- `.lake` is gitignored (`.gitignore:64`), so a fresh clone brings none.
+- No restore stamp exists at either lake-root, so `lake-cache.sh restore` was
+  not the mechanism — this container was provisioned some other way
+  (`qou/scripts/lean-cache-restore.sh` extracts the same branch at repo root
+  and writes no stamp).
+- `lake-cache/qou-v4-24-0` was last seeded 2026-08-07T00:11Z; the newest
+  restored olean is 2026-08-06. Consistent.
+
+And operationally: this session elaborated three paper modules standalone
+against those oleans — including a new file, `QOU/QBeta/C1ThetaZeroLocus.lean`,
+which imports `QOU.QBeta.C1ConnectionPoles` — at roughly two minutes each. So
+"Every restore still rebuilds the paper, and sibling .lean files cannot
+elaborate standalone" does not hold in a container provisioned today.
+
+### What I did NOT establish
+
+I did not open the tarball on the branch — that is ~1.6 GB of split parts. The
+provenance above is inference (mtimes + gitignore + no local build), strong but
+indirect.
+
+### The reseed may still be wanted — for different reasons
+
+Two real findings survive, and neither is the one in the title:
+
+1. **The qou cache is partial.** 945 own oleans against the ~1582 modules this
+   bean cites. Some of the paper does still rebuild.
+2. **Trace coverage is 0%.** `status` reports `traced: 5/950 oleans (0%)` for
+   `qou` and `0/7268 (0%)` for `mathlib`. Lake reads `.trace`, not `.olean`, to
+   decide staleness — so `lake build` rebuilds regardless of how many oleans
+   are present. That is why `scripts/lean-verify.sh` (which bypasses `lake`
+   entirely) works here while `lake build` does not, and it is a better
+   justification for a reseed than the zero-own-oleans claim.
+
+Whoever holds this bean should re-decide on (1) and (2). Retitling it would be
+their call, not mine.

--- a/.beans/folio-assistant-zq4t--status-and-seed-disagreed-about-which-caches-need-o.md
+++ b/.beans/folio-assistant-zq4t--status-and-seed-disagreed-about-which-caches-need-o.md
@@ -1,0 +1,45 @@
+---
+# folio-assistant-zq4t
+title: status and seed disagreed about which caches need own-package oleans — the false alarm that misdirected 5d7z
+status: done
+type: bug
+priority: high
+created_at: 2026-08-08T15:10:00Z
+updated_at: 2026-08-08T15:10:00Z
+---
+
+Claimed and finished on `claude/agent-4672-4676-stalled-cldnw5`.
+
+`lake-cache.sh seed` exempts `mathlib` from the own-package guard — for that
+roster entry the lake-root is `.`, the "own package" is the workspace-root shim
+that exists only to pull Mathlib in, and its `.lake/build/lib` is empty by
+construction. `cmd_status` had no such exemption, so pointing it at the
+workspace root printed:
+
+    package:    mathlib
+    branch:     lake-cache/mathlib-v4-24-0
+    oleans:     7268  (deps + own)
+    own pkg:    0
+    ! but ZERO belong to this package — only its dependencies are cached.
+
+That is the mathlib family behaving correctly, dressed as a gutted
+per-package cache.
+
+Fixed by factoring the exemption into one predicate, `own_oleans_expected`,
+which both callers now ask. Two tests added: `status` applies the exemption,
+and `status` still reports a genuinely gutted per-package cache. Suite: 23
+pass, 7 skip, 0 fail.
+
+## Why it mattered
+
+Those seven lines are, verbatim, the evidence bean `folio-assistant-5d7z`
+opens with — "7268 oleans, all dependencies, none QOU.*". They are the
+**mathlib** family's numbers, attributed to `qou`. See the correction appended
+to that bean; it is a sibling's and was not resolved here.
+
+## Method note
+
+The tell was that `status` and `seed` asked the same question in two places
+and answered it differently. When a guard has an exemption, the reporter that
+shares its predicate needs the same one — otherwise the reporter manufactures
+alarms the guard would have waved through.

--- a/scripts/lake-cache.sh
+++ b/scripts/lake-cache.sh
@@ -212,14 +212,30 @@ count_oleans() {
 # Oleans belonging to the package ITSELF, as opposed to its dependencies.
 #
 # A SECOND way a healthy-looking total lies, distinct from the gutting
-# check below. A cache branch can carry thousands of Mathlib oleans and
-# NONE of the paper's own modules — `lake-cache/qou-v4-24-0` does exactly
-# that: 7268 oleans, zero `QOU.*`. Nothing was evicted, so the stamp
-# check passes; the branch was simply seeded without the package. Every
-# build still recompiles the paper, and sibling `.lean` files cannot
+# check below. A cache branch can carry thousands of dependency oleans
+# and NONE of the package's own modules: nothing was evicted, so the
+# stamp check passes; the branch was simply seeded without the package.
+# Every build then recompiles it, and sibling `.lean` files cannot
 # elaborate standalone.
 count_own_oleans() {
   find "$1/.lake/build/lib" -name '*.olean' -type f 2>/dev/null | head -20000 | wc -l | tr -d ' '
+}
+
+# Exit 0 = this family SHOULD carry own-package oleans, so zero of them
+# is a defect worth reporting.
+#
+# `mathlib` is the exception: its roster entry has lake-root `.`, where
+# the "own package" is the workspace-root shim that exists only to pull
+# Mathlib in. Its `.lake/build/lib` is empty by construction and the
+# dependencies ARE the payload.
+#
+# `seed` has always exempted it. `status` did not, and so reported the
+# workspace-root cache as `7268 oleans / own pkg 0` under the alarm
+# "ZERO belong to this package" — a false positive that reads exactly
+# like a gutted per-package cache and was mistaken for one. Both callers
+# now ask here, so they cannot disagree again.
+own_oleans_expected() {  # pkg
+  [ "$1" != "mathlib" ]
 }
 
 # Trace files, which are what Lake actually consults for staleness.
@@ -339,7 +355,7 @@ cmd_status() {
   fi
   if [ "$n" -gt 0 ]; then
     printf '\n  cache PRESENT — %s oleans on disk.\n' "$n"
-    if [ "$own" -eq 0 ]; then
+    if [ "$own" -eq 0 ] && own_oleans_expected "$pkg"; then
       warn "but ZERO belong to this package — only its dependencies are cached."
       info "Anything importing the package's own modules still rebuilds, and"
       info "sibling .lean files will not elaborate standalone. Reseed with a"
@@ -520,16 +536,14 @@ cmd_seed() {
 Seeding an empty cache is worse than none: the next agent gets a hit,
 skips the build, and fails with no oleans."
 
-  # Refuse to seed a package whose OWN modules are absent.
+  # Refuse to seed a package whose OWN modules are absent: thousands of
+  # dependency oleans and none of the package's own makes the total look
+  # healthy while every consumer still rebuilds from source.
   #
-  # This is the exact defect that shipped on lake-cache/qou-v4-24-0:
-  # 7268 oleans, every one a dependency, zero QOU.*. The total looked
-  # healthy, so nothing caught it, and every consumer since has
-  # rebuilt the paper from source while believing the cache was warm.
-  # `mathlib` is exempt — for that package the dependencies ARE the
-  # payload and `.lake/build` is legitimately thin.
+  # Exemptions live in `own_oleans_expected` — `status` asks the same
+  # question, and the two used to answer it differently.
   local own; own=$(count_own_oleans "$root")
-  if [ "$pkg" != "mathlib" ] && [ "$own" -eq 0 ]; then
+  if own_oleans_expected "$pkg" && [ "$own" -eq 0 ]; then
     die "refusing to seed '$br': $n oleans present but ZERO belong to '$pkg'.
 Only .lake/packages/ was populated — .lake/build/lib is empty, so the
 package itself never built. Run a full \`lake build\` in $root first.

--- a/scripts/tests/lake-cache.test.ts
+++ b/scripts/tests/lake-cache.test.ts
@@ -239,6 +239,33 @@ describe("lake-cache.sh — seed guard", () => {
     rmSync(ml, { recursive: true, force: true });
   });
 
+  // `status` used to lack the exemption `seed` has, so pointing it at the
+  // workspace root printed `7268 oleans / own pkg 0` under "ZERO belong to
+  // this package". That is the mathlib family behaving correctly — deps are
+  // its payload — but it reads exactly like a gutted per-package cache, and
+  // was mistaken for one (bean folio-assistant-5d7z). Both callers now go
+  // through `own_oleans_expected`.
+  test("status applies the same mathlib exemption as seed", () => {
+    const ml = mkdtempSync(join(tmpdir(), "lakecache-mlstatus-"));
+    execFileSync("bash", ["-c", `cp -r '${lakeRoot}'/lakefile.toml '${lakeRoot}'/lean-toolchain '${ml}/'`], { stdio: "pipe" });
+    makeLake(ml, 5, 0);
+    git(["init", "-q"], ml);
+    const r = run(["status", "--package", "mathlib", "--lake-root", ml], ml);
+    expect(r.out).toContain("cache PRESENT");
+    expect(r.out).not.toContain("ZERO belong to");
+    rmSync(ml, { recursive: true, force: true });
+  });
+
+  test("status still reports a genuinely gutted per-package cache", () => {
+    const bad = mkdtempSync(join(tmpdir(), "lakecache-badstatus-"));
+    execFileSync("bash", ["-c", `cp -r '${lakeRoot}'/lakefile.toml '${lakeRoot}'/lean-toolchain '${bad}/'`], { stdio: "pipe" });
+    makeLake(bad, 5, 0);
+    git(["init", "-q"], bad);
+    const r = run(["status", "--package", PKG, "--lake-root", bad], bad);
+    expect(r.out).toContain("ZERO belong to");
+    rmSync(bad, { recursive: true, force: true });
+  });
+
   test("refuses to seed an empty tree", () => {
     const empty = mkdtempSync(join(tmpdir(), "lakecache-empty-"));
     execFileSync("bash", ["-c", `cp -r '${lakeRoot}'/lakefile.toml '${lakeRoot}'/lean-toolchain '${empty}/'`], { stdio: "pipe" });


### PR DESCRIPTION
## The bug

`seed` has always exempted `mathlib` from the own-package guard, and the reason
is in its own comment: that roster entry has lake-root `.`, where the "own
package" is the workspace-root shim that exists only to pull Mathlib in, so
`.lake/build/lib` is empty by construction and the dependencies *are* the
payload.

`cmd_status` had no such exemption. Pointed at the workspace root of a `qou`
checkout it printed:

```
  package:    mathlib
  branch:     lake-cache/mathlib-v4-24-0
  oleans:     7268  (deps + own)
  own pkg:    0

  cache PRESENT — 7268 oleans on disk.
  ! but ZERO belong to this package — only its dependencies are cached.
```

That is the mathlib family behaving correctly, dressed as a gutted per-package
cache.

## Why it mattered

Those seven lines are, verbatim, the evidence bean `folio-assistant-5d7z` opens
with — *"The production cache branch has 7268 oleans, all dependencies, none
QOU.\*"* — attributed there to `lake-cache/qou-v4-24-0`. Pointed at the paper's
own lake-root, the same command reports:

```
  package:    qou
  branch:     lake-cache/qou-v4-24-0
  oleans:     950  (deps + own)
  own pkg:    945
```

Three sessions have now planned a multi-hour CI reseed on the first reading. I
appended a correction to that bean rather than resolving it — it is a sibling's,
actively held as of this morning.

To be clear about what the correction does and does not claim: I did not open
the 1.6 GB tarball on the cache branch. The provenance is inference — 942 of the
945 own-package oleans carry mtimes spread over 2026-06-09…2026-08-06, `.lake`
is gitignored, and there is no restore stamp, so they cannot have been built in
this container. Operationally, this session elaborated three paper modules
standalone against them, including a new file importing `QOU.QBeta.*`.

Two real findings survive and are recorded on the bean, because a reseed may
still be wanted for them: the qou cache is **partial** (945 own oleans against
~1582 modules), and **trace coverage is 0%**, which matters more — Lake reads
`.trace`, not `.olean`, to decide staleness.

## The fix

The exemption moves into one predicate:

```sh
own_oleans_expected() {  # pkg
  [ "$1" != "mathlib" ]
}
```

asked by both `cmd_status` and `cmd_seed`, so they cannot answer the same
question differently again.

## Tests

Two added alongside the existing `seed` exemption test:

- `status` applies the same mathlib exemption as `seed`
- `status` still reports a genuinely gutted per-package cache

`bun test scripts/tests/lake-cache.test.ts` → 23 pass, 7 skip, 0 fail.
Full suite → 499 pass, 35 skip, 0 fail.

Verified against the real checkout: the false alarm is gone for the mathlib
family, and the qou family still reports its 945 own oleans.

## Note

`eslint` is broken in this container independently of this change — `bunx
eslint` with no arguments fails the same way (`Oops! Something went wrong!`).
`bun test` was the gate used.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsEwLaLqBdu1cNtjCqqc94)_