### PR TITLE
Three checks reported pass for evidence they could not read

### DIFF
--- a/.beans/folio-assistant-ayf6--checkers-report-pass-when-the-evidence-they-need-i.md
+++ b/.beans/folio-assistant-ayf6--checkers-report-pass-when-the-evidence-they-need-i.md
@@ -1,0 +1,67 @@
+---
+# folio-assistant-ayf6
+title: Checkers report pass when the evidence they need is missing or corrupt
+status: completed
+type: bug
+priority: normal
+created_at: 2026-08-08T15:51:47Z
+updated_at: 2026-08-08T15:54:21Z
+---
+
+Continuing the sweep from PRs 74-79 for checks that report clean because they never looked.
+
+Two checkers in qa-checkers-extended.ts answer 'pass' when the artefact they must inspect is absent or unreadable. That is not a vacuous truth about the block, it is an unanswered question reported as a satisfied one:
+
+- checkCanonicalScriptNotDeprecated: the block declares script: '<path>'. If that path does not exist on disk the checker returns pass, asserting the script is not deprecated about a script that is not there. Also returns pass when the .ts manifest itself is unreadable.
+- checkComputeLpDualPresent: returns pass when the witness JSON named by the block does not exist, and again inside catch when the witness exists but does not parse. A corrupt witness file currently makes the criterion assert success.
+
+The discriminator used: is the missing thing the SUBJECT of the criterion (no script declared -> vacuously satisfied, pass is right) or the EVIDENCE needed to judge (declared script missing -> unknown, must be n/a). Only the evidence cases are being changed.
+
+Verified safe: nothing in the tree gates on result === 'pass' except q-usage-audit.ts:380, which concerns a human reviewer's decisive verdict and is unrelated. Gates fail on fail/warn, not on n/a.
+
+
+## Summary of Changes
+
+Three `pass` results became `n/a`, all of them cases where the checker could
+not read the artefact its answer depends on:
+
+- `checkCanonicalScriptNotDeprecated` — declared script absent from disk, and
+  no `.ts` manifest at all.
+- `checkComputeLpDualPresent` — witness JSON missing, and (the sharpest one)
+  witness present but unparseable, which used to return `pass` from inside the
+  `catch`.
+
+Each carries a note naming the file, so the sidecar says which artefact was
+unreadable rather than just recording `n/a`.
+
+### What was deliberately left alone
+
+The vacuous cases still pass, and are now pinned by tests in both directions:
+
+- a block declaring NO script cannot have a deprecated one;
+- a block that is not an LP computation is genuinely outside the LP criterion.
+
+Collapsing those into `n/a` would hollow the sweep out from the opposite side —
+every ordinary block would report "not assessed". The distinction the whole fix
+turns on is subject-absent (vacuously satisfied) versus evidence-absent
+(unanswered).
+
+### Verified
+
+Nothing in the tree gates on `result === "pass"` except `q-usage-audit.ts:380`,
+which concerns a human reviewer's decisive verdict — unrelated. Gates fail on
+`fail`/`warn`, so `n/a` costs no build.
+
+9 tests, and all four `n/a` cases were watched failing against the old code
+while the five vacuous/positive controls held in both versions.
+
+### One correction to the test, worth recording
+
+The first draft used relative script/witness paths and a `process.chdir` into a
+temp repo. That exercised nothing: `qa-checkers-extended` captures
+`REPO_ROOT = findContentRepoRoot()` at MODULE LOAD, so the chdir changed
+nothing and every relative fixture path resolved against the real repository —
+where it did not exist, making every case look like "missing evidence"
+regardless of setup. Two tests passed for the wrong reason and two failed
+confusingly. Fixtures now use absolute paths, which `resolve()` returns
+unchanged.

--- a/content/pipeline/qa-checkers-extended.ts
+++ b/content/pipeline/qa-checkers-extended.ts
@@ -700,12 +700,30 @@ export function checkComputeLpDualPresent(
   const absPath = witness.startsWith("/")
     ? witness
     : resolve(REPO_ROOT, witness);
-  if (!existsSync(absPath)) return { result: "pass", hits: [] };
+  // Past this point the block IS an LP computation, so the witness is the
+  // evidence the criterion turns on. Missing or unparseable, the answer is
+  // unknown — `pass` for a corrupt witness is the criterion asserting a
+  // result it could not read. (A missing witness is separately a `fail`
+  // under `compute-witness-exists`, so the finding is not lost here.)
+  if (!existsSync(absPath)) {
+    return {
+      result: "n/a",
+      hits: [],
+      notes: `witness ${witness} not found — LP dual fields not checked`,
+    };
+  }
   let body: Record<string, unknown> = {};
   try {
     body = JSON.parse(readFileSync(absPath, "utf-8"));
-  } catch {
-    return { result: "pass", hits: [] };
+  } catch (e) {
+    return {
+      result: "n/a",
+      hits: [],
+      notes:
+        `witness ${witness} does not parse as JSON (${
+          e instanceof Error ? e.message.slice(0, 80) : "unknown"
+        }) — LP dual fields not checked`,
+    };
   }
   // LP fields may live at the top level OR nested anywhere reachable
   // by a shallow walk (the conventional layout for WitnessBuilder
@@ -988,12 +1006,24 @@ export function checkCanonicalScriptNotDeprecated(
   tsPath: string | undefined,
 ): CheckerResult {
   const ts = readMaybe(tsPath);
-  if (!ts) return { result: "pass", hits: [] };
+  // No manifest to read: nothing was examined, so nothing passed. Every
+  // other checker in this file spells this `n/a`.
+  if (!ts) return { result: "n/a", hits: [] };
   const scriptMatch = ts.match(/script:\s*["']([^"']+)["']/);
   if (!scriptMatch) return { result: "pass", hits: [] };
   const scriptRelPath = scriptMatch[1];
   const scriptAbsPath = resolve(REPO_ROOT, scriptRelPath);
-  if (!existsSync(scriptAbsPath)) return { result: "pass", hits: [] };
+  if (!existsSync(scriptAbsPath)) {
+    // The block NAMES a script and the file is not there. "Not
+    // deprecated" is then a claim about something unread — absence of
+    // the evidence, not evidence of absence. A block declaring no script
+    // at all is different, and still passes vacuously above.
+    return {
+      result: "n/a",
+      hits: [],
+      notes: `declared script ${scriptRelPath} not found — deprecation not checked`,
+    };
+  }
   const scriptSrc = readFileSync(scriptAbsPath, "utf-8");
   const hits: CheckerHit[] = [];
   // Check for script-level deprecation markers (first 10 lines or

--- a/scripts/tests/checker-missing-evidence.test.ts
+++ b/scripts/tests/checker-missing-evidence.test.ts
@@ -1,0 +1,128 @@
+/**
+ * A checker that cannot read its evidence has not verified anything, and
+ * must not say `pass`.
+ *
+ * Two in `qa-checkers-extended` did. `checkCanonicalScriptNotDeprecated`
+ * returned `pass` when the script a block NAMES is not on disk — a claim
+ * that the script is not deprecated, about a file nobody opened.
+ * `checkComputeLpDualPresent` returned `pass` when the witness JSON was
+ * missing, and again from inside its `catch`, so a **corrupt** witness
+ * made the criterion assert success.
+ *
+ * The line these draw: a missing SUBJECT is vacuously satisfied and
+ * still passes — a block that declares no script cannot have a
+ * deprecated one. A missing piece of EVIDENCE is an unanswered question
+ * and reads `n/a`. Both directions are pinned below, because collapsing
+ * the two the other way would make every unremarkable block `n/a` and
+ * hollow the sweep out from the opposite side.
+ */
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  checkCanonicalScriptNotDeprecated,
+  checkComputeLpDualPresent,
+} from "../../content/pipeline/qa-checkers-extended";
+
+let root: string;
+
+/**
+ * Fixtures use ABSOLUTE script/witness paths.
+ *
+ * `qa-checkers-extended` captures `REPO_ROOT = findContentRepoRoot()` at
+ * module load, so a `process.chdir` in a test changes nothing and a
+ * relative fixture path silently resolves against the real repository —
+ * where it does not exist, making every case look like "missing
+ * evidence" regardless of what the test set up. `resolve(root, abs)`
+ * returns `abs`, so absolute paths reach the real code path.
+ */
+function comp(name: string): string {
+  return join(root, "computations", name);
+}
+
+function tsFile(name: string, body: string): string {
+  const p = join(root, "content", "p", "ch", name);
+  writeFileSync(p, body);
+  return p;
+}
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), "evidence-"));
+  mkdirSync(join(root, "content", "p", "ch"), { recursive: true });
+  mkdirSync(join(root, "computations"), { recursive: true });
+});
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("checkCanonicalScriptNotDeprecated", () => {
+  test("n/a when the declared script is not on disk", () => {
+    const p = tsFile("missing.ts", 'export default theorem({ label: "thm:a", script: "'+comp("gone.py")+'" });\n');
+    const r = (checkCanonicalScriptNotDeprecated(p));
+    expect(r.result).toBe("n/a");
+    expect(r.notes).toContain("not found");
+  });
+
+  test("pass when the block declares NO script — vacuously satisfied", () => {
+    // The other direction. A block without a script cannot have a
+    // deprecated one; turning this into n/a would empty the criterion.
+    const p = tsFile("noscript.ts", 'export default theorem({ label: "thm:b" });\n');
+    expect((checkCanonicalScriptNotDeprecated(p)).result).toBe("pass");
+  });
+
+  test("n/a when there is no manifest to read at all", () => {
+    expect(checkCanonicalScriptNotDeprecated(undefined).result).toBe("n/a");
+    expect(checkCanonicalScriptNotDeprecated("/nonexistent/x.ts").result).toBe("n/a");
+  });
+
+  test("still FAILS on a script that is actually deprecated", () => {
+    // The criterion must keep working — the point is to stop reporting
+    // success without evidence, not to stop reporting.
+    writeFileSync(join(root, "computations", "old.py"), '"""DEPRECATED: superseded."""\n');
+    const p = tsFile("dep.ts", 'export default theorem({ label: "thm:c", script: "'+comp("old.py")+'" });\n');
+    const r = (checkCanonicalScriptNotDeprecated(p));
+    expect(r.result).toBe("fail");
+  });
+
+  test("passes on a live script", () => {
+    writeFileSync(join(root, "computations", "live.py"), '"""Computes a thing."""\n');
+    const p = tsFile("live.ts", 'export default theorem({ label: "thm:d", script: "'+comp("live.py")+'" });\n');
+    expect((checkCanonicalScriptNotDeprecated(p)).result).toBe("pass");
+  });
+});
+
+describe("checkComputeLpDualPresent", () => {
+  const LP_BLOCK = (witness: string) =>
+    `export default theorem({\n  label: "thm:lp-shadow-price",\n  computation: { script: "computations/lp_solve.py", witness: "${witness}" },\n});\n`;
+
+  test("n/a when the witness file is missing", () => {
+    const p = tsFile("lpmissing.ts", LP_BLOCK(comp("gone.json")));
+    const r = (checkComputeLpDualPresent(p));
+    expect(r.result).toBe("n/a");
+    expect(r.notes).toContain("not found");
+  });
+
+  test("n/a — not pass — when the witness does not parse", () => {
+    // The sharpest case: a CORRUPT witness used to assert success.
+    writeFileSync(join(root, "computations", "broken.json"), "{ not json at all ");
+    const p = tsFile("lpbroken.ts", LP_BLOCK(comp("broken.json")));
+    const r = (checkComputeLpDualPresent(p));
+    expect(r.result).toBe("n/a");
+    expect(r.notes).toContain("does not parse");
+  });
+
+  test("pass for a block that is not an LP computation at all", () => {
+    // Subject absent, not evidence — the criterion genuinely does not
+    // apply, and must not become n/a for every ordinary block.
+    writeFileSync(join(root, "computations", "plain.json"), JSON.stringify({ value: 1 }));
+    const p = tsFile("plain.ts",
+      'export default theorem({ label: "thm:plain", computation: { script: "'+comp("plain.py")+'", witness: "'+comp("plain.json")+'" } });\n');
+    expect((checkComputeLpDualPresent(p)).result).toBe("pass");
+  });
+
+  test("n/a when there is no manifest", () => {
+    expect(checkComputeLpDualPresent(undefined).result).toBe("n/a");
+  });
+});


### PR DESCRIPTION
Same sweep as #74–#79. A checker that cannot open the artefact its answer depends on has not verified anything, and must not say `pass`.

`checkCanonicalScriptNotDeprecated` returned `pass` when the script a block **names** is not on disk — asserting the script is not deprecated about a file nobody opened — and again when the `.ts` manifest itself could not be read.

`checkComputeLpDualPresent` returned `pass` when the witness JSON was missing, and again from inside its `catch`. That last one is the sharpest in the set: **a corrupt witness made the criterion assert success.**

All three now return `n/a` with a note naming the unreadable artefact, so the sidecar records *which* file was missing rather than a bare `n/a`.

## The line this draws

Subject absent is not the same as evidence absent, and both directions are pinned by tests:

| case | result |
|---|---|
| block declares **no** script — cannot have a deprecated one | `pass` (vacuous) |
| block is not an LP computation at all | `pass` (out of scope) |
| declared script or witness will not open | `n/a` (unanswered) |

Collapsing the first two into `n/a` would hollow the sweep out from the opposite side, with every ordinary block reporting "not assessed".

## Verified before changing the result

- Nothing in the tree gates on `result === "pass"` except `q-usage-audit.ts:380`, which concerns a human reviewer's decisive verdict — unrelated. Gates fail on `fail`/`warn`, so `n/a` costs no build.
- A missing witness is separately a **`fail`** under `compute-witness-exists`, so the finding moves to the criterion that owns it rather than disappearing.

## Testing

9 new tests. The four `n/a` cases were watched failing against the old code while the five vacuous/positive controls held in both versions.

**A correction to the test itself.** My first draft used relative script/witness paths with a `process.chdir` into a temp repo, and exercised nothing: `qa-checkers-extended` captures `REPO_ROOT = findContentRepoRoot()` at *module load*, so the chdir changed nothing and every relative fixture path resolved against the real repository — where it did not exist, making every case look like missing evidence regardless of setup. Two tests passed for the wrong reason. Fixtures use absolute paths now, which `resolve()` returns unchanged.

Rebased onto #80, which reworked the same LP function to strip all nine reference fields. The two changes are independent and both suites pass together: 529 → 540 pass, 0 fail; `tsc --noEmit` and `eslint .` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LL9F9XMXAvKZzjxxhMs2bQ)_