### PR TITLE
beans: the Lean cache reseed is declined, and the LP criterion stays as it is

### DIFF
--- a/.beans/folio-assistant-02kc--cache-carries-oleans-without-trace-siblings-lake-r.md
+++ b/.beans/folio-assistant-02kc--cache-carries-oleans-without-trace-siblings-lake-r.md
@@ -1,11 +1,11 @@
 ---
 # folio-assistant-02kc
 title: Cache carries oleans WITHOUT .trace siblings — lake rebuilds and evicts them
-status: in-progress
+status: scrapped
 type: bug
 priority: critical
 created_at: 2026-08-07T13:56:17Z
-updated_at: 2026-08-08T15:40:00Z
+updated_at: 2026-08-08T16:05:00Z
 ---
 
 Root cause of the cache never helping lake build. Lake decides staleness from .trace files; an olean with no trace is out-of-date, so lake rebuilds it and evicts. Measured: restore laid 7268 oleans with only 775 traces; a single-module 'lake build' ran 823 targets and left 772 oleans — every survivor had a trace (494 mathlib oleans / 494 traces, 0 of 200 sampled lacking one). The cache only ever worked for direct lean+LEAN_PATH calls, which is why the triviality probe succeeded while builds did not.
@@ -228,3 +228,32 @@ shim. `status` used to raise the gutted-cache alarm on it anyway; fixed in
 `folio-assistant-5d7z`, which had inherited that reading.
 
 Not resolving this bean — it is a sibling's, and the blocker stands.
+
+---
+
+## 2026-08-08 — SCRAPPED by owner decision: the defect is real and accepted
+
+Same ruling as `5d7z`, which this bean is the root cause of. Asked directly;
+the answer was **leave it**.
+
+Nothing above is retracted. Oleans without `.trace` siblings genuinely are
+invisible to Lake's staleness check, coverage genuinely is 0% on both families,
+and `lake build` genuinely does rebuild and evict. The diagnosis stands; what
+changed is that fixing it was weighed against what it buys and declined.
+
+It buys `lake build`. The paper is verified through `scripts/lean-verify.sh`,
+which calls `lean` with `LEAN_PATH` and never invokes `lake` — the split this
+bean itself predicted ("the cache only ever worked for direct lean+LEAN_PATH
+calls, which is why the triviality probe succeeded while builds did not"). That
+prediction is now the reason the fix is not needed: the working path is the one
+in use.
+
+Costs, for the record: widening the environment's network policy to four hosts,
+or hours of Actions time on a repo whose auto-triggers were disabled for
+billing.
+
+Marked `scrapped` rather than left `in-progress` specifically so it stops being
+re-tested. **Three sessions have now independently re-confirmed this blocker**
+— it is well established and needs no fourth. If `lake build` ever becomes
+load-bearing, reopen and follow
+`docs/guides/reseeding-the-lean-cache.md`.

--- a/.beans/folio-assistant-5d7z--reseed-lake-cacheqou-v4-24-0-it-carries-zero-of-th.md
+++ b/.beans/folio-assistant-5d7z--reseed-lake-cacheqou-v4-24-0-it-carries-zero-of-th.md
@@ -1,11 +1,11 @@
 ---
 # folio-assistant-5d7z
 title: Reseed lake-cache/qou-v4-24-0 — it carries ZERO of the paper's own oleans
-status: in-progress
+status: scrapped
 type: bug
 priority: high
 created_at: 2026-08-07T12:10:50Z
-updated_at: 2026-08-08T15:10:00Z
+updated_at: 2026-08-08T16:05:00Z
 ---
 
 The production cache branch has 7268 oleans, all dependencies, none QOU.*. Every restore still rebuilds the paper, and sibling .lean files cannot elaborate standalone. lake-cache.sh status now detects and reports this.
@@ -216,3 +216,37 @@ Two real findings survive, and neither is the one in the title:
 
 Whoever holds this bean should re-decide on (1) and (2). Retitling it would be
 their call, not mine.
+
+---
+
+## 2026-08-08 — SCRAPPED by owner decision: the reseed is not worth its cost
+
+Asked directly, with the corrected premise and the real costs on the table.
+The ruling: **leave it.** Recording the reasoning so this is not re-opened by
+inference.
+
+What the reseed would have bought, and what it would have cost:
+
+| | |
+|---|---|
+| buys | `lake build` works; `nimj`'s triviality probe reaches the 57% of blocks it currently cannot |
+| costs | either widening the environment's network policy, or hours of Actions time on a repo whose auto-triggers were disabled for billing (owner directive, 2026-06-30) |
+
+The decisive point is that **the cache already serves the path the paper is
+verified on**. `scripts/lean-verify.sh` calls `lean` with `LEAN_PATH` directly
+and never touches `lake`; four modules were type-checked that way in the
+session that closed this. What the reseed fixes is `lake build`, which nothing
+in the verification path uses.
+
+The two findings that survive the correction above — 945 own oleans against
+~1582 modules, and 0% trace coverage — are real and stay recorded. They are
+the reasons this WOULD be worth doing if `lake build` ever became load-bearing.
+It is not today.
+
+`docs/guides/reseeding-the-lean-cache.md` stays as the runbook for whoever
+does want it, and `lake-cache.sh status` still reports the trace shortfall
+rather than hiding it. Nothing was ripped out; the work was declined, not
+undone.
+
+Status `in-progress` → `scrapped`. Flipping a bean I did not open, on an
+explicit owner decision rather than my own reading of it.

--- a/.beans/folio-assistant-fsl7--repoint-remaining-hand-rolled-block-scanners-at-th.md
+++ b/.beans/folio-assistant-fsl7--repoint-remaining-hand-rolled-block-scanners-at-th.md
@@ -4,7 +4,7 @@ title: Repoint remaining hand-rolled block scanners at the module loader
 status: todo
 type: task
 created_at: 2026-08-08T13:25:41Z
-updated_at: 2026-08-08T15:55:00Z
+updated_at: 2026-08-08T16:05:00Z
 ---
 
 Follow-up to jwd9, which replaced the source-text scan with module imports in conjectural-propagation-audit and conditional-class-banner-audit and added write-verification to prune-transitive-deps.
@@ -63,3 +63,32 @@ schema field and forgot this list", which the comment addresses.
 Bullet 2 (`readBlockManifest`) is untouched and still fine as filed.
 
 Leaving this bean `todo` — its actual subject, the repointing, is undone.
+
+## 2026-08-08 — bullet 1 closed by owner decision; the bean stays open for the loader
+
+Put to the owner with the three options and their trade-offs. The ruling:
+**leave the LP criterion as it now stands.**
+
+So bullet 1 is closed — not by being repointed, but by the defect underneath it
+being fixed and the remaining refactor being judged not worth its risk:
+
+- the **true allowlist** was declined because it narrows the gate. Reading only
+  `label`/`title`/`tags`/`script`/`witness` would stop checking a block whose
+  only LP token lives in an `authorNotes` body. Trading a known-safe behaviour
+  for a silent miss mode is the wrong direction for a criterion whose job is to
+  demand evidence.
+- the **complete denylist** stands as the honest middle: identical behaviour to
+  before except for the bug, tested in both directions, and inert across all
+  3523 blocks of the `qou` folio.
+
+Its remaining failure mode is "someone adds a reference field to the schema and
+forgets `REFERENCE_ARRAY_FIELDS`". That is now a comment away from the schema it
+mirrors, and a test file named for the criterion.
+
+**The bean stays `todo`, and its subject is now only the sync loader** — bullet
+1's original ask. That is worth doing when someone is already in loader work, as
+it retires the text-surgery class across every synchronous checker rather than
+one criterion. It is not worth opening on its own account, and it is not
+blocking anything.
+
+Bullet 2 (`readBlockManifest`) unchanged and still fine as filed.

--- a/.beans/folio-assistant-nimj--nazrin-as-triviality-oracle-proof-not-machine-triv.md
+++ b/.beans/folio-assistant-nimj--nazrin-as-triviality-oracle-proof-not-machine-triv.md
@@ -1,11 +1,11 @@
 ---
 # folio-assistant-nimj
 title: Nazrin as triviality oracle (proof-not-machine-trivial)
-status: in-progress
+status: scrapped
 type: task
 priority: normal
 created_at: 2026-08-07T09:13:35Z
-updated_at: 2026-08-08T11:54:20Z
+updated_at: 2026-08-08T16:05:00Z
 ---
 
 
@@ -194,3 +194,39 @@ number will say which fix it needs.
 What changed is that the measurement will now be trustworthy when it runs.
 Before this it would have been taken with a five-rung ladder, a timeout counted
 as a loss, and any statement containing `:=` silently scored "not trivial".
+
+---
+
+## 2026-08-08 — SCRAPPED by owner decision, downstream of the reseed being declined
+
+Every remaining item here needs the `5d7z` reseed, and that was put to the
+owner with its costs and declined. So the false-positive rate stays
+**unmeasured by choice, not by blocker** — which is a different and more
+honest state than "blocked", and the reason this is being closed rather than
+left open to be re-tested a fourth time.
+
+The bean's own standard was right and is being held to: *"shipping the scaffold
+is not the same as adopting the idea."* The idea is not adopted.
+
+**Nothing is ripped out**, because nothing costs anything to keep:
+
+- `proof-not-machine-trivial` stays shipped at `minor`, warn-only, and inert by
+  construction — no cache means `n/a`, and the note says "not measured", never
+  "nothing trivial". It cannot produce a wrong answer; it can only decline to
+  produce one.
+- `lean-triviality-probe.ts` and its control test stay. The control is what
+  established the probe discriminates at all, and it runs on core Lean with no
+  cache, no Mathlib and no folio — so it keeps working regardless of this.
+- The three defects fixed along the way stay fixed, and one of them was never
+  about this bean: `topLevelCut` also repaired the QA **statement hash**, where
+  a statement containing `:=` hashed a truncated prefix and a changed statement
+  never invalidated its sidecar. That was a staleness check passing by finding
+  nothing, and it is fixed independently of anything decided here.
+
+So the ledger is: the criterion is real and safe, the probe is real and
+verified, one genuine bug in an unrelated system was caught, and the only thing
+not obtained is the tuning evidence — which needs the reseed nobody is buying.
+
+To reopen: land the reseed, re-run the probe over the full corpus, measure the
+FP rate at `TRIVIAL_STEP_THRESHOLD = 3`, then decide on severity. In that
+order, and not before.


### PR DESCRIPTION
Bean-only. Two owner decisions, recorded so they stop being re-derived — the
first blocker has now been independently re-confirmed by three sessions.

## Reseed declined — `5d7z`, `02kc`, `nimj` → `scrapped`

Put to the owner with the corrected premise and the real costs. Ruling: leave
it.

The decisive point is that **the cache already serves the path the paper is
verified on**. `scripts/lean-verify.sh` calls `lean` with `LEAN_PATH` and never
invokes `lake`; four modules were type-checked that way in the session that
closed this. What a reseed fixes is `lake build`, which nothing in the
verification path uses — and `02kc` predicted exactly this split itself ("the
cache only ever worked for direct lean+LEAN_PATH calls"). That prediction is now
the reason the fix isn't needed.

Against that: widening the environment's network policy to four hosts, or hours
of Actions time on a repo whose auto-triggers were disabled for billing in June.

**Nothing is retracted and nothing is ripped out.** The trace-coverage defect is
real — it is now *accepted* rather than open. `docs/guides/reseeding-the-lean-cache.md`
stays as the runbook, and `lake-cache.sh status` still reports the shortfall
rather than hiding it. `nimj`'s `proof-not-machine-trivial` stays shipped at
`minor`, warn-only, inert by construction — it can decline to answer, not answer
wrongly — and its probe plus the control test that proved the probe
discriminates both keep working on core Lean with no cache at all.

Worth separating out: one fix from that arc was never about `nimj`. `topLevelCut`
also repaired the QA **statement hash**, where a statement containing `:=` hashed
a truncated prefix, so a changed statement never invalidated its sidecar. A
staleness check passing by finding nothing. Fixed, and unaffected by any of this.

`nimj`'s false-positive rate is now unmeasured **by choice**, not by blocker —
a different and more honest state.

Marked `scrapped` rather than left `in-progress` specifically so they stop being
re-tested.

## LP criterion stays — `fsl7` bullet 1 closed, bean stays `todo`

The true allowlist was declined because it **narrows** the gate: a block whose
only LP token lives in an `authorNotes` body would stop being checked at all.
Trading known-safe behaviour for a silent miss mode is the wrong direction for a
criterion whose job is to demand evidence.

The complete denylist from #80 is the honest middle — identical behaviour except
for the bug, tested both directions, inert across all 3523 blocks of the `qou`
folio. Its remaining failure mode ("someone adds a schema reference field and
forgets the list") is a comment away from the schema it mirrors.

The bean's remaining subject is the **sync loader**, worth doing when someone is
already in loader work since it retires the text-surgery class across every
synchronous checker. Not worth opening on its own, and not blocking anything.

## Scope

No code. Suite unchanged: 531 pass, 35 skip, 0 fail.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsEwLaLqBdu1cNtjCqqc94)_