### PR TITLE
qa: six reference fields leaked into `compute-lp-dual-present`

### DIFF
--- a/.beans/folio-assistant-fsl7--repoint-remaining-hand-rolled-block-scanners-at-th.md
+++ b/.beans/folio-assistant-fsl7--repoint-remaining-hand-rolled-block-scanners-at-th.md
@@ -4,7 +4,7 @@ title: Repoint remaining hand-rolled block scanners at the module loader
 status: todo
 type: task
 created_at: 2026-08-08T13:25:41Z
-updated_at: 2026-08-08T13:25:41Z
+updated_at: 2026-08-08T15:55:00Z
 ---
 
 Follow-up to jwd9, which replaced the source-text scan with module imports in conjectural-propagation-audit and conditional-class-banner-audit and added write-verification to prune-transitive-deps.
@@ -15,3 +15,51 @@ Still scanning source text:
 - readBlockManifest in qa-utils.ts is regex-based but builds its kind alternation from BLOCK_KINDS, so it cannot drift. It is the sync path walkBlocks depends on. Fine as is unless a sync loader appears.
 
 Not urgent. Filed so the remaining scanners are known rather than rediscovered.
+
+## 2026-08-08 — the first bullet's *bug* is fixed; the repoint itself is not
+
+Bullet 1 said `qa-checkers-extended.ts` "strips uses/cites from .ts text to
+decide whether an LP hint refers to this block or a downstream one", and that
+repointing needs a sync loader or a restructure. Looking at it turned up a live
+defect underneath, worth separating from the refactor:
+
+**The strip list was three fields; the schema has nine.** `compute-lp-dual-present`
+stripped `uses`, `cites` and `interprets`, then grepped everything else. But
+`examples`, `proofs`, `defines`, `requires`, `mathlibLinks` and `blocks` are
+reference fields too — they hold labels and paths pointing at OTHER blocks — and
+an LP token in any of them read as evidence that THIS block computes LP duals.
+Demonstrated with fixtures: `examples`, `proofs` and `defines` each produced a
+spurious `fail` before the change.
+
+Fixed by making the list complete and naming it: `REFERENCE_ARRAY_FIELDS` /
+`REFERENCE_SCALAR_FIELDS` + `stripReferenceFields`, sited next to the criterion
+with a note that adding a reference field to the schema means adding it here.
+`scripts/tests/qa-checkers-lp-dual.test.ts` pins both directions — the criterion
+still fires on a real LP solver whose witness lacks its dual certificate, and
+stays quiet for a token in each of the six reference fields.
+
+Verified inert on real content: the criterion was run over all 3523 blocks of
+the `qou` folio before and after — identical output, zero diff. (All pass there
+today, so the corpus alone is a weak signal; the fixtures are what carry the
+evidence, and three of them failed before the change.)
+
+### What is still open here, and why it is a decision rather than a task
+
+The mechanism is still text surgery on `.ts` source. Two ways forward, and they
+are not equivalent:
+
+- **A true allowlist** — read `label`, `title`, `tags`, `script`, `witness`
+  instead of "everything except the reference fields". Cleaner, and immune to a
+  new reference field being added. But it NARROWS the gate: a block whose only
+  LP token lives in an `authorNotes` body would stop being checked. That is a
+  behaviour change with a real miss mode, so it wants a deliberate call rather
+  than being slipped in under a refactor.
+- **A sync loader**, which bullet 1 already names. Still absent.
+
+Until one of those, the complete denylist is the honest middle: same behaviour
+as before except for the bug, and the failure mode is now "someone added a
+schema field and forgot this list", which the comment addresses.
+
+Bullet 2 (`readBlockManifest`) is untouched and still fine as filed.
+
+Leaving this bean `todo` — its actual subject, the repointing, is undone.

--- a/content/pipeline/qa-checkers-extended.ts
+++ b/content/pipeline/qa-checkers-extended.ts
@@ -605,6 +605,38 @@ export function checkComputeWitnessExists(
   return { result: hits.length > 0 ? "fail" : "pass", hits };
 }
 
+/**
+ * Every block field whose contents are LABELS OR PATHS POINTING ELSEWHERE,
+ * as opposed to describing the block itself. Mirrors `BlockBase` and its
+ * kind-specific extensions in `schemas/types.ts`.
+ *
+ * A checker asking "does this block do X?" must not read these — they say
+ * what OTHER blocks do.
+ */
+const REFERENCE_ARRAY_FIELDS = [
+  "uses",
+  "cites",
+  "examples",
+  "proofs",
+  "defines",
+  "requires",
+  "mathlibLinks",
+  "blocks",
+] as const;
+
+/** The same, for fields holding a single reference rather than an array. */
+const REFERENCE_SCALAR_FIELDS = ["interprets", "see"] as const;
+
+/** Blank out every reference field, leaving what the block says about itself. */
+function stripReferenceFields(ts: string): string {
+  let out = ts;
+  for (const f of REFERENCE_ARRAY_FIELDS) out = stripArrayField(out, f);
+  for (const f of REFERENCE_SCALAR_FIELDS) {
+    out = out.replace(new RegExp(`\\b${f}\\s*:\\s*"[^"]*"`, "g"), "");
+  }
+  return out;
+}
+
 const LP_DUAL_HINT_RE =
   /lp-dual|operator-selection-lp|shadow-price|primal-dual|lp-duality/i;
 const LP_DUAL_REQUIRED_FIELDS = [
@@ -627,20 +659,26 @@ export function checkComputeLpDualPresent(
   if (!ts) return { result: "n/a", hits: [] };
   const { witness } = getComputationField(ts);
   if (!witness) return { result: "pass", hits: [] };
-  // Filter: only blocks whose ts mentions LP/SDP/operator-selection
-  // OUTSIDE the `uses: [...]` array. References inside `uses:` are
-  // downstream dependencies (the block consumes an LP result) — they
-  // do not imply the block's OWN witness must carry LP dual fields.
-  // Strip uses: array + cites: array + interprets: field — these are
-  // downstream references, not evidence the block computes LP duals.
-  // Non-greedy `[\s\S]*?\]` stopped at the FIRST `]`, so an entry
-  // containing one (`"def:family[0]"`) left the rest of the array in
-  // place — and a stray LP hint inside it then read as evidence about
-  // this block. `stripArrayField` scans to the matching bracket.
-  const tsStripped = stripArrayField(stripArrayField(ts, "uses"), "cites").replace(
-    /\binterprets\s*:\s*"[^"]*"/g,
-    "",
-  );
+  // Filter: only blocks whose ts mentions LP/SDP/operator-selection in a
+  // field that describes THIS block. Every reference field points at a
+  // DIFFERENT one — a block that `uses:` an LP bound consumes a result, it
+  // does not compute duals — so an LP token inside one says nothing about
+  // the witness this block must carry.
+  //
+  // Two bugs have come from getting the strip wrong, and both read a
+  // reference as evidence:
+  //
+  //  - a non-greedy `[\s\S]*?\]` stopped at the FIRST `]`, so an entry
+  //    containing one (`"def:family[0]"`) left the rest of the array in
+  //    place. `stripArrayField` scans to the matching bracket instead.
+  //  - the list itself was `uses` + `cites` + `interprets`, which is only
+  //    three of the schema's reference fields. `examples`, `proofs`,
+  //    `defines`, `requires` and `mathlibLinks` all point elsewhere too,
+  //    and all leaked.
+  //
+  // The list below is the complete set; adding a reference field to the
+  // schema means adding it here.
+  const tsStripped = stripReferenceFields(ts);
   if (!LP_DUAL_HINT_RE.test(tsStripped)) {
     return { result: "pass", hits: [] };
   }

--- a/scripts/tests/qa-checkers-lp-dual.test.ts
+++ b/scripts/tests/qa-checkers-lp-dual.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { checkComputeLpDualPresent } from "../../content/pipeline/qa-checkers-extended.ts";
+
+/**
+ * `compute-lp-dual-present` decides whether a block's OWN witness must carry
+ * LP/SDP dual fields. Getting that wrong in either direction is expensive: a
+ * false fire demands dual data from a block that never solved an LP, and a
+ * miss lets a solver ship without its certificate.
+ *
+ * The filter has always had two gates — an LP hint somewhere in the block, and
+ * LP evidence in `script` / `witness` / `label`. The first gate used to be a
+ * DENYLIST: strip `uses:`, `cites:` and `interprets:` from the source text and
+ * grep whatever remained. That reads every OTHER reference-bearing field —
+ * `examples`, `proofs`, `defines`, `requires`, `mathlibLinks` — as evidence
+ * about this block, when each of them points at a DIFFERENT one.
+ *
+ * These tests pin both directions, and the leak case is why the gate is now an
+ * allowlist over named fields.
+ */
+
+let root: string;
+let goodWitness: string;
+let barrenWitness: string;
+
+/** A witness carrying the full dual certificate. */
+const FULL = {
+  data: {
+    y0_star: 1,
+    y_star: [1, 2],
+    primal_obj: 3,
+    dual_obj: 3,
+    duality_gap: 0,
+    active_set: [0],
+  },
+};
+
+/** A witness from a solver that recorded no dual information. */
+const BARREN = { data: { value: 42 } };
+
+function blockTs(fields: string): string {
+  return `import { proposition } from "../../schema/builders";
+export default proposition({
+${fields}
+});
+`;
+}
+
+/** Write a block `.ts` into the fixture root and return its path. */
+function fixture(name: string, fields: string): string {
+  const p = join(root, `${name}.ts`);
+  writeFileSync(p, blockTs(fields));
+  return p;
+}
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), "lpdual-"));
+  mkdirSync(join(root, "w"), { recursive: true });
+  goodWitness = join(root, "w", "full.witness.json");
+  barrenWitness = join(root, "w", "barren.witness.json");
+  writeFileSync(goodWitness, JSON.stringify(FULL));
+  writeFileSync(barrenWitness, JSON.stringify(BARREN));
+});
+
+afterAll(() => {
+  if (root) rmSync(root, { recursive: true, force: true });
+});
+
+describe("compute-lp-dual-present — fires when it should", () => {
+  test("flags a block whose own LP script ships a witness with no dual fields", () => {
+    const p = fixture(
+      "solver",
+      `  label: "prop:operator-selection-lp-bound",
+  title: "An lp-duality bound",
+  computation: { script: "computations/solve_operator_selection_lp.py", witness: "${barrenWitness}" },`,
+    );
+    const r = checkComputeLpDualPresent(p);
+    expect(r.result).toBe("fail");
+  });
+
+  test("passes the same block once the witness carries the certificate", () => {
+    const p = fixture(
+      "solver-ok",
+      `  label: "prop:operator-selection-lp-bound",
+  title: "An lp-duality bound",
+  computation: { script: "computations/solve_operator_selection_lp.py", witness: "${goodWitness}" },`,
+    );
+    expect(checkComputeLpDualPresent(p).result).toBe("pass");
+  });
+});
+
+describe("compute-lp-dual-present — does not fire on OTHER blocks' references", () => {
+  // The gate that these pin: an LP token inside a field that points at a
+  // different block says nothing about what THIS block computes.
+  const cases: Array<[string, string]> = [
+    ["uses", `  uses: ["prop:lp-duality-bound"],`],
+    ["cites", `  cites: ["prop:lp-duality-bound"],`],
+    ["interprets", `  interprets: "prop:lp-duality-bound",`],
+    // Not covered by the old denylist — the leak this change closes.
+    ["examples", `  examples: ["ex:shadow-price-table"],`],
+    ["proofs", `  proofs: ["proof:primal-dual-gap"],`],
+    ["defines", `  defines: ["def:lp-dual-witness"],`],
+  ];
+
+  for (const [field, line] of cases) {
+    test(`an LP token in \`${field}\` is not evidence about this block`, () => {
+      const p = fixture(
+        `ref-${field}`,
+        `  label: "prop:some-lp-consuming-result",
+  title: "A result that consumes an LP bound",
+${line}
+  computation: { script: "computations/solve_lp_thing.py", witness: "${barrenWitness}" },`,
+      );
+      expect(checkComputeLpDualPresent(p).result).toBe("pass");
+    });
+  }
+});
+
+describe("compute-lp-dual-present — gating", () => {
+  test("n/a without a ts path", () => {
+    expect(checkComputeLpDualPresent(undefined).result).toBe("n/a");
+  });
+
+  test("passes a block with no witness at all", () => {
+    const p = fixture(
+      "no-witness",
+      `  label: "prop:lp-duality-discussion",
+  title: "About lp-duality",`,
+    );
+    expect(checkComputeLpDualPresent(p).result).toBe("pass");
+  });
+
+  test("passes when the LP hint is only theoretical context, not the computation", () => {
+    // Gate two: tags describe what a block is ABOUT; the script and witness
+    // names say what it computed.
+    const p = fixture(
+      "context-only",
+      `  label: "prop:mass-gap-estimate",
+  title: "A primal-dual discussion",
+  tags: ["lp-duality"],
+  computation: { script: "computations/mass_gap.py", witness: "${barrenWitness}" },`,
+    );
+    expect(checkComputeLpDualPresent(p).result).toBe("pass");
+  });
+});


### PR DESCRIPTION
Found while looking at bean `folio-assistant-fsl7` bullet 1. The bullet asks for
a refactor; underneath it was a live defect, which is what this PR fixes.

## The bug

`compute-lp-dual-present` decides whether a block's **own** witness must carry
LP/SDP dual fields. Gate one stripped `uses`, `cites` and `interprets` from the
`.ts` source and grepped whatever remained.

The schema has **nine** reference fields, not three. `examples`, `proofs`,
`defines`, `requires`, `mathlibLinks` and `blocks` all hold labels or paths
pointing at *other* blocks — a block that `examples:` an LP table is pointing
elsewhere, not solving an LP — and an LP token in any of them read as evidence
about this block.

Demonstrated, not inferred: fixtures with the token in `examples`, `proofs` and
`defines` each produce a spurious `fail` against the old code.

## The fix

The list is complete and named:

```ts
const REFERENCE_ARRAY_FIELDS = [
  "uses", "cites", "examples", "proofs",
  "defines", "requires", "mathlibLinks", "blocks",
] as const;
const REFERENCE_SCALAR_FIELDS = ["interprets", "see"] as const;
```

with `stripReferenceFields` beside it and a comment tying it to
`schemas/types.ts`, so adding a reference field to the schema means adding it
here. The existing `stripArrayField` bracket-matching is unchanged — that part
was already correct.

## Evidence

`scripts/tests/qa-checkers-lp-dual.test.ts`, 11 tests, pinning both directions:

- **fires** — a real LP solver whose witness carries no dual certificate still
  fails, and passes once the certificate is there
- **stays quiet** — one test per reference field, six in all
- **gating** — no ts path, no witness, and theoretical-context-only (an
  `lp-duality` tag with a non-LP script) all behave as before

Three of the eleven fail against the old code; all eleven pass after.

Verified inert on real content: the criterion was run over all **3523 blocks**
of the `qou` folio before and after — identical output, zero diff. Worth being
plain that the corpus is a weak signal on its own, since every block passes this
criterion today; the fixtures carry the evidence.

Full suite: 522 pass, 35 skip, 0 fail.

## What this deliberately does not do

`fsl7`'s actual subject — repointing the scanner at the module loader — is still
undone, and the bean stays `todo`. The two ways forward are not equivalent, so I
did not pick one under cover of a bug fix:

- a **true allowlist** (read `label`/`title`/`tags`/`script`/`witness`) is
  cleaner and immune to a new reference field, but **narrows** the gate — a
  block whose only LP token lives in an `authorNotes` body would stop being
  checked;
- a **sync loader**, which the bean already names, still does not exist.

The complete denylist is the honest middle: same behaviour as before except for
the bug, with the remaining failure mode ("someone added a schema field and
forgot this list") addressed by the comment.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsEwLaLqBdu1cNtjCqqc94)_