### PR TITLE
The citation check could never fire, and three rules skipped kinds

### DIFF
--- a/.beans/folio-assistant-j19q--constraint-rules-silently-skip-kinds-whose-field-t.md
+++ b/.beans/folio-assistant-j19q--constraint-rules-silently-skip-kinds-whose-field-t.md
@@ -1,0 +1,81 @@
+---
+# folio-assistant-j19q
+title: Constraint rules silently skip kinds whose field they check is universal
+status: completed
+type: bug
+priority: normal
+created_at: 2026-08-08T15:36:24Z
+updated_at: 2026-08-08T15:42:47Z
+---
+
+validate.ts:510 does 'if (!rule.appliesTo.includes(block.kind)) continue' — a kind absent from a rule's appliesTo is silently unvalidated.
+
+Enumerated all 10 rules in schemas/constraints.ts against BLOCK_KINDS (15). Five are legitimately kind-specific (lean-file-exists = definition, simulator-html-exists = simulator, remark-interprets/interprets-resolve = remark, provable-lean-warning = the 4 provable kinds). uses-resolve is already full. The other four are narrower than the field they check:
+
+- cites-resolve applies to 9 kinds, but 'cites' is a BlockBase field — every kind can carry it. An algorithm/proof/simulator/equation/diagram/table block whose cites[] names a key absent from references.ts is never checked.
+- simulator-ref-resolve applies to 8, but 'simulator' is also BlockBase.
+- md-crossref-resolve applies to 10; its check already returns null when there is no md content, so the narrowing only creates blind spots. A proof block's .md with a broken [text](#label) is unchecked.
+- md-exists applies to 10 while its description says 'Every block must have a companion .md file'. NOT changing this one: whether equation/diagram/table need an .md is an editorial policy question, not obviously drift, and qou has ~445 table blocks. Flagged only.
+
+All three widened rules already self-guard on the absent field, so widening is behaviour-preserving for blocks without it.
+
+Blocked on a small refactor: constraints.ts cannot import BLOCK_KINDS from types.ts because types.ts imports values from constraints.ts and appliesTo is evaluated at module init — the cycle would leave it undefined. Moving BLOCK_KINDS to a leaf module and re-exporting from types.ts.
+
+
+## Summary of Changes
+
+Two defects, one nested inside the other.
+
+### 1. `cites-resolve` could never fire at all
+
+The narrowing was the smaller problem. `validate.ts:499` built its
+`ConstraintContext` **without `allRefIds`**, and the rule opens with
+`if (… || !ctx.allRefIds) return null` — so the only rule validating a block's
+`cites[]` against the bibliography returned null for every block of every kind,
+always. `bib-qa` does not cover it either: it scans `.tex` and `.md` for
+`\cite{}` and bracket forms, never the `.ts` manifest field.
+
+`validate.ts` now supplies `allRefIds` from the reference registry. A folio with
+no bibliography is legitimate, so an absent registry is not an error — but it
+must not read as "citations checked" either, so the validator emits one `info`
+line saying `cites-resolve` did not run. `hasErrors` counts only `error`, so
+this reports without failing anyone. Added `referenceRegistryConfigured()` to
+the registry, since `getReferenceRegistry()` throws and a caller that may
+legitimately proceed without references needs to ask rather than catch.
+
+### 2. Three rules were narrower than the field they check
+
+`cites` and `simulator` are **BlockBase** fields — every kind can carry one —
+and `md-crossref-resolve` already guards on `ctx.mdContent`. All three
+self-guard when the field is absent, so widening to `...BLOCK_KINDS` is
+behaviour-preserving for blocks without it and gap-closing for blocks with it.
+
+`md-exists` was deliberately NOT changed. Its description says "every block"
+while it applies to 10 of 15, but whether an `equation`/`diagram`/`table`
+block needs a companion `.md` is an editorial policy question, and qou carries
+~445 table blocks. Left as found, recorded in the test's `KIND_SPECIFIC` table
+with that reason.
+
+### The refactor this needed
+
+`constraints.ts` could not import `BLOCK_KINDS` from `types.ts`: `types.ts`
+imports schemas from `constraints.ts` at module scope, and `appliesTo` arrays
+are built during module init — exactly when a cycle leaves the import
+undefined. That is *why* those lists were hand-written. `BLOCK_KINDS`,
+`BlockKind` and `BLOCK_KIND_ALT` moved to the leaf module
+`schemas/block-kinds.ts`, re-exported from `types.ts` so no consumer changed.
+The compile-time exhaustiveness proof stays in `types.ts` (it needs the union);
+verified it still bites across the file boundary by deleting `"table"` from the
+list and watching `tsc` fail at `types.ts(1007)`.
+
+### Correction to this bean's own numbers
+
+It said 10 rules. There are **11** — my enumeration regex required `id:` within
+400 chars of `appliesTo` and missed `lean-stub-conjecture-kind-check`, which is
+the same incomplete-scan-reporting-as-complete defect being fixed. The new test
+found it, which is what the test is for. That rule is genuinely provable-only
+and is recorded as such.
+
+9 tests. The durable part is the forcing function: every rule must be universal
+or listed in `KIND_SPECIFIC` with a stated reason, so a 16th block kind fails
+the suite rather than quietly narrowing what gets validated.

--- a/content/pipeline/references-registry-di.ts
+++ b/content/pipeline/references-registry-di.ts
@@ -42,6 +42,21 @@ export function configureReferenceRegistry(api: ReferenceRegistryAPI): void {
   currentApi = api;
 }
 
+/**
+ * Has a folio supplied references at all?
+ *
+ * `getReferenceRegistry` throws when unconfigured, which is right for a
+ * lookup that must succeed — but a caller that can legitimately proceed
+ * without references needs to ASK rather than catch. `validate.ts` is
+ * one: it builds the constraint context, and `cites-resolve` no-ops when
+ * `allRefIds` is absent. Without this predicate the validator could not
+ * tell "this folio has no bibliography" from "the citation check did not
+ * run", and reported the same clean result either way.
+ */
+export function referenceRegistryConfigured(): boolean {
+  return currentApi !== null;
+}
+
 export function getReferenceRegistry(): ReferenceRegistryAPI {
   if (!currentApi) {
     throw new Error(

--- a/content/pipeline/validate.ts
+++ b/content/pipeline/validate.ts
@@ -30,6 +30,7 @@ import { renderBlock, validateLatexAst } from "./render-latex";
 import { validateDefterms } from "./validate-defterm";
 import { validateValueDirectives } from "./validate-value";
 import { findContentRepoRoot, findPapers } from "./repo-root";
+import { referenceRegistryConfigured, getReferenceRegistry } from "./references-registry-di";
 
 // ── File discovery ───────────────────────────────────────────────
 
@@ -494,12 +495,35 @@ export async function validateObjects(
   // `ReferenceError: dir is not defined` on any run reaching a single block.
   // Restoring the binding is the fix; substituting `objectsDir` would silence
   // the crash and make `md-exists` fail for every block in the paper.
+  // `cites-resolve` opens with `if (… || !ctx.allRefIds) return null`, and
+  // this context never supplied `allRefIds` — so the only rule that
+  // validates a block's `cites[]` against the bibliography could not fire
+  // for any block, ever. `bib-qa` does not cover it either: it scans
+  // `.tex` and `.md` for `\cite{}`, never the `.ts` manifest field.
+  //
+  // A folio with no bibliography is legitimate, so an absent registry is
+  // not an error — but it must not read as "citations checked" either.
+  const refsConfigured = referenceRegistryConfigured();
+  const allRefIds = refsConfigured
+    ? new Set(getReferenceRegistry().referenceMap.keys())
+    : undefined;
+  if (!refsConfigured) {
+    issues.push({
+      level: "info",
+      block: "(bibliography)",
+      message:
+        "no reference registry configured — cites-resolve did not run, so " +
+        "cites[] entries were NOT validated against references",
+    });
+  }
+
   for (const [name, { block, dir }] of allBlocks) {
     const mdContent = mdCache.get(name);
     const ctx: ConstraintContext = {
       rootName: name,
       dir,
       allLabels,
+      allRefIds,
       fileExists: (p: string) => existsSync(p),
       lakeTreeContainsBasename,
       mdContent,

--- a/schemas/block-kinds.ts
+++ b/schemas/block-kinds.ts
@@ -1,0 +1,71 @@
+/**
+ * The block kinds, as a runtime value — in a leaf module so anything can
+ * read it.
+ *
+ * This list used to live in `types.ts`, which is where its consumers
+ * mostly are. But `types.ts` imports schemas from `constraints.ts` at
+ * module scope, so `constraints.ts` could not import back without a
+ * runtime cycle — and its `appliesTo` arrays are built during module
+ * initialisation, exactly when a cycle leaves the import undefined.
+ *
+ * That is why `constraints.ts` spelled its kind lists out by hand, and
+ * why several of them ended up narrower than the rule they gated: a
+ * kind missing from `appliesTo` is skipped by `validate.ts` without a
+ * word. This module imports nothing, so there is no longer a reason for
+ * any list of kinds to be written out anywhere.
+ *
+ * `types.ts` re-exports `BLOCK_KINDS` and `BlockKind`, so existing
+ * importers are unaffected, and keeps the compile-time proof that this
+ * array and the `Block` union cover each other — that check needs the
+ * union, which necessarily lives with the types.
+ *
+ * @module schemas/block-kinds
+ */
+
+/**
+ * Every block kind, as a RUNTIME value.
+ *
+ * `Block` is a type and is erased at compile time, so anything that has
+ * to recognise a block by reading its source — the QA pipeline's block
+ * discovery, the propagation sweeps, the viewer registry, the constraint
+ * table — needs a list it can actually iterate. Seven such lists existed,
+ * hand-maintained and independent, and every one of them was short.
+ *
+ * The cost was silent. `readBlockManifest` returns `undefined` for an
+ * unrecognised builder and `walkBlocks` skips whatever it returns
+ * `undefined` for, so on the qou corpus 461 blocks — 445 `table`, 16
+ * `algorithm` — were never yielded, never swept, and never audited.
+ * Roughly 13% of the corpus, excluded by a stale regex rather than by
+ * any decision.
+ */
+export const BLOCK_KINDS = [
+  "definition",
+  "theorem",
+  "lemma",
+  "proposition",
+  "corollary",
+  "algorithm",
+  "conjecture",
+  "example",
+  "remark",
+  "proof",
+  "simulator",
+  "prose",
+  "equation",
+  "diagram",
+  "table",
+] as const;
+
+export type BlockKind = (typeof BLOCK_KINDS)[number];
+
+/**
+ * `BLOCK_KINDS` as a regex alternation, for the several places that
+ * identify a block by scanning its `.ts` source for the builder call.
+ *
+ * Those call sites need different surrounding patterns — anchored vs
+ * not, `export default` required or optional, followed by `(` or by
+ * `({` — so they build their own regex around this rather than sharing
+ * one. What they must NOT do is spell out the alternation, which is how
+ * five of them came to list 13 of the 15 kinds.
+ */
+export const BLOCK_KIND_ALT = BLOCK_KINDS.join("|");

--- a/schemas/constraints.ts
+++ b/schemas/constraints.ts
@@ -10,6 +10,9 @@ import { z } from "zod";
 
 import { LEAN_REF_PATTERN, leanPackageByName, parseLeanRef } from "./lean-packages.js";
 import type { Block } from "./types.js";
+// Leaf module — importing the kind list from `types.js` would be a runtime
+// cycle, and `appliesTo` is built at module init, exactly when that bites.
+import { BLOCK_KINDS } from "./block-kinds.js";
 
 
 // ─── Enumerations ────────────────────────────────────────────────────────────
@@ -817,8 +820,11 @@ export const CONSTRAINT_RULES: ConstraintRule[] = [
     id: "simulator-ref-resolve",
     description: "Blocks with simulator refs must reference an existing simulator label",
     appliesTo: [
-      "definition", "theorem", "lemma", "proposition", "corollary",
-      "conjecture", "example", "remark",
+      // `simulator` is a BlockBase field, so ANY kind can carry one. The
+      // check below returns null when the field is absent, so listing
+      // fewer kinds only creates blind spots — `validate.ts` skips an
+      // unlisted kind without a word.
+      ...BLOCK_KINDS,
     ],
     check: (block, ctx) => {
       if (!("simulator" in block) || !block.simulator) return null;
@@ -877,8 +883,10 @@ export const CONSTRAINT_RULES: ConstraintRule[] = [
     id: "cites-resolve",
     description: "All citation keys in cites[] must exist in references.ts",
     appliesTo: [
-      "definition", "theorem", "lemma", "proposition", "corollary",
-      "conjecture", "example", "remark", "prose",
+      // `cites` is a BlockBase field — every kind can carry one. An
+      // `algorithm` or `table` block citing a key absent from
+      // references.ts used to pass by never being looked at.
+      ...BLOCK_KINDS,
     ],
     check: (block, ctx) => {
       if (!("cites" in block) || !block.cites || !ctx.allRefIds) return null;
@@ -922,8 +930,10 @@ export const CONSTRAINT_RULES: ConstraintRule[] = [
     id: "md-crossref-resolve",
     description: "All [text](#label) cross-references in .md content must resolve to existing labels",
     appliesTo: [
-      "definition", "theorem", "lemma", "proposition", "corollary",
-      "conjecture", "example", "remark", "simulator", "prose",
+      // Guarded on `ctx.mdContent` below, so kinds without an .md are
+      // already no-ops. A `proof` block's .md with a broken
+      // `[text](#label)` was simply never checked.
+      ...BLOCK_KINDS,
     ],
     check: (_block, ctx) => {
       if (!ctx.mdContent) return null;

--- a/schemas/types.ts
+++ b/schemas/types.ts
@@ -14,6 +14,7 @@ export { isCrossPaperRef, KNOWN_LABEL_PREFIXES } from "./constraints.js";
  */
 
 import { z } from "zod";
+import type { BlockKind } from "./block-kinds.js";
 
 import {
   ActorTypeSchema,
@@ -987,55 +988,14 @@ export type Block =
   | TableBlock;
 
 /**
- * Every block kind, as a RUNTIME value.
- *
- * `Block` above is a type and is erased at compile time, so anything that has
- * to recognise a block by reading its source — the QA pipeline's block
- * discovery, the propagation sweeps, the viewer registry — needs a list it can
- * actually iterate. Five such lists existed, hand-maintained and independent,
- * and all five carried the same 13 of these 15: `algorithm` and `table` were
- * added to the union and never propagated.
- *
- * The cost was silent. `readBlockManifest` returns `undefined` for an
- * unrecognised builder and `walkBlocks` skips whatever it returns `undefined`
- * for, so on the qou corpus 461 blocks — 445 `table`, 16 `algorithm` — were
- * never yielded, never swept, and never audited. Roughly 13% of the corpus,
- * excluded by a stale regex rather than by any decision.
- *
- * `_blockKindsAreExhaustive` below makes `tsc` fail if this array and the
- * union ever disagree again, in either direction.
+ * `BLOCK_KINDS`, `BlockKind` and `BLOCK_KIND_ALT` now live in the leaf
+ * module `./block-kinds`, so `constraints.ts` can import them without a
+ * runtime cycle through this file. Re-exported here because that is
+ * where every existing consumer looks for them.
  */
-export const BLOCK_KINDS = [
-  "definition",
-  "theorem",
-  "lemma",
-  "proposition",
-  "corollary",
-  "algorithm",
-  "conjecture",
-  "example",
-  "remark",
-  "proof",
-  "simulator",
-  "prose",
-  "equation",
-  "diagram",
-  "table",
-] as const;
+export { BLOCK_KINDS, BLOCK_KIND_ALT } from "./block-kinds.js";
+export type { BlockKind } from "./block-kinds.js";
 
-export type BlockKind = (typeof BLOCK_KINDS)[number];
-
-/**
- * `BLOCK_KINDS` as a regex alternation, for the several places that identify a
- * block by scanning its `.ts` source for the builder call.
- *
- * Those call sites need different surrounding patterns — anchored vs not,
- * `export default` required or optional, followed by `(` or by `({` — so they
- * build their own regex around this rather than sharing one. What they must
- * NOT do is spell out the alternation, which is how five of them came to list
- * 13 of the 15 kinds.
- */
-export const BLOCK_KIND_ALT = BLOCK_KINDS.join("|");
 
 /**
  * Compile-time proof that `BLOCK_KINDS` and `Block["kind"]` cover each other.

--- a/scripts/tests/constraint-applies-to.test.ts
+++ b/scripts/tests/constraint-applies-to.test.ts
@@ -1,0 +1,161 @@
+/**
+ * `validate.ts` gates every constraint on its `appliesTo` list:
+ *
+ *     if (!rule.appliesTo.includes(block.kind)) continue;
+ *
+ * A kind missing from that list is not reported as unchecked — it is
+ * simply never checked. Which makes a short `appliesTo` the same defect
+ * as a short block-kind regex, one layer down: the validator passes
+ * because it never looked.
+ *
+ * Three rules were short for no reason. `cites` and `simulator` are
+ * **BlockBase** fields, so every kind can carry one, and both checks
+ * already return null when the field is absent — the narrower list only
+ * removed coverage. `md-crossref-resolve` guards on `ctx.mdContent`, so
+ * kinds without an `.md` were already no-ops.
+ *
+ * The rest are genuinely kind-specific, and this pins WHICH and WHY. A
+ * new kind added to `Block` now has to be classified here: it either
+ * lands in `BLOCK_KINDS` and every universal rule picks it up, or
+ * someone states the reason it is exempt.
+ */
+import { describe, expect, test } from "bun:test";
+import { CONSTRAINT_RULES } from "../../schemas/constraints";
+import { BLOCK_KINDS } from "../../schemas/block-kinds";
+
+/**
+ * Rules that are deliberately narrower, with the reason. Anything not
+ * listed here must apply to every kind.
+ */
+const KIND_SPECIFIC: Record<string, { kinds: string[]; because: string }> = {
+  "lean-file-exists": {
+    kinds: ["definition"],
+    because: "only definitions are required to carry a sibling .lean",
+  },
+  "simulator-html-exists": {
+    kinds: ["simulator"],
+    because: "the html field belongs to the simulator block itself",
+  },
+  "remark-interprets": {
+    kinds: ["remark"],
+    because: "`interprets` is a remark-only field",
+  },
+  "interprets-resolve": {
+    kinds: ["remark"],
+    because: "`interprets` is a remark-only field",
+  },
+  "provable-lean-warning": {
+    kinds: ["theorem", "lemma", "proposition", "corollary"],
+    because: "only provable kinds are expected to have a formalisation",
+  },
+  "lean-stub-conjecture-kind-check": {
+    kinds: ["proposition", "theorem", "lemma", "corollary"],
+    because:
+      "asks whether a PROVABLE block should have been a conjecture, given " +
+      "its Lean stub. The question is meaningless for any other kind.",
+  },
+  "md-exists": {
+    kinds: [
+      "definition", "theorem", "lemma", "proposition", "corollary",
+      "conjecture", "example", "remark", "simulator", "prose",
+    ],
+    because:
+      "whether equation/diagram/table/proof/algorithm blocks must have a " +
+      "companion .md is an editorial policy question, not drift — left as " +
+      "found, deliberately. Its description says 'every block', which is " +
+      "wider than its behaviour; see bean j19q.",
+  },
+};
+
+const byId = new Map(CONSTRAINT_RULES.map((c) => [c.id, c]));
+
+describe("constraint appliesTo coverage", () => {
+  test("every rule is either universal or listed as kind-specific", () => {
+    // The forcing function. A new rule with a short appliesTo, or a new
+    // block kind that some rule was not extended to, fails here rather
+    // than quietly narrowing what gets validated.
+    const unexplained: string[] = [];
+    for (const rule of CONSTRAINT_RULES) {
+      const missing = BLOCK_KINDS.filter((k) => !rule.appliesTo.includes(k));
+      if (missing.length === 0) continue;
+      if (KIND_SPECIFIC[rule.id]) continue;
+      unexplained.push(`${rule.id} skips: ${missing.join(", ")}`);
+    }
+    expect(unexplained).toEqual([]);
+  });
+
+  test("each kind-specific rule matches its documented scope exactly", () => {
+    // Pins the narrowing itself, so widening or narrowing one of these
+    // is a deliberate edit here rather than a silent change in coverage.
+    for (const [id, { kinds }] of Object.entries(KIND_SPECIFIC)) {
+      const rule = byId.get(id);
+      expect({ id, found: rule !== undefined }).toEqual({ id, found: true });
+      expect({ id, kinds: [...rule!.appliesTo].sort() }).toEqual({ id, kinds: [...kinds].sort() });
+    }
+  });
+
+  test("rules checking a BlockBase field apply to every kind", () => {
+    // `cites` and `simulator` are on BlockBase, so any kind can carry
+    // them. `uses` was already universal; these two were not.
+    for (const id of ["cites-resolve", "simulator-ref-resolve", "uses-resolve"]) {
+      const rule = byId.get(id)!;
+      const missing = BLOCK_KINDS.filter((k) => !rule.appliesTo.includes(k));
+      expect({ id, missing }).toEqual({ id, missing: [] });
+    }
+  });
+
+  test("md-crossref-resolve covers every kind that can have an .md", () => {
+    const rule = byId.get("md-crossref-resolve")!;
+    expect(rule.appliesTo).toContain("proof");
+    expect(rule.appliesTo).toContain("algorithm");
+    expect(rule.appliesTo).toContain("table");
+  });
+
+  test("no rule lists a kind that is not a block kind", () => {
+    // The other direction of drift: a rule naming a kind that was
+    // renamed or removed silently applies to nothing.
+    const all = new Set<string>(BLOCK_KINDS);
+    for (const rule of CONSTRAINT_RULES) {
+      const bogus = rule.appliesTo.filter((k) => !all.has(k));
+      expect({ id: rule.id, bogus }).toEqual({ id: rule.id, bogus: [] });
+    }
+  });
+});
+
+describe("cites-resolve actually fires now", () => {
+  const rule = byId.get("cites-resolve")!;
+  const ctx = {
+    rootName: "b", dir: "/tmp", allLabels: new Set<string>(),
+    allRefIds: new Set(["knuth1984"]),
+    fileExists: () => true,
+    lakeTreeContainsBasename: () => false,
+  } as unknown as Parameters<typeof rule.check>[1];
+
+  test("catches a bad citation key on a `table` block", () => {
+    // `table` was not in this rule's appliesTo, so validate.ts skipped it
+    // entirely. qou carries ~445 table blocks.
+    const block = { kind: "table", label: "tbl:x", cites: ["nosuchkey"] };
+    const msg = rule.check(block as never, ctx);
+    expect(msg).toBeTruthy();
+    expect(String(msg)).toContain("nosuchkey");
+  });
+
+  test("accepts a good key, on the same previously-excluded kind", () => {
+    const block = { kind: "table", label: "tbl:x", cites: ["knuth1984"] };
+    expect(rule.check(block as never, ctx)).toBeNull();
+  });
+
+  test("still no-ops for a block with no cites[]", () => {
+    // Why widening is behaviour-preserving: the rule self-guards.
+    const block = { kind: "table", label: "tbl:x" };
+    expect(rule.check(block as never, ctx)).toBeNull();
+  });
+
+  test("no-ops when allRefIds is absent — which is why it never fired", () => {
+    // The real defect: validate.ts built its ConstraintContext without
+    // allRefIds, so this returned null for EVERY block regardless of kind.
+    const noRefs = { ...ctx, allRefIds: undefined } as unknown as Parameters<typeof rule.check>[1];
+    const block = { kind: "theorem", label: "thm:x", cites: ["nosuchkey"] };
+    expect(rule.check(block as never, noRefs)).toBeNull();
+  });
+});


### PR DESCRIPTION
Continuing the sweep from #74–#76 into the constraint table. `validate.ts` gates every rule on its `appliesTo`:

```ts
if (!rule.appliesTo.includes(block.kind)) continue;
```

A kind missing from that list is not reported as unchecked. It is simply never checked — the same defect as a short block-kind regex, one layer down.

## The citation check could never fire at all

The narrowing turned out to be the smaller problem. `validate.ts` built its `ConstraintContext` **without `allRefIds`**, and `cites-resolve` opens with `if (… || !ctx.allRefIds) return null`. So the only rule validating a block's `cites[]` against the bibliography returned `null` for every block of every kind, always.

`bib-qa` does not cover it either: it scans `.tex` and `.md` for `\cite{}` and bracket forms, never the `.ts` manifest field.

The validator now supplies `allRefIds` from the reference registry. A folio with no bibliography is legitimate, so an absent registry is not an error — but it must not read as "citations checked" either, so one `info` line says `cites-resolve` did not run:

```
ℹ [(bibliography)]: no reference registry configured — cites-resolve did not run,
  so cites[] entries were NOT validated against references
```

`hasErrors` counts only `error`, so this reports without failing anyone. `referenceRegistryConfigured()` is new: `getReferenceRegistry()` throws, and a caller that may legitimately proceed without references needs to *ask* rather than catch.

## Three rules were narrower than the field they check

`cites` and `simulator` are **BlockBase** fields — every kind can carry one — and `md-crossref-resolve` already guards on `ctx.mdContent`. All three self-guard when the field is absent, so widening to `...BLOCK_KINDS` is behaviour-preserving for blocks without it and gap-closing for blocks with it. A `table` block citing a key absent from `references.ts`, or a `proof` block whose `.md` has a broken `[text](#label)`, was never looked at.

**`md-exists` is deliberately not changed.** Its description says "every block" while it applies to 10 of 15, but whether an `equation`/`diagram`/`table` block needs a companion `.md` is an editorial policy question, and qou carries ~445 table blocks. Left as found, recorded with that reason.

## Why the lists were hand-written

`constraints.ts` could not import `BLOCK_KINDS` from `types.ts`: `types.ts` imports schemas from `constraints.ts` at module scope, and `appliesTo` arrays are built during module initialisation — exactly when a cycle leaves the import `undefined`.

So `BLOCK_KINDS`, `BlockKind` and `BLOCK_KIND_ALT` move to the leaf module `schemas/block-kinds.ts`, re-exported from `types.ts` so no consumer changes. The compile-time exhaustiveness proof stays with the union; I verified it still bites across the new file boundary by deleting `"table"` from the list and watching `tsc` fail at `types.ts(1007)`.

## A correction I owe my own investigation

I first enumerated "10 rules". There are **11**. My enumeration regex required `id:` within 400 chars of `appliesTo` and missed `lean-stub-conjecture-kind-check` — an incomplete scan reporting as complete, which is the defect being fixed. The new test found it. That rule is genuinely provable-only and is recorded as such.

## Testing

9 new tests. The durable part is the forcing function: every rule must be universal **or** listed in `KIND_SPECIFIC` with a stated reason, so a sixteenth block kind fails the suite rather than quietly narrowing what gets validated.

Suite 509 → 518 pass, 0 fail; `tsc --noEmit` and `eslint .` clean. The validator was also run against a folio-shaped fixture to confirm the `info` line appears and does not affect validity.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LL9F9XMXAvKZzjxxhMs2bQ)_