### PR TITLE
Source ledger: triage an upload before importing it, and show the author why

### DIFF
--- a/content/pipeline/bib-qa.ts
+++ b/content/pipeline/bib-qa.ts
@@ -381,15 +381,26 @@ function loadVerifications(): Map<string, VerificationEntry> {
   const path = join(CONTENT_DIR, "bib-qa-verifications.json");
   if (!existsSync(path)) return new Map();
   const raw = JSON.parse(readFileSync(path, "utf-8"));
-  const arr: VerificationEntry[] = raw.entries ?? [];
-  return new Map(arr.map((e) => [e.id, e]));
+  const arr: (VerificationEntry & { id: string | null })[] = raw.entries ?? [];
+  // Since the source-ledger migration (2026-08-08) the file also carries rows
+  // for uploaded documents that back no reference yet; those have `id: null`
+  // and would otherwise collide on a single null key.  Bib QA is per-
+  // reference, so they are not its business.
+  return new Map(
+    arr.filter((e): e is VerificationEntry => typeof e.id === "string").map((e) => [e.id, e]),
+  );
 }
 
 function localPdfPath(verif?: VerificationEntry, refId?: string): string | null {
-  // Prefer the explicit path in verifications JSON.
-  if (verif?.local_pdf) {
-    const abs = join(REPO_ROOT, verif.local_pdf);
-    if (existsSync(abs)) return verif.local_pdf;
+  // Prefer the explicit path recorded in the ledger.  `source` is the current
+  // shape; `local_pdf` is the deprecated pre-migration field.
+  const recorded =
+    (verif as { source?: { kind: string; file?: string } } | undefined)?.source?.kind === "upload"
+      ? (verif as unknown as { source: { file: string } }).source.file
+      : verif?.local_pdf;
+  if (recorded) {
+    const abs = join(REPO_ROOT, recorded);
+    if (existsSync(abs)) return recorded;
   }
   // Fallback: glob uploads/ for any file matching the ref id.
   if (refId) {

--- a/content/pipeline/source-ledger-index.ts
+++ b/content/pipeline/source-ledger-index.ts
@@ -1,0 +1,284 @@
+#!/usr/bin/env bun
+/**
+ * Source-ledger indexer — migrate `bib-qa-verifications.json` to the
+ * `source-ledger/v1` shape and seed a row for every document in `uploads/`.
+ *
+ * ## What this does
+ *
+ * 1. **Migrate.**  Each legacy `VerificationEntry` becomes a `LedgerEntry`:
+ *    its `local_pdf` becomes `source: { kind: "upload", file }`; an entry
+ *    with no local copy becomes `source: { kind: "external", url }` taken
+ *    from the reference's URL/DOI.  Nothing is lost — `local_pdf` is kept
+ *    for one release as a deprecated read-path.
+ *
+ * 2. **Seed.**  Every file under `uploads/` that has no row gets one, at
+ *    `status: "unreviewed"`.  Where the filename is an arXiv id that
+ *    `references.ts` already cites, `id` is filled in; otherwise `id` is
+ *    `null` and the relevance triage resolves it.
+ *
+ * The indexer deliberately does **not** parse PDFs.  Identifying an
+ * unlabelled document is a judgement call, and the relevance triage reads
+ * the document anyway — see `.claude/skills/local/paper-relevance-triage.md`.
+ * An optional `--matches <file>` accepts a precomputed
+ * `{ "<upload-basename>": ["<refId>", …] }` map (see
+ * `scripts/extract-upload-titles.py`) to seed `id` for documents whose
+ * filename carries no arXiv id.
+ *
+ * ## One source of truth
+ *
+ * This script writes judgements and joins only.  It never copies a title,
+ * author, year, or DOI out of `references.ts` — see the schema header in
+ * `schemas/bib-verification.ts`.
+ *
+ * ## Usage
+ *
+ *   bun run content/pipeline/source-ledger-index.ts            # report only
+ *   bun run content/pipeline/source-ledger-index.ts --write
+ *   bun run content/pipeline/source-ledger-index.ts --write --matches m.json
+ *
+ * @module content/pipeline/source-ledger-index
+ */
+
+import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { basename, join } from "node:path";
+import type { LedgerEntry, SourceLedger, SourceRef } from "../../schemas/bib-verification";
+
+const REPO_ROOT = process.env.FOLIO_REPO_ROOT ?? process.cwd();
+const LEDGER_PATH = join(REPO_ROOT, "content", "bib-qa-verifications.json");
+const REFERENCES_PATH = join(REPO_ROOT, "content", "schema", "references.ts");
+const UPLOADS_DIR = join(REPO_ROOT, "uploads");
+
+const SCHEMA_ID = "source-ledger/v1";
+
+/** Documents we index.  Anything else in `uploads/` is scaffolding. */
+const SOURCE_EXTENSIONS = [".pdf", ".txt", ".tex", ".djvu", ".epub"];
+
+// ── references.ts probing ────────────────────────────────────────────────
+//
+// `references.ts` is TypeScript, not data, so it is not imported here — a
+// regex read keeps the indexer free of a bun/tsc round-trip and of any
+// chance of executing paper source.  Only two facts are read: which ids
+// exist, and which arXiv ids they mention.
+
+interface RefIndex {
+  /** Every `ref()` id. */
+  ids: Set<string>;
+  /** arXiv id (lower-case, no version) → reference id. */
+  byArxiv: Map<string, string>;
+  /** reference id → its URL, for the `external` source fallback. */
+  urls: Map<string, string>;
+}
+
+function readReferences(): RefIndex {
+  const src = readFileSync(REFERENCES_PATH, "utf-8");
+  const ids = new Set<string>();
+  const byArxiv = new Map<string, string>();
+  const urls = new Map<string, string>();
+
+  // Each entry is a `ref({ … })` call; split on the builder so an arXiv id
+  // is attributed to the entry it actually appears in.
+  for (const m of src.matchAll(/ref\(\{(.*?)\n\s*\}\)/gs)) {
+    const body = m[1];
+    const idM = body.match(/\bid:\s*"([^"]+)"/);
+    if (!idM) continue;
+    const id = idM[1];
+    ids.add(id);
+
+    const urlM = body.match(/\bURL:\s*"([^"]+)"/);
+    if (urlM) urls.set(id, urlM[1]);
+    else {
+      const doiM = body.match(/\bDOI:\s*"([^"]+)"/);
+      if (doiM) urls.set(id, `https://doi.org/${doiM[1]}`);
+    }
+
+    for (const a of body.matchAll(
+      /(?:arxiv\.org\/abs\/|arXiv:\s*)([a-z-]+\/\d{7}|\d{4}\.\d{4,5})/gi,
+    )) {
+      byArxiv.set(a[1].toLowerCase(), id);
+    }
+  }
+  return { ids, byArxiv, urls };
+}
+
+/** The arXiv id a filename encodes, if any.
+ *
+ * Handles both eras and the browser's duplicate suffix:
+ *   `2411.03801v1.pdf`   → `2411.03801`   (new style, complete)
+ *   `0409565v2.pdf`      → `0409565`      (old style, archive prefix absent)
+ *   `0401068v1 (1).pdf`  → `0401068`
+ *
+ * Old-style ids arrive without their archive prefix (`math/`, `hep-th/`),
+ * so they are matched by suffix against the reference index. */
+export function arxivIdFromFilename(file: string): string | null {
+  const stem = basename(file)
+    .replace(/\.[^.]+$/, "")
+    .replace(/\s*\(\d+\)$/, "")
+    .trim();
+  const modern = stem.match(/^(\d{4}\.\d{4,5})(v\d+)?$/);
+  if (modern) return modern[1];
+  const legacy = stem.match(/^(\d{7})(v\d+)?$/);
+  if (legacy) return legacy[1];
+  return null;
+}
+
+function lookupArxiv(arxiv: string, refs: RefIndex): string | null {
+  const direct = refs.byArxiv.get(arxiv);
+  if (direct) return direct;
+  // Old-style: the filename lacks the archive prefix, so match on suffix.
+  if (!arxiv.includes(".")) {
+    for (const [key, id] of refs.byArxiv) {
+      if (key.endsWith(`/${arxiv}`)) return id;
+    }
+  }
+  return null;
+}
+
+// ── migration ────────────────────────────────────────────────────────────
+
+/** Legacy shape, pre-2026-08-08. */
+interface LegacyEntry {
+  id: string;
+  status: string;
+  local_pdf?: string | null;
+  [k: string]: unknown;
+}
+
+function migrateEntry(e: LegacyEntry, refs: RefIndex): LedgerEntry {
+  const { local_pdf, ...rest } = e;
+  let source: SourceRef;
+  if (local_pdf) {
+    source = { kind: "upload", file: local_pdf };
+  } else {
+    source = { kind: "external", url: refs.urls.get(e.id) ?? "" };
+  }
+  return {
+    ...(rest as Omit<LedgerEntry, "source" | "local_pdf">),
+    source,
+    // Retained one release for pre-migration readers; new writers omit it.
+    ...(local_pdf ? { local_pdf } : {}),
+  };
+}
+
+// ── main ─────────────────────────────────────────────────────────────────
+
+function main(): void {
+  const write = process.argv.includes("--write");
+  const matchesIdx = process.argv.indexOf("--matches");
+  let seeded: Record<string, string[]> = {};
+  if (matchesIdx !== -1) {
+    const p = process.argv[matchesIdx + 1];
+    if (!p || !existsSync(p)) {
+      console.error(`--matches: file not found: ${p}`);
+      process.exit(2);
+    }
+    seeded = JSON.parse(readFileSync(p, "utf-8"));
+  }
+
+  const refs = readReferences();
+  const raw = JSON.parse(readFileSync(LEDGER_PATH, "utf-8"));
+  const legacy: LegacyEntry[] = raw.entries ?? [];
+
+  const entries: LedgerEntry[] = legacy.map((e) =>
+    // Idempotent: a row already carrying `source` is left alone.
+    (e as unknown as LedgerEntry).source
+      ? (e as unknown as LedgerEntry)
+      : migrateEntry(e, refs),
+  );
+
+  const haveFile = new Set(
+    entries
+      .map((e) => (e.source?.kind === "upload" ? e.source.file : null))
+      .filter((f): f is string => !!f)
+      .map((f) => basename(f)),
+  );
+
+  // Seed a row for every uploaded document that has none.
+  let addedWithRef = 0;
+  let addedOrphan = 0;
+  const unresolvedRefIds: string[] = [];
+
+  if (existsSync(UPLOADS_DIR)) {
+    for (const f of readdirSync(UPLOADS_DIR).sort()) {
+      if (!SOURCE_EXTENSIONS.some((ext) => f.toLowerCase().endsWith(ext))) continue;
+      if (haveFile.has(f)) continue;
+
+      const arxiv = arxivIdFromFilename(f);
+      let id: string | null = arxiv ? lookupArxiv(arxiv, refs) : null;
+
+      if (!id) {
+        // Fall back to a precomputed title match, when supplied.  A match
+        // naming an id that no longer exists is dropped, not trusted.
+        const cands = (seeded[f] ?? []).filter((c) => refs.ids.has(c));
+        const dropped = (seeded[f] ?? []).filter((c) => !refs.ids.has(c));
+        unresolvedRefIds.push(...dropped);
+        // Only an unambiguous single match seeds the join; anything else is
+        // left for the triage to adjudicate.
+        if (cands.length === 1) id = cands[0];
+      }
+
+      entries.push({
+        source: { kind: "upload", file: `uploads/${f}` },
+        id,
+        status: "unreviewed",
+      });
+      if (id) addedWithRef++;
+      else addedOrphan++;
+    }
+  }
+
+  const ledger: SourceLedger = {
+    _schema: SCHEMA_ID,
+    _authoritative_for:
+      "Source document <-> reference join, source-verification status, and " +
+      "relevance triage. Bibliographic metadata lives ONLY in " +
+      "content/schema/references.ts; this file stores no title, author, " +
+      "year, or DOI.",
+    entries,
+  };
+
+  const uploads = entries.filter((e) => e.source?.kind === "upload");
+  const triaged = entries.filter((e) => e.relevance);
+
+  // An `upload` row naming a file that is not in the repo records a source
+  // examination nobody can reproduce.  Surface it rather than let the join
+  // dangle: the reading may well have happened, but the evidence did not
+  // survive the session that claimed it.
+  const dangling = uploads.filter(
+    (e) => e.source.kind === "upload" && !existsSync(join(REPO_ROOT, e.source.file)),
+  );
+  console.log(`references.ts entries      : ${refs.ids.size}`);
+  console.log(`ledger rows                : ${entries.length}`);
+  console.log(`  migrated from legacy     : ${legacy.length}`);
+  console.log(`  seeded (ref resolved)    : ${addedWithRef}`);
+  console.log(`  seeded (orphan, id null) : ${addedOrphan}`);
+  console.log(`uploads with a row         : ${uploads.length}`);
+  console.log(`  file missing from repo   : ${dangling.length}`);
+  console.log(`rows with a relevance pass : ${triaged.length}`);
+  console.log(`rows still to triage       : ${entries.length - triaged.length}`);
+  if (dangling.length) {
+    console.log(
+      `\n${dangling.length} row(s) cite a local file that is not in the repo. The examination ` +
+        `they record cannot be reproduced; re-fetch the source or downgrade the status:`,
+    );
+    for (const e of dangling.slice(0, 10)) {
+      const f = e.source.kind === "upload" ? e.source.file : "";
+      console.log(`  ${(e.id ?? "(no ref)").padEnd(28)} ${e.status.padEnd(15)} ${f}`);
+    }
+    if (dangling.length > 10) console.log(`  … and ${dangling.length - 10} more`);
+  }
+  if (unresolvedRefIds.length) {
+    console.log(
+      `\n--matches named ${unresolvedRefIds.length} id(s) absent from references.ts (dropped): ` +
+        `${[...new Set(unresolvedRefIds)].slice(0, 8).join(", ")}`,
+    );
+  }
+
+  if (write) {
+    writeFileSync(LEDGER_PATH, `${JSON.stringify(ledger, null, 2)}\n`);
+    console.log(`\nwrote ${LEDGER_PATH}`);
+  } else {
+    console.log("\n(dry run — pass --write to persist)");
+  }
+}
+
+main();

--- a/content/pipeline/source-ledger-merge.ts
+++ b/content/pipeline/source-ledger-merge.ts
@@ -1,0 +1,215 @@
+#!/usr/bin/env bun
+/**
+ * Merge relevance-triage findings into the source ledger, and queue the
+ * accepted actions as beans.
+ *
+ * Triage parallelises over documents but the ledger is one file, so agents
+ * write their findings to their own JSON and this merges them in a single
+ * pass.  See `.claude/skills/local/paper-relevance-triage.md`.
+ *
+ * ## What a findings file looks like
+ *
+ * A JSON array whose elements carry the assessment plus the two facts the
+ * triage establishes about identity:
+ *
+ * ```jsonc
+ * [{
+ *   "file": "uploads/0409565v2.pdf",
+ *   "id": "leitnerpawloski2004",        // or null when still unidentified
+ *   "citation_status": "entry-uncited",  // advisory; not stored
+ *   "relevance": { … RelevanceAssessment, minus assessed_by/assessed_at … }
+ * }]
+ * ```
+ *
+ * `identified` (title/authors/year), if present, is **read and discarded**.
+ * Bibliographic metadata belongs in `content/schema/references.ts`; the
+ * ledger stores judgements and joins only.  The merge reports which
+ * documents need a `ref()` entry so that metadata can be added there.
+ *
+ * ## Beans
+ *
+ * With `--create-beans`, every proposed action other than `no-action` that
+ * does not already carry a bean id becomes one, and the id is written back
+ * into the action.  Re-running is safe: an action with a `bean` is skipped.
+ *
+ * ## Usage
+ *
+ *   bun run content/pipeline/source-ledger-merge.ts findings/*.json
+ *   bun run content/pipeline/source-ledger-merge.ts findings/*.json --write
+ *   bun run content/pipeline/source-ledger-merge.ts findings/*.json --write --create-beans
+ *
+ * @module content/pipeline/source-ledger-merge
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type {
+  LedgerEntry,
+  ProposedAction,
+  RelevanceAssessment,
+  SourceLedger,
+  Verifier,
+} from "../../schemas/bib-verification";
+
+const REPO_ROOT = process.env.FOLIO_REPO_ROOT ?? process.cwd();
+const LEDGER_PATH = join(REPO_ROOT, "content", "bib-qa-verifications.json");
+
+/** Model identifier recorded as the assessing agent. */
+const AGENT_MODEL = process.env.FOLIO_AGENT_MODEL ?? "unknown-agent";
+
+interface Finding {
+  file: string;
+  id?: string | null;
+  citation_status?: string;
+  relevance: Partial<RelevanceAssessment> & { verdict: RelevanceAssessment["verdict"] };
+  /** Read and discarded — see the module header. */
+  identified?: unknown;
+}
+
+/** Create a bean and return its id, or null if the tracker is unavailable. */
+function createBean(title: string): string | null {
+  try {
+    const out = execFileSync("beans", ["create", title, "--type", "task"], {
+      cwd: REPO_ROOT,
+      encoding: "utf-8",
+    });
+    // `beans create` prints e.g. "Created qou-ab12 qou-ab12--slug.md"
+    const m = out.match(/Created\s+(\S+)/);
+    return m ? m[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+/** A work item's title: the action and its target, never "read paper X". */
+function beanTitle(a: ProposedAction, refId: string | null, file: string): string {
+  const subject = refId ? `[${refId}]` : file.replace(/^uploads\//, "");
+  const target = a.target ? ` at ${a.target}` : "";
+  switch (a.action) {
+    case "add-reference":
+      return `Add reference for ${subject} — ${a.rationale}`;
+    case "cite-in-block":
+      return `Cite ${subject}${target} — ${a.rationale}`;
+    case "aid-proof":
+      return `Apply ${subject}${target} — ${a.rationale}`;
+    case "new-remark":
+      return `Remark interpreting ${subject}${target} — ${a.rationale}`;
+    case "new-block":
+      return `Import block from ${subject}${target} — ${a.rationale}`;
+    case "compute-check":
+      return `Cross-check ${subject}${target} — ${a.rationale}`;
+    default:
+      return `${a.action}: ${subject}${target}`;
+  }
+}
+
+function main(): void {
+  const args = process.argv.slice(2);
+  const write = args.includes("--write");
+  const doBeans = args.includes("--create-beans");
+  const files = args.filter((a) => !a.startsWith("--"));
+
+  if (files.length === 0) {
+    console.error("usage: source-ledger-merge.ts <findings.json…> [--write] [--create-beans]");
+    process.exit(2);
+  }
+
+  const ledger: SourceLedger = JSON.parse(readFileSync(LEDGER_PATH, "utf-8"));
+  const byFile = new Map<string, LedgerEntry>();
+  for (const e of ledger.entries) {
+    if (e.source?.kind === "upload") byFile.set(e.source.file, e);
+  }
+
+  const assessedBy: Verifier = { kind: "agent", model: AGENT_MODEL };
+  const now = new Date().toISOString();
+
+  let merged = 0;
+  let created = 0;
+  let beansMade = 0;
+  let idsResolved = 0;
+  const needRef: string[] = [];
+  const counts: Record<string, number> = {};
+  const missing: string[] = [];
+
+  for (const path of files) {
+    if (!existsSync(path)) {
+      missing.push(path);
+      continue;
+    }
+    const findings: Finding[] = JSON.parse(readFileSync(path, "utf-8"));
+    for (const f of findings) {
+      let entry = byFile.get(f.file);
+      if (!entry) {
+        // A document triaged before the indexer saw it.
+        entry = { source: { kind: "upload", file: f.file }, id: null, status: "unreviewed" };
+        ledger.entries.push(entry);
+        byFile.set(f.file, entry);
+        created++;
+      }
+
+      // The triage confirms or corrects the machine-seeded join.
+      if (f.id !== undefined && f.id !== entry.id) {
+        entry.id = f.id;
+        if (f.id) idsResolved++;
+      }
+      if (!entry.id) needRef.push(f.file);
+
+      const actions = (f.relevance.proposedActions ?? []).map((a) => ({ ...a }));
+      if (doBeans) {
+        for (const a of actions) {
+          if (a.action === "no-action" || a.bean) continue;
+          const id = createBean(beanTitle(a, entry.id ?? null, f.file));
+          if (id) {
+            a.bean = id;
+            beansMade++;
+          }
+        }
+      }
+
+      entry.relevance = {
+        verdict: f.relevance.verdict,
+        rationale: f.relevance.rationale ?? "",
+        keyResults: f.relevance.keyResults ?? [],
+        proposedActions: actions,
+        assessed_by: f.relevance.assessed_by ?? assessedBy,
+        assessed_at: f.relevance.assessed_at ?? now,
+        ...(f.relevance.source_sha ? { source_sha: f.relevance.source_sha } : {}),
+      };
+      counts[f.relevance.verdict] = (counts[f.relevance.verdict] ?? 0) + 1;
+      merged++;
+    }
+  }
+
+  const triaged = ledger.entries.filter((e) => e.relevance).length;
+  console.log(`findings merged        : ${merged}`);
+  if (created) console.log(`  rows created         : ${created}`);
+  if (idsResolved) console.log(`  reference ids set    : ${idsResolved}`);
+  console.log("verdicts:");
+  for (const [v, n] of Object.entries(counts).sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${v.padEnd(14)} ${n}`);
+  }
+  if (doBeans) console.log(`beans created          : ${beansMade}`);
+  console.log(`ledger triaged / total : ${triaged} / ${ledger.entries.length}`);
+
+  if (needRef.length) {
+    console.log(
+      `\n${needRef.length} triaged document(s) still have no references.ts entry. ` +
+        `Add the ref() there — the ledger stores no metadata:`,
+    );
+    for (const f of needRef.slice(0, 10)) console.log(`  ${f}`);
+    if (needRef.length > 10) console.log(`  … and ${needRef.length - 10} more`);
+  }
+  if (missing.length) {
+    console.log(`\nfindings file(s) not found: ${missing.join(", ")}`);
+  }
+
+  if (write) {
+    writeFileSync(LEDGER_PATH, `${JSON.stringify(ledger, null, 2)}\n`);
+    console.log(`\nwrote ${LEDGER_PATH}`);
+  } else {
+    console.log("\n(dry run — pass --write to persist)");
+  }
+}
+
+main();

--- a/content/pipeline/source-ledger-merge.ts
+++ b/content/pipeline/source-ledger-merge.ts
@@ -68,9 +68,9 @@ interface Finding {
 }
 
 /** Create a bean and return its id, or null if the tracker is unavailable. */
-function createBean(title: string): string | null {
+function createBean(title: string, body: string): string | null {
   try {
-    const out = execFileSync("beans", ["create", title, "--type", "task"], {
+    const out = execFileSync("beans", ["create", title, "--type", "task", "--body", body], {
       cwd: REPO_ROOT,
       encoding: "utf-8",
     });
@@ -82,26 +82,58 @@ function createBean(title: string): string | null {
   }
 }
 
-/** A work item's title: the action and its target, never "read paper X". */
+/**
+ * A work item's title: the action and its target, never "read paper X".
+ *
+ * Kept short on purpose — the title is what `beans list` shows, and a queue
+ * whose every row wraps to four lines is a queue nobody scans.  The reasoning
+ * goes in the body.
+ */
 function beanTitle(a: ProposedAction, refId: string | null, file: string): string {
   const subject = refId ? `[${refId}]` : file.replace(/^uploads\//, "");
   const target = a.target ? ` at ${a.target}` : "";
-  switch (a.action) {
-    case "add-reference":
-      return `Add reference for ${subject} — ${a.rationale}`;
-    case "cite-in-block":
-      return `Cite ${subject}${target} — ${a.rationale}`;
-    case "aid-proof":
-      return `Apply ${subject}${target} — ${a.rationale}`;
-    case "new-remark":
-      return `Remark interpreting ${subject}${target} — ${a.rationale}`;
-    case "new-block":
-      return `Import block from ${subject}${target} — ${a.rationale}`;
-    case "compute-check":
-      return `Cross-check ${subject}${target} — ${a.rationale}`;
-    default:
-      return `${a.action}: ${subject}${target}`;
+  const verb: Record<string, string> = {
+    "add-reference": "Add reference for",
+    "cite-in-block": "Cite",
+    "aid-proof": "Apply",
+    "new-remark": "Remark interpreting",
+    "new-block": "Import block from",
+    "compute-check": "Cross-check",
+  };
+  const title = `${verb[a.action] ?? a.action} ${subject}${target}`;
+  return title.length > 100 ? `${title.slice(0, 97)}…` : title;
+}
+
+/** The bean body: why, what the source says, and where the source is. */
+function beanBody(
+  a: ProposedAction,
+  entry: LedgerEntry,
+  relevance: Finding["relevance"],
+  file: string,
+): string {
+  const lines = [a.rationale, ""];
+
+  // Only the results relevant to this action's target, when it names one.
+  const results = (relevance.keyResults ?? []).filter(
+    (k) => !a.target || !k.targets?.length || k.targets.includes(a.target),
+  );
+  if (results.length) {
+    lines.push("**From the source**");
+    for (const k of results) {
+      lines.push(`- ${k.locator} — ${k.statement}`);
+      lines.push(`  Use here: ${k.useForFolio}`);
+    }
+    lines.push("");
   }
+
+  lines.push(
+    `Source: \`${file}\`${entry.id ? ` (\`${entry.id}\`)` : " — no `references.ts` entry yet"}`,
+    `Relevance: **${relevance.verdict}** — agent assessment, not yet adjudicated.`,
+    "",
+    "Raised by `local/paper-relevance-triage`; the ledger row is in " +
+      "`content/bib-qa-verifications.json`.",
+  );
+  return lines.join("\n");
 }
 
 function main(): void {
@@ -159,7 +191,10 @@ function main(): void {
       if (doBeans) {
         for (const a of actions) {
           if (a.action === "no-action" || a.bean) continue;
-          const id = createBean(beanTitle(a, entry.id ?? null, f.file));
+          const id = createBean(
+            beanTitle(a, entry.id ?? null, f.file),
+            beanBody(a, entry, f.relevance, f.file),
+          );
           if (id) {
             a.bean = id;
             beansMade++;

--- a/schemas/bib-verification.ts
+++ b/schemas/bib-verification.ts
@@ -114,3 +114,194 @@ export function verifierLabel(v: Verifier): string {
   const base = `human (${v.name})`;
   return v.agent_assistance ? `${base}, assisted by ${v.agent_assistance.model}` : base;
 }
+
+// ─── Source ledger (2026-08-08) ──────────────────────────────────────────────
+//
+// The roster above answers "was this reference checked against a source?".
+// It is extended here to also answer "is the source *relevant*, and what
+// should the author do about it?" — the paper-relevance triage.
+//
+// ## One source of truth
+//
+// The ledger stores judgements, never bibliography.  Exactly one file owns
+// each fact:
+//
+// | Fact                                   | Owner                              |
+// |----------------------------------------|------------------------------------|
+// | title, authors, year, DOI, URL, type   | `content/schema/references.ts`     |
+// | source document ↔ reference join       | this ledger (`source` + `id`)      |
+// | was the source checked                 | this ledger (`status`)             |
+// | is it relevant, what to do about it    | this ledger (`relevance`)          |
+// | the resulting work items               | `.beans/`                          |
+//
+// A ledger entry therefore carries NO bibliographic metadata — no `title`,
+// no `authors`, no `year`.  It points at a reference by `id` and the
+// consumer joins.  A reviewer who wants a title for an orphan reads it out
+// of the PDF at display time; it is never written here, because the moment
+// a source is judged worth citing the triage's first action is to create
+// its `ref()` entry, and metadata is born in `references.ts` or nowhere.
+//
+// Migration history:
+//   2026-08-08  `source` discriminated union + `relevance` block; `id`
+//               becomes nullable so a local document with no reference yet
+//               (an "orphan" upload) is a first-class row.  `local_pdf` is
+//               superseded by `source: { kind: "upload", file }` and is
+//               retained only as a deprecated read-path for old consumers.
+
+/** Where the examined source lives.
+ *
+ * Mirrors the `Verifier` discriminated-union idiom above.  An `upload` row
+ * is a document committed under `uploads/`; an `external` row was checked
+ * against a remote source with no local copy. */
+export type SourceRef =
+  | {
+      kind: "upload";
+      /** Repo-relative path, e.g. `uploads/0409565v2.pdf`. */
+      file: string;
+    }
+  | {
+      kind: "external";
+      /** The URL or DOI that was consulted. */
+      url: string;
+    };
+
+/** How relevant a source is to this folio's own argument. */
+export type RelevanceVerdict =
+  /** Supplies a result the paper uses, or demonstrably should use. */
+  | "core"
+  /** Background, technique, or context worth citing but not load-bearing. */
+  | "supporting"
+  /** Same field, no result this paper can consume. */
+  | "tangential"
+  /** No bearing on the paper. */
+  | "not-relevant"
+  /** Not yet assessed. */
+  | "undetermined";
+
+/** A single result inside the source that the folio could consume. */
+export interface KeyResult {
+  /** Locator *within the source*: "Thm 3.2", "§4.1", "eq. (12)", "p. 87". */
+  locator: string;
+  /** What the result says, in one sentence. */
+  statement: string;
+  /** What this folio could do with it — the reason it is listed. */
+  useForFolio: string;
+  /** Candidate content-block labels this would attach to. */
+  targets?: string[];
+}
+
+/** The kinds of link a triage can propose between a source and the folio. */
+export type LinkageAction =
+  /** No `ref()` entry exists yet — create one in `references.ts`. */
+  | "add-reference"
+  /** Reference exists; cite it at a named block that currently does not. */
+  | "cite-in-block"
+  /** Supplies a lemma or technique for a named `sorry` / proof gap. */
+  | "aid-proof"
+  /** Warrants a `remark` block interpreting the result for this folio. */
+  | "new-remark"
+  /** Warrants importing a definition/proposition as a content block. */
+  | "new-block"
+  /** Carries a numerical claim worth cross-checking against a witness. */
+  | "compute-check"
+  /** Read and judged to need nothing. */
+  | "no-action";
+
+/** One proposed link, and the work item it became. */
+export interface ProposedAction {
+  action: LinkageAction;
+  /** Why this action, specifically — the evidence for the proposal. */
+  rationale: string;
+  /** Block label, Lean declaration, or script path the action targets. */
+  target?: string;
+  /** Beans id once the action has been queued as work (e.g. `qou-f4el`). */
+  bean?: string;
+}
+
+/** The relevance triage of one source.
+ *
+ * Epistemically parallel to `VerificationEntry`: `assessed_by` carries the
+ * same agent-vs-human distinction, because a relevance verdict is a
+ * judgement call and an agent's is a claim awaiting review, not a fact. */
+export interface RelevanceAssessment {
+  verdict: RelevanceVerdict;
+  /** Why this verdict — the reasoning, not a restatement of the verdict. */
+  rationale: string;
+  /** Results worth consuming.  Empty for `tangential` / `not-relevant`. */
+  keyResults: KeyResult[];
+  /** What the author could do about it. */
+  proposedActions: ProposedAction[];
+  /** Who produced the assessment. */
+  assessed_by: Verifier;
+  /** ISO 8601 timestamp. */
+  assessed_at: string;
+  /** Human review of an agent assessment, same semantics as
+   *  `VerificationEntry.human_adjudicated`. */
+  human_adjudicated?: {
+    who: string;
+    at: string;
+    note?: string;
+  };
+  /** 12-char SHA-256 prefix of the source file at assessment time.  A
+   *  re-upload changes the hash and marks the assessment stale — the same
+   *  staleness idiom the `.qa.json` sidecars use. */
+  source_sha?: string;
+}
+
+/** A row in the source ledger.
+ *
+ * Supersedes `VerificationEntry`.  Every `VerificationEntry` maps onto a
+ * `LedgerEntry` with `id` set and `source` derived from `local_pdf`
+ * (`upload`) or the reference's URL (`external`). */
+export interface LedgerEntry {
+  /** The document this row is about. */
+  source: SourceRef;
+  /** Reference id in `references.ts`, or `null` when the source backs no
+   *  reference yet (an orphan upload awaiting triage). */
+  id: string | null;
+  /** Source-verification status.  `unreviewed` for a freshly-indexed
+   *  upload that nothing has looked at. */
+  status: VerificationStatus | "unreviewed";
+  verified_at?: string;
+  verified_by?: Verifier;
+  human_adjudicated?: {
+    who: string;
+    at: string;
+    note?: string;
+  };
+  fixes_applied?: number;
+  fix_commit?: string;
+  note?: string;
+  /** The relevance triage, once run. */
+  relevance?: RelevanceAssessment;
+  /**
+   * @deprecated Superseded by `source: { kind: "upload", file }`.  Written
+   * by the migration for one release so pre-2026-08-08 readers keep
+   * working; new writers must not set it.
+   */
+  local_pdf?: string | null;
+}
+
+/** Top-level JSON shape of the extended `bib-qa-verifications.json`. */
+export interface SourceLedger {
+  _schema: string;
+  _authoritative_for?: string;
+  entries: LedgerEntry[];
+}
+
+/** The repo-relative path of a ledger entry's local document, if it has one. */
+export function ledgerLocalFile(e: LedgerEntry): string | null {
+  if (e.source?.kind === "upload") return e.source.file;
+  return e.local_pdf ?? null;
+}
+
+/** Stable key for a ledger row.  Uploads key by file (they exist whether or
+ *  not a reference does); external rows key by reference id. */
+export function ledgerKey(e: LedgerEntry): string {
+  return e.source.kind === "upload" ? e.source.file : (e.id ?? e.source.url);
+}
+
+/** Has this source been triaged for relevance? */
+export function isTriaged(e: LedgerEntry): boolean {
+  return !!e.relevance && e.relevance.verdict !== "undetermined";
+}

--- a/src/routes/relevance.ts
+++ b/src/routes/relevance.ts
@@ -1,0 +1,272 @@
+/**
+ * Folio Assistant — source-relevance API routes.
+ *
+ * Presents the source ledger (`content/bib-qa-verifications.json`) to the
+ * author: what has been uploaded, whether it bears on the folio, which of
+ * its results are usable, whether it is already cited, and what to do next.
+ *
+ *   GET  /api/relevance/ledger?verdict=&status=&cited=  → triaged rows
+ *   GET  /api/relevance/queue                            → untriaged rows
+ *   GET  /api/relevance/summary                          → counts for a dashboard
+ *   POST /api/relevance/adjudicate                       → accept/revise a verdict
+ *
+ * ## The join happens here
+ *
+ * The ledger stores no bibliographic metadata — only a reference `id`.  These
+ * handlers read `content/schema/references.ts` and join title/authors/year
+ * onto each row at request time.  That is the whole point of the split: one
+ * writer for metadata, many readers.  Do not cache the joined shape back into
+ * the ledger.
+ *
+ * ## Adjudication
+ *
+ * A relevance verdict produced by an agent is a claim.  `POST
+ * /api/relevance/adjudicate` is how a human accepts, revises, or rejects it,
+ * writing `human_adjudicated` alongside — never overwriting — the agent's
+ * `assessed_by`.  Both survive, so the dashboard can distinguish "an agent
+ * thinks this is core" from "the author agrees".
+ *
+ * @module folio-assistant/routes/relevance
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+
+import { hasRole, forbidden, getUserRole } from "../core/rbac.js";
+import { log } from "../core/logging.js";
+import type {
+  LedgerEntry,
+  RelevanceVerdict,
+  SourceLedger,
+} from "../../schemas/bib-verification.js";
+
+const CORS = { "Access-Control-Allow-Origin": "*" };
+
+interface RelevanceRoutesConfig {
+  /** Repo root directory. */
+  repoRoot: string;
+}
+
+/** Bibliographic facts, read from references.ts and joined onto a row. */
+interface RefFacts {
+  title: string | null;
+  authors: string | null;
+  year: string | null;
+  url: string | null;
+}
+
+function ledgerPath(repoRoot: string): string {
+  return join(repoRoot, "content", "bib-qa-verifications.json");
+}
+
+function readLedger(repoRoot: string): SourceLedger {
+  const p = ledgerPath(repoRoot);
+  if (!existsSync(p)) return { _schema: "source-ledger/v1", entries: [] };
+  return JSON.parse(readFileSync(p, "utf-8"));
+}
+
+/**
+ * Read `references.ts` for the facts the ledger deliberately does not store.
+ *
+ * A regex read rather than an import: `references.ts` is a 470-entry
+ * TypeScript module, and the route needs four strings per entry, not the
+ * validated CSL objects.  It is also never executed this way.
+ */
+function readRefFacts(repoRoot: string): Map<string, RefFacts> {
+  const p = join(repoRoot, "content", "schema", "references.ts");
+  const out = new Map<string, RefFacts>();
+  if (!existsSync(p)) return out;
+  const src = readFileSync(p, "utf-8");
+
+  for (const m of src.matchAll(/ref\(\{(.*?)\n\s*\}\)/gs)) {
+    const body = m[1];
+    const id = body.match(/\bid:\s*"([^"]+)"/)?.[1];
+    if (!id) continue;
+
+    const title = body.match(/\n\s*title:\s*"((?:[^"\\]|\\.)*)"/)?.[1] ?? null;
+    const year = body.match(/"date-parts":\s*\[\[\s*(\d{4})/)?.[1] ?? null;
+    const url =
+      body.match(/\bURL:\s*"([^"]+)"/)?.[1] ??
+      (body.match(/\bDOI:\s*"([^"]+)"/)?.[1]
+        ? `https://doi.org/${body.match(/\bDOI:\s*"([^"]+)"/)?.[1]}`
+        : null);
+
+    const families = [...body.matchAll(/\bfamily:\s*"((?:[^"\\]|\\.)*)"/g)].map((f) => f[1]);
+    const literals = [...body.matchAll(/\bliteral:\s*"((?:[^"\\]|\\.)*)"/g)].map((f) => f[1]);
+    const names = families.length ? families : literals;
+    const authors = names.length
+      ? names.length > 3
+        ? `${names[0]} et al.`
+        : names.join(", ")
+      : null;
+
+    out.set(id, { title: title?.replace(/\\"/g, '"') ?? null, authors, year, url });
+  }
+  return out;
+}
+
+/** A ledger row plus the reference facts joined in for display. */
+function decorate(e: LedgerEntry, facts: Map<string, RefFacts>, repoRoot: string) {
+  const file = e.source?.kind === "upload" ? e.source.file : null;
+  const ref = e.id ? (facts.get(e.id) ?? null) : null;
+  return {
+    ...e,
+    /** Joined at read time from references.ts — never stored in the ledger. */
+    reference: ref,
+    /** True when the row cites a local document that is not in the repo. */
+    sourceMissing: file ? !existsSync(join(repoRoot, file)) : false,
+    /** True when the document backs no reference yet. */
+    orphan: e.id === null,
+  };
+}
+
+// ── GET ──────────────────────────────────────────────────────────
+
+export async function handleRelevanceGet(
+  url: URL,
+  config: RelevanceRoutesConfig,
+): Promise<Response | null> {
+  const path = url.pathname;
+  if (!path.startsWith("/api/relevance/")) return null;
+
+  const ledger = readLedger(config.repoRoot);
+  const facts = readRefFacts(config.repoRoot);
+
+  if (path === "/api/relevance/summary") {
+    const byVerdict: Record<string, number> = {};
+    let triaged = 0;
+    let orphans = 0;
+    let missing = 0;
+    let openActions = 0;
+    for (const e of ledger.entries) {
+      if (e.id === null) orphans++;
+      if (e.source?.kind === "upload" && !existsSync(join(config.repoRoot, e.source.file))) {
+        missing++;
+      }
+      if (!e.relevance) continue;
+      triaged++;
+      byVerdict[e.relevance.verdict] = (byVerdict[e.relevance.verdict] ?? 0) + 1;
+      openActions += e.relevance.proposedActions.filter((a) => a.action !== "no-action").length;
+    }
+    return Response.json(
+      {
+        total: ledger.entries.length,
+        triaged,
+        untriaged: ledger.entries.length - triaged,
+        orphans,
+        sourceMissing: missing,
+        openActions,
+        byVerdict,
+      },
+      { headers: CORS },
+    );
+  }
+
+  if (path === "/api/relevance/queue") {
+    // What the author has not looked at yet.  Uploaded documents first:
+    // an external row with no local copy cannot be read here anyway.
+    const rows = ledger.entries
+      .filter((e) => !e.relevance)
+      .sort((a, b) => Number(b.source?.kind === "upload") - Number(a.source?.kind === "upload"))
+      .map((e) => decorate(e, facts, config.repoRoot));
+    return Response.json({ count: rows.length, entries: rows }, { headers: CORS });
+  }
+
+  if (path === "/api/relevance/ledger") {
+    const verdict = url.searchParams.get("verdict");
+    const status = url.searchParams.get("status");
+    const cited = url.searchParams.get("cited");
+
+    let rows = ledger.entries.filter((e) => e.relevance);
+    if (verdict) rows = rows.filter((e) => e.relevance?.verdict === verdict);
+    if (status) rows = rows.filter((e) => e.status === status);
+    if (cited === "false") rows = rows.filter((e) => e.id === null);
+    if (cited === "true") rows = rows.filter((e) => e.id !== null);
+
+    // Most actionable first: core before supporting, and within a verdict,
+    // the rows carrying the most outstanding proposals.
+    const rank: Record<RelevanceVerdict, number> = {
+      core: 0,
+      supporting: 1,
+      undetermined: 2,
+      tangential: 3,
+      "not-relevant": 4,
+    };
+    rows.sort((a, b) => {
+      const d = rank[a.relevance!.verdict] - rank[b.relevance!.verdict];
+      if (d !== 0) return d;
+      return b.relevance!.proposedActions.length - a.relevance!.proposedActions.length;
+    });
+
+    return Response.json(
+      {
+        count: rows.length,
+        entries: rows.map((e) => decorate(e, facts, config.repoRoot)),
+      },
+      { headers: CORS },
+    );
+  }
+
+  return null;
+}
+
+// ── POST ─────────────────────────────────────────────────────────
+
+interface AdjudicatePayload {
+  /** Upload path, or reference id for an external row. */
+  key: string;
+  /** Accept the agent's verdict, or replace it. */
+  verdict?: RelevanceVerdict;
+  who: string;
+  note?: string;
+}
+
+export async function handleRelevancePost(
+  req: Request,
+  url: URL,
+  config: RelevanceRoutesConfig,
+): Promise<Response | null> {
+  if (url.pathname !== "/api/relevance/adjudicate") return null;
+
+  if (!hasRole(req, "collaborator")) {
+    return forbidden("adjudicating a relevance verdict", "collaborator");
+  }
+
+  let payload: AdjudicatePayload;
+  try {
+    payload = (await req.json()) as AdjudicatePayload;
+  } catch {
+    return Response.json({ error: "invalid JSON body" }, { status: 400, headers: CORS });
+  }
+  if (!payload?.key || !payload?.who) {
+    return Response.json({ error: "key and who are required" }, { status: 400, headers: CORS });
+  }
+
+  const ledger = readLedger(config.repoRoot);
+  const entry = ledger.entries.find(
+    (e) => (e.source?.kind === "upload" ? e.source.file : e.id) === payload.key,
+  );
+  if (!entry) {
+    return Response.json({ error: "no such ledger row" }, { status: 404, headers: CORS });
+  }
+  if (!entry.relevance) {
+    return Response.json(
+      { error: "row has no relevance assessment to adjudicate" },
+      { status: 409, headers: CORS },
+    );
+  }
+
+  // The agent's claim is preserved: a human decision is recorded alongside
+  // `assessed_by`, never in place of it.
+  if (payload.verdict) entry.relevance.verdict = payload.verdict;
+  entry.relevance.human_adjudicated = {
+    who: payload.who,
+    at: new Date().toISOString(),
+    ...(payload.note ? { note: payload.note } : {}),
+  };
+
+  writeFileSync(ledgerPath(config.repoRoot), `${JSON.stringify(ledger, null, 2)}\n`);
+  log("relevance", `adjudicated ${payload.key} by ${getUserRole(req)}`);
+
+  return Response.json({ ok: true, entry }, { headers: CORS });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,6 +20,7 @@ import { handleBranchGet, handleBranchPost } from "./routes/branches.js";
 import { handleFeedbackGet, handleFeedbackPost } from "./routes/feedback.js";
 import { handleChatPost } from "./routes/chat.js";
 import { handleGlossaryGet, handleGlossaryPost } from "./routes/glossary.js";
+import { handleRelevanceGet, handleRelevancePost } from "./routes/relevance.js";
 import { registerBeansTools } from "./tools/beans-prime.js";
 
 // ── MIME types for static serving ────────────────────────────────
@@ -153,6 +154,10 @@ export class FolioServer {
     const glossaryRes = await handleGlossaryGet(url, { repoRoot: this.config.repoRoot });
     if (glossaryRes) return glossaryRes;
 
+    // Source-relevance routes
+    const relevanceRes = await handleRelevanceGet(url, { repoRoot: this.config.repoRoot });
+    if (relevanceRes) return relevanceRes;
+
     // Content adapter routes
     const adapterRes = await this.adapter.handleGet(url);
     if (adapterRes) return adapterRes;
@@ -174,6 +179,10 @@ export class FolioServer {
     // Glossary curator operations
     const glossaryRes = await handleGlossaryPost(url, req, { repoRoot: this.config.repoRoot });
     if (glossaryRes) return glossaryRes;
+
+    // Source-relevance adjudication
+    const relevanceRes = await handleRelevancePost(req, url, { repoRoot: this.config.repoRoot });
+    if (relevanceRes) return relevanceRes;
 
     // Chat
     const chatRes = await handleChatPost(url, req, this.adapter, this.feedbackStore);

--- a/ui/source-relevance.html
+++ b/ui/source-relevance.html
@@ -1,0 +1,279 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Source relevance</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <style>
+    /* Theme tokens mirror ui/bib-qa.html so the two dashboards read as one tool. */
+    :root { --ease: cubic-bezier(0.4,0,0.2,1); }
+    [data-theme="dark"] {
+      --bg:#0e0e12; --bg-s:#16161c; --bg-r:#1e1e26; --bg-c:#12121a;
+      --fg:#c8c8d0; --fg-d:#70707c; --fg-b:#eeeef4;
+      --ac:#7ca8e6; --ac-d:#4a6a9a;
+      --grn:#7ce6a4; --yel:#e6c87c; --red:#e67c7c; --ora:#e6a47c;
+      --brd:#2a2a34;
+    }
+    [data-theme="light"] {
+      --bg:#fafafa; --bg-s:#ffffff; --bg-r:#f0f0f4; --bg-c:#f5f5fa;
+      --fg:#2c2c34; --fg-d:#888894; --fg-b:#111118;
+      --ac:#2a6bc4; --ac-d:#6a9ad4;
+      --grn:#1a8a44; --yel:#9a7a20; --red:#c44a4a; --ora:#b07030;
+      --brd:#d8d8e0;
+    }
+    * { margin:0; padding:0; box-sizing:border-box; }
+    body {
+      background: var(--bg); color: var(--fg);
+      font-family: 'Inter','Helvetica Neue',sans-serif;
+      font-size: 14px; line-height: 1.5; min-height: 100vh;
+    }
+    a { color: var(--ac); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    code, .mono { font-family: 'JetBrains Mono', monospace; font-size: .85em; }
+
+    .top-bar {
+      position: sticky; top: 0; z-index: 100;
+      background: var(--bg-s); border-bottom: 1px solid var(--brd);
+      display: flex; align-items: center; gap: 1rem;
+      padding: .5rem 1.5rem; height: 44px;
+    }
+    .top-bar h1 { font-size: .95rem; font-weight: 600; color: var(--fg-b); white-space: nowrap; }
+    .top-bar .spacer { flex: 1; }
+    .top-bar button, select {
+      background: var(--bg-r); color: var(--fg); border: 1px solid var(--brd);
+      border-radius: 5px; padding: .25rem .6rem; font-size: .8rem;
+      font-family: inherit; cursor: pointer;
+    }
+    .top-bar button:hover { border-color: var(--ac-d); }
+
+    .wrap { max-width: 1100px; margin: 0 auto; padding: 1.5rem; }
+
+    /* Summary tiles */
+    .tiles { display: flex; flex-wrap: wrap; gap: .75rem; margin-bottom: 1.5rem; }
+    .tile {
+      background: var(--bg-s); border: 1px solid var(--brd); border-radius: 8px;
+      padding: .7rem 1rem; min-width: 116px; flex: 1;
+    }
+    .tile .n { font-size: 1.5rem; font-weight: 600; color: var(--fg-b); line-height: 1.1; }
+    .tile .l { font-size: .72rem; color: var(--fg-d); text-transform: uppercase; letter-spacing: .04em; }
+    .tile.warn .n { color: var(--ora); }
+
+    .filters { display: flex; flex-wrap: wrap; gap: .5rem; align-items: center; margin-bottom: 1rem; }
+    .filters label { font-size: .78rem; color: var(--fg-d); }
+
+    /* Document card */
+    .card {
+      background: var(--bg-s); border: 1px solid var(--brd); border-radius: 8px;
+      padding: 1rem 1.1rem; margin-bottom: .9rem;
+    }
+    .card header { display: flex; align-items: flex-start; gap: .6rem; margin-bottom: .35rem; }
+    .card h2 { font-size: .95rem; font-weight: 600; color: var(--fg-b); flex: 1; }
+    .meta { font-size: .78rem; color: var(--fg-d); margin-bottom: .6rem; }
+    .meta .sep { opacity: .5; margin: 0 .4rem; }
+
+    .badge {
+      font-size: .68rem; font-weight: 600; text-transform: uppercase; letter-spacing: .04em;
+      padding: .15rem .45rem; border-radius: 4px; white-space: nowrap;
+      border: 1px solid currentColor;
+    }
+    .v-core { color: var(--grn); }
+    .v-supporting { color: var(--ac); }
+    .v-undetermined { color: var(--yel); }
+    .v-tangential { color: var(--fg-d); }
+    .v-not-relevant { color: var(--fg-d); opacity: .8; }
+    .badge.orphan { color: var(--ora); }
+    .badge.missing { color: var(--red); }
+    .badge.claim { color: var(--yel); }
+    .badge.human { color: var(--grn); }
+
+    .rationale { font-size: .86rem; margin-bottom: .7rem; }
+
+    .section-label {
+      font-size: .7rem; text-transform: uppercase; letter-spacing: .05em;
+      color: var(--fg-d); margin: .7rem 0 .3rem;
+    }
+    ul.results, ul.actions { list-style: none; }
+    ul.results li, ul.actions li {
+      background: var(--bg-c); border-left: 2px solid var(--brd);
+      padding: .45rem .7rem; margin-bottom: .35rem; border-radius: 0 4px 4px 0;
+      font-size: .84rem;
+    }
+    ul.results li .loc { color: var(--ac); font-weight: 600; }
+    ul.results li .use { color: var(--fg-d); display: block; margin-top: .2rem; }
+    ul.actions li { border-left-color: var(--ac-d); }
+    ul.actions li .act {
+      font-family: 'JetBrains Mono', monospace; font-size: .78rem;
+      color: var(--grn); font-weight: 500;
+    }
+    ul.actions li .tgt { color: var(--fg-b); }
+    ul.actions li .bean { float: right; font-size: .72rem; color: var(--fg-d); }
+
+    .adjudicate { margin-top: .8rem; display: flex; gap: .5rem; align-items: center; }
+    .adjudicate input {
+      background: var(--bg-r); color: var(--fg); border: 1px solid var(--brd);
+      border-radius: 5px; padding: .25rem .5rem; font: inherit; font-size: .8rem;
+    }
+    .empty { color: var(--fg-d); text-align: center; padding: 3rem 0; }
+    .err { color: var(--red); padding: 1rem; }
+  </style>
+</head>
+<body>
+  <div class="top-bar">
+    <h1>Source relevance</h1>
+    <span class="spacer"></span>
+    <button id="theme">theme</button>
+    <button id="reload">reload</button>
+  </div>
+
+  <div class="wrap">
+    <div class="tiles" id="tiles"></div>
+
+    <div class="filters">
+      <label for="f-verdict">verdict</label>
+      <select id="f-verdict">
+        <option value="">all</option>
+        <option value="core">core</option>
+        <option value="supporting">supporting</option>
+        <option value="undetermined">undetermined</option>
+        <option value="tangential">tangential</option>
+        <option value="not-relevant">not-relevant</option>
+      </select>
+      <label for="f-cited">citation</label>
+      <select id="f-cited">
+        <option value="">all</option>
+        <option value="false">no reference entry</option>
+        <option value="true">has reference entry</option>
+      </select>
+      <label for="f-view">view</label>
+      <select id="f-view">
+        <option value="ledger">triaged</option>
+        <option value="queue">not yet triaged</option>
+      </select>
+    </div>
+
+    <div id="list"></div>
+  </div>
+
+<script>
+// The ledger stores no bibliographic metadata; the API joins title/authors
+// from references.ts at request time. This page renders what it is given and
+// never writes metadata back.
+const $ = (s) => document.querySelector(s);
+
+function esc(s) {
+  return String(s ?? "").replace(/[&<>"']/g, (c) =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c]);
+}
+
+async function loadSummary() {
+  const r = await fetch("/api/relevance/summary");
+  const s = await r.json();
+  const tiles = [
+    { n: s.total, l: "documents" },
+    { n: s.triaged, l: "triaged" },
+    { n: s.untriaged, l: "to review" },
+    { n: s.orphans, l: "no reference", warn: s.orphans > 0 },
+    { n: s.openActions, l: "open actions" },
+    { n: s.sourceMissing, l: "file missing", warn: s.sourceMissing > 0 },
+  ];
+  $("#tiles").innerHTML = tiles.map((t) =>
+    `<div class="tile${t.warn ? " warn" : ""}"><div class="n">${t.n}</div><div class="l">${esc(t.l)}</div></div>`
+  ).join("");
+}
+
+function renderCard(e) {
+  const rel = e.relevance;
+  const ref = e.reference;
+  const file = e.source?.kind === "upload" ? e.source.file : null;
+  const title = ref?.title ?? (file ? file.replace(/^uploads\//, "") : e.id) ?? "(unidentified)";
+
+  const badges = [];
+  if (rel) badges.push(`<span class="badge v-${esc(rel.verdict)}">${esc(rel.verdict)}</span>`);
+  if (e.orphan) badges.push('<span class="badge orphan">no reference</span>');
+  if (e.sourceMissing) badges.push('<span class="badge missing">file missing</span>');
+  if (rel) {
+    badges.push(rel.human_adjudicated
+      ? '<span class="badge human">adjudicated</span>'
+      : '<span class="badge claim">agent claim</span>');
+  }
+
+  const metaBits = [];
+  if (ref?.authors) metaBits.push(esc(ref.authors));
+  if (ref?.year) metaBits.push(esc(ref.year));
+  if (e.id) metaBits.push(`<code>${esc(e.id)}</code>`);
+  if (file) metaBits.push(`<code>${esc(file)}</code>`);
+  if (ref?.url) metaBits.push(`<a href="${esc(ref.url)}" target="_blank" rel="noopener">source</a>`);
+
+  const results = (rel?.keyResults ?? []).map((k) =>
+    `<li><span class="loc">${esc(k.locator)}</span> — ${esc(k.statement)}
+       <span class="use">${esc(k.useForFolio)}${
+         k.targets?.length ? " → " + k.targets.map((t) => `<code>${esc(t)}</code>`).join(", ") : ""
+       }</span></li>`).join("");
+
+  const actions = (rel?.proposedActions ?? []).map((a) =>
+    `<li>${a.bean ? `<span class="bean">${esc(a.bean)}</span>` : ""}
+       <span class="act">${esc(a.action)}</span>
+       ${a.target ? ` <span class="tgt">${esc(a.target)}</span>` : ""}
+       <div>${esc(a.rationale)}</div></li>`).join("");
+
+  const key = file ?? e.id;
+  return `<div class="card">
+    <header><h2>${esc(title)}</h2>${badges.join(" ")}</header>
+    <div class="meta">${metaBits.join('<span class="sep">·</span>')}</div>
+    ${rel ? `<div class="rationale">${esc(rel.rationale)}</div>` : ""}
+    ${results ? `<div class="section-label">Results this folio could use</div><ul class="results">${results}</ul>` : ""}
+    ${actions ? `<div class="section-label">Options to pursue</div><ul class="actions">${actions}</ul>` : ""}
+    ${rel && !rel.human_adjudicated ? `
+      <div class="adjudicate">
+        <input type="text" placeholder="your name" data-who="${esc(key)}">
+        <button data-accept="${esc(key)}">accept verdict</button>
+      </div>` : ""}
+  </div>`;
+}
+
+async function load() {
+  const view = $("#f-view").value;
+  const params = new URLSearchParams();
+  if (view === "ledger") {
+    if ($("#f-verdict").value) params.set("verdict", $("#f-verdict").value);
+    if ($("#f-cited").value) params.set("cited", $("#f-cited").value);
+  }
+  try {
+    await loadSummary();
+    const r = await fetch(`/api/relevance/${view}?${params}`);
+    const data = await r.json();
+    $("#list").innerHTML = data.entries?.length
+      ? data.entries.map(renderCard).join("")
+      : '<div class="empty">Nothing here.</div>';
+  } catch (err) {
+    $("#list").innerHTML = `<div class="err">${esc(err.message)}</div>`;
+  }
+}
+
+$("#list").addEventListener("click", async (ev) => {
+  const key = ev.target.getAttribute?.("data-accept");
+  if (!key) return;
+  const who = document.querySelector(`input[data-who="${CSS.escape(key)}"]`)?.value?.trim();
+  if (!who) return alert("Enter your name so the adjudication is attributable.");
+  const r = await fetch("/api/relevance/adjudicate", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ key, who }),
+  });
+  if (!r.ok) return alert(`Failed: ${(await r.json()).error ?? r.status}`);
+  load();
+});
+
+$("#theme").onclick = () => {
+  const el = document.documentElement;
+  el.dataset.theme = el.dataset.theme === "dark" ? "light" : "dark";
+};
+$("#reload").onclick = load;
+for (const id of ["#f-verdict", "#f-cited", "#f-view"]) $(id).onchange = load;
+load();
+</script>
+</body>
+</html>


### PR DESCRIPTION
A folio accumulates uploads faster than it cites them. `qou` has **284 documents in `uploads/` and one intake record**; citation status was recoverable only by hand. This adds the layer that sits *before* `paper-importer`: is this source relevant, which of its results are usable here, is it already cited, and what should the author do about it.

Paired with litlfred/qou#4775, which carries the migrated data and the `paper-relevance-triage` skill.

## Why the roster, and not a new file

The verification roster already owned the document↔reference join (`local_pdf`) and the "was this source examined" question. Relevance triage is the same lifecycle, so it extends that file rather than opening a fourth overlapping store next to `references.ts` and the ad-hoc intake JSONs.

**The ledger holds judgements and joins only** — no title, author, year, or DOI. A row points at a reference by `id`, and `routes/relevance.ts` performs the join at request time by reading `references.ts`. One writer for metadata, many readers. The dashboard renders what the API joins and never writes it back.

| Fact | Sole owner |
|---|---|
| title, authors, year, DOI, URL | `content/schema/references.ts` |
| document ↔ reference join | ledger `source` + `id` |
| was the source examined | ledger `status` |
| is it relevant, what to do | ledger `relevance` |
| resulting work items | `.beans/` |

## Schema

`source` becomes a discriminated union — `{kind:"upload", file}` | `{kind:"external", url}` — mirroring the file's own existing `Verifier` idiom, so a document backing no reference yet is a first-class row instead of unrepresentable. `id` is nullable for exactly that case; `local_pdf` survives one release as a deprecated read-path.

`RelevanceAssessment` carries the verdict, key results with in-source locators, proposed linkage actions (`add-reference` / `cite-in-block` / `aid-proof` / `new-remark` / `new-block` / `compute-check`), and the bean each action became.

`assessed_by` reuses the agent-vs-human `Verifier` union. A relevance verdict is a judgement, and an agent's is a claim awaiting review — the dashboard badges it *agent claim* until a human adjudicates through `POST /api/relevance/adjudicate`, which records the human decision **alongside** the agent's rather than overwriting it.

## What's here

| File | Role |
|---|---|
| `schemas/bib-verification.ts` | `SourceRef`, `RelevanceAssessment`, `LedgerEntry`, `SourceLedger` + helpers |
| `content/pipeline/source-ledger-index.ts` | migrate legacy rows, seed a row per uploaded document, resolve what a filename can prove |
| `content/pipeline/source-ledger-merge.ts` | land parallel agents' findings, queue each accepted action as a bean |
| `src/routes/relevance.ts` | `/api/relevance/{summary,queue,ledger,adjudicate}` — the join lives here |
| `ui/source-relevance.html` | author dashboard: verdict, usable results, options to pursue |
| `content/pipeline/bib-qa.ts` | keeps working across the migration |

`bib-qa.ts` now skips nullable-id rows (not per-reference QA's business — they would otherwise collide on a single null key) and reads `source.file` with a `local_pdf` fallback.

## Notable finding

The indexer reports upload rows whose file is not in the repo. On `qou` that is **45 of 57** — rows recording a source examination, 43 of them `verified-clean`, against files never committed (`uploads/*.pdf` is whitelisted, so nothing suppressed them). Surfaced rather than left dangling; the disposition is the folio owner's call.

## Verification

- `bunx tsc --noEmit` clean across the changed files.
- `source-ledger-index` is idempotent — a row already carrying `source` passes through untouched; re-running produces no diff. Exercised on the real 134-row → 407-row `qou` migration.
- `source-ledger-merge` re-run is safe: an action already carrying a `bean` is not re-queued.
- Dashboard escapes all interpolated values; adjudication is gated at `collaborator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdgQh2nTPj4gJcX7WpeKpZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NdgQh2nTPj4gJcX7WpeKpZ)_