### PR TITLE
29 workflows never fire, and their headers say otherwise

### DIFF
--- a/.beans/folio-assistant-5rfy--29-of-32-workflows-never-fire-on-their-own-qa-swee.md
+++ b/.beans/folio-assistant-5rfy--29-of-32-workflows-never-fire-on-their-own-qa-swee.md
@@ -1,0 +1,77 @@
+---
+# folio-assistant-5rfy
+title: 29 of 32 workflows never fire on their own; qa-sweep-nightly has no schedule
+status: completed
+type: bug
+priority: normal
+created_at: 2026-08-08T16:57:25Z
+updated_at: 2026-08-08T17:03:44Z
+---
+
+Follow-on from the code-quality-gates find (bean cnlf), one level up. Only code-quality-gates.yml, docs-site.yml and atomic-mass-gen-check.yml have a non-dispatch trigger; there is no schedule: or cron: anywhere in .github/workflows.
+
+Sharpest instance: qa-sweep-nightly.yml documents in its own header 'schedule - daily at 04:30 UTC' and has no schedule: block. It exists because a session found 60-70% of open watcher-sidecar fails were STALE for want of a re-sweep - a problem it was built to solve and has never run to solve.
+
+Two readings and they need separating per workflow: (a) the trigger was dropped or never added, or (b) it is deliberately manual in the PLATFORM repo because the job needs a folio checked out and would otherwise sweep zero blocks - passing by finding nothing.
+
+Deliverable: classify all 32 into correctly-manual / belongs-to-the-folio / should-fire-and-does-not, with the evidence for each, before changing any trigger.
+
+
+## Summary of Changes
+
+### It is one migration decision, not 29 oversights
+
+`git log --diff-filter=A` on every workflow: **all 34 arrived in a single commit**
+— `109a4ff`, 2026-06-29, the repo split — and every one of them was
+`workflow_dispatch`-only at birth, including `code-quality-gates.yml`. Since
+then exactly three acquired a real trigger: `atomic-mass-gen-check`,
+`docs-site`, and `code-quality-gates` (fixed today, bean `cnlf`).
+
+The only `cron:` this repo has ever contained belonged to a workflow `bc8937a`
+deliberately DELETED — a folio's paper-builder image that did not belong in the
+platform. So the schedules the headers describe were never here to lose.
+
+The neutering was **right**. The platform has no `content/<paper>/` (0 paper
+dirs), no `chapters/`, no `tools/`, no `human-agent-discussions/`. A content
+sweep here would sweep nothing and report clean — this bean's own defect class.
+What was wrong is that no file said so, leaving every reader to infer
+automation that does not exist.
+
+### Fixed
+
+Fourteen workflows carry a `TRIGGERS, ACTUAL:` note naming the real trigger and
+what the platform lacks. Plus `scripts/tests/workflow-triggers.test.ts` (5
+tests) as the forcing function: a header may not advertise a trigger the `on:`
+block lacks unless it carries that note. Verified by stripping the note from
+`qa-sweep-nightly.yml` and watching the suite go red.
+
+Two tests guard the other direction, which matters more than the first: the
+three live workflows must STAY wired (otherwise the suite is satisfiable by
+neutering them and annotating), and no workflow may reference
+`github.event.pull_request` while unable to receive a PR event — dead PR
+context is the signature of a trigger removed without the body revisited.
+`wrapper-tests.yml` had exactly that, keying `concurrency.group` off
+`github.event.pull_request.head.ref`.
+
+### One real gap, left for the owner
+
+`build-lean-mcp.yml` is not a split artefact. It builds
+`adapters/mcp-server/Dockerfile` — platform code, present here — and its header
+promises push-to-main plus twice-weekly rebuilds. It has neither, so the
+UNIFIED image that `publish.yml`, `lean-build.yml`, `blueprint.yml` and the
+local render hooks all depend on is never rebuilt unless a human dispatches it.
+
+NOT wired here on purpose: it pushes to GHCR and its own header says "the
+self-updater on the folio server polls for new image digests and auto-deploys".
+Turning it on publishes images and triggers live deploys. Owner's call.
+
+### Two guesses I checked instead of writing down
+
+`deploy-folio.yml` looked like a schedule mismatch; its prose actually says a
+cron self-updater is NOT needed. And `release-please` / `discussions-maintain`
+looked like outward-facing platform gaps needing a decision — both target
+directories (`tools/`, `human-agent-discussions/`) the platform does not carry,
+so they are ordinary split artefacts. My first scan also missed
+`wrapper-tests.yml` entirely, because the pattern looked for "on every PR" and
+the header says "Triggered on PRs that…" — an incomplete scan reporting as
+complete, so the scan was widened to over-report and each hit read by hand.

--- a/.github/workflows/build-clarabel-mpfr.yml
+++ b/.github/workflows/build-clarabel-mpfr.yml
@@ -8,6 +8,13 @@
 # weekly rebuild to keep the cached artifact fresh.
 name: Build clarabel-MPFR binary
 
+#
+# TRIGGERS, ACTUAL: `workflow_dispatch` only.
+# The triggers described above are the FOLIO's — copied in at the repo split
+# (109a4ff) with the trigger neutered and the prose left alone. Correct here:
+# this workflow builds a `tools/` native artifact, and `tools/` does not exist in the platform.
+# See bean `folio-assistant-5rfy`.
+
 on:
   workflow_dispatch:
 permissions:

--- a/.github/workflows/build-lean-mcp.yml
+++ b/.github/workflows/build-lean-mcp.yml
@@ -18,6 +18,15 @@
 
 name: Build Paper Assistant Image
 
+#
+# TRIGGERS, ACTUAL: `workflow_dispatch` only — the push and twice-weekly
+# triggers described above are NOT wired. Unlike the folio-side workflows,
+# this one CAN run here (`adapters/mcp-server/Dockerfile` is platform code),
+# and the image it builds is the one publish/lean-build/blueprint all use.
+# So it is a real gap, not a split artefact — but wiring it starts pushing to
+# GHCR, which the folio server auto-deploys, so it needs an owner's decision.
+# See bean `folio-assistant-5rfy`.
+
 on:
   workflow_dispatch:
 env:

--- a/.github/workflows/deploy-folio.yml
+++ b/.github/workflows/deploy-folio.yml
@@ -20,6 +20,14 @@
 
 name: Deploy Folio
 
+#
+# TRIGGERS, ACTUAL: `workflow_dispatch` only.
+# The triggers described above are the FOLIO's. This file was copied into the
+# platform in the repo split (109a4ff) with every trigger neutered to
+# dispatch, and the prose left as it was. It is correct here: this workflow
+# deploys a folio, and the platform carries no folio. The folio's copy holds the real
+# triggers. See bean `folio-assistant-5rfy`.
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/discussions-maintain.yml
+++ b/.github/workflows/discussions-maintain.yml
@@ -16,6 +16,12 @@ name: Maintain discussion archive
 # GITHUB_TOKEN pushes don't retrigger workflows, and the commit carries
 # [skip ci] as a second loop guard.
 
+#
+# TRIGGERS, ACTUAL: `workflow_dispatch` only.
+# The triggers described above are the other repo's. Copied in at the split
+# (109a4ff) with the trigger neutered and the prose left alone. Correct here:
+# this workflow maintains `human-agent-discussions/`, which the platform does not carry. See bean `folio-assistant-5rfy`.
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/lean-build-sidecar.yml
+++ b/.github/workflows/lean-build-sidecar.yml
@@ -24,6 +24,14 @@
 
 name: Lean build sidecar
 
+#
+# TRIGGERS, ACTUAL: `workflow_dispatch` only.
+# The triggers described above are the FOLIO's. This file was copied into the
+# platform in the repo split (109a4ff) with every trigger neutered to
+# dispatch, and the prose left as it was. It is correct here: this workflow
+# builds a folio's Lean tree, and the platform carries no folio. The folio's copy holds the real
+# triggers. See bean `folio-assistant-5rfy`.
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,14 @@ name: Build & Publish
 #     feature_branch / publish_branch inputs preserved from the legacy
 #     workflow so existing runbooks keep working.
 
+#
+# TRIGGERS, ACTUAL: `workflow_dispatch` only.
+# The triggers described above are the FOLIO's. This file was copied into the
+# platform in the repo split (109a4ff) with every trigger neutered to
+# dispatch, and the prose left as it was. It is correct here: this workflow
+# builds a folio's PDF/HTML (it is `workflow_call` — folios invoke it), and the platform carries no folio. The folio's copy holds the real
+# triggers. See bean `folio-assistant-5rfy`.
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/pyhecke-native-wheels.yml
+++ b/.github/workflows/pyhecke-native-wheels.yml
@@ -10,6 +10,13 @@ name: pyhecke-native wheels
 # Auto-trigger:   push to main that touches tools/pyhecke-native/
 #                 or tools/hecke-engine/ (the underlying Rust crate)
 
+#
+# TRIGGERS, ACTUAL: `workflow_dispatch` only.
+# The triggers described above are the FOLIO's — copied in at the repo split
+# (109a4ff) with the trigger neutered and the prose left alone. Correct here:
+# this workflow builds `tools/` wheels, and `tools/` does not exist in the platform.
+# See bean `folio-assistant-5rfy`.
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/pyodide-smoke.yml
+++ b/.github/workflows/pyodide-smoke.yml
@@ -16,6 +16,13 @@ name: Pyodide integration smoke
 #   - No native deps got smuggled into the pure-Python surface
 #     (would manifest as "ModuleNotFoundError: No module named '_X'")
 
+#
+# TRIGGERS, ACTUAL: `workflow_dispatch` only.
+# The triggers described above are the FOLIO's — copied in at the repo split
+# (109a4ff) with the trigger neutered and the prose left alone. Correct here:
+# this workflow smoke-tests a `tools/` build, and `tools/` does not exist in the platform.
+# See bean `folio-assistant-5rfy`.
+
 on:
   workflow_dispatch:
 

--- a/.github/workflows/qa-sweep-nightly.yml
+++ b/.github/workflows/qa-sweep-nightly.yml
@@ -43,6 +43,14 @@
 
 name: QA sweep nightly
 
+#
+# TRIGGERS, ACTUAL: `workflow_dispatch` only.
+# The triggers described above are the FOLIO's. This file was copied into the
+# platform in the repo split (109a4ff) with every trigger neutered to
+# dispatch, and the prose left as it was. It is correct here: this workflow
+# sweeps `content/<paper>/` blocks, and the platform carries no folio. The folio's copy holds the real
+# triggers. See bean `folio-assistant-5rfy`.
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/qa-sweep.yml
+++ b/.github/workflows/qa-sweep.yml
@@ -34,6 +34,14 @@
 
 name: QA sweep (all integration watchers)
 
+#
+# TRIGGERS, ACTUAL: `workflow_dispatch` only.
+# The triggers described above are the FOLIO's. This file was copied into the
+# platform in the repo split (109a4ff) with every trigger neutered to
+# dispatch, and the prose left as it was. It is correct here: this workflow
+# sweeps `content/<paper>/` blocks, and the platform carries no folio. The folio's copy holds the real
+# triggers. See bean `folio-assistant-5rfy`.
+
 on:
   workflow_dispatch:
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -56,6 +56,12 @@ name: release-please
 # rescue path: `gh pr create --head release-please--...`. See
 # docs/release-process.md (once added) for the exact recipe.
 
+#
+# TRIGGERS, ACTUAL: `workflow_dispatch` only.
+# The triggers described above are the other repo's. Copied in at the split
+# (109a4ff) with the trigger neutered and the prose left alone. Correct here:
+# this workflow releases the packages under `tools/`, which the platform does not carry. See bean `folio-assistant-5rfy`.
+
 on:
   workflow_dispatch:
 

--- a/.github/workflows/witness-pipeline.yml
+++ b/.github/workflows/witness-pipeline.yml
@@ -27,6 +27,14 @@
 
 name: Witness pipeline
 
+#
+# TRIGGERS, ACTUAL: `workflow_dispatch` only.
+# The triggers described above are the FOLIO's. This file was copied into the
+# platform in the repo split (109a4ff) with every trigger neutered to
+# dispatch, and the prose left as it was. It is correct here: this workflow
+# audits folio content and witnesses, and the platform carries no folio. The folio's copy holds the real
+# triggers. See bean `folio-assistant-5rfy`.
+
 on:
   workflow_dispatch:
 

--- a/.github/workflows/witness-refresh.yml
+++ b/.github/workflows/witness-refresh.yml
@@ -27,6 +27,14 @@ name: Witness refresh (commit-back to main)
 # routed through this workflow — they keep using publish.yml's regen
 # step, which now succeeds against an up-to-date baseline.
 
+#
+# TRIGGERS, ACTUAL: `workflow_dispatch` only.
+# The triggers described above are the FOLIO's. This file was copied into the
+# platform in the repo split (109a4ff) with every trigger neutered to
+# dispatch, and the prose left as it was. It is correct here: this workflow
+# refreshes a folio's witness set, and the platform carries no folio. The folio's copy holds the real
+# triggers. See bean `folio-assistant-5rfy`.
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/wrapper-tests.yml
+++ b/.github/workflows/wrapper-tests.yml
@@ -8,6 +8,13 @@ name: Wrapper tests (per-language smoke matrix)
 # Triggered on PRs that touch any wrapper or the engine itself; also
 # manually via workflow_dispatch.
 
+#
+# TRIGGERS, ACTUAL: `workflow_dispatch` only.
+# The triggers described above are the FOLIO's — copied in at the repo split
+# (109a4ff) with the trigger neutered and the prose left alone. Correct here:
+# this workflow tests `tools/hecke-engine-c`, and `tools/` does not exist in the platform.
+# See bean `folio-assistant-5rfy`.
+
 on:
   workflow_dispatch:
 

--- a/scripts/tests/workflow-triggers.test.ts
+++ b/scripts/tests/workflow-triggers.test.ts
@@ -1,0 +1,126 @@
+/**
+ * A workflow's header must not describe triggers it does not have.
+ *
+ * All 34 workflows arrived in one commit (`109a4ff`, the repo split) with
+ * every trigger neutered to `workflow_dispatch` and their prose left
+ * describing the FOLIO's triggers. Since then exactly three acquired a
+ * real one — `atomic-mass-gen-check`, `docs-site`, and
+ * `code-quality-gates`, whose header insisted *"the ratchet only works if
+ * something runs it"* while the file had never run once.
+ *
+ * The neutering was right: the platform has no `content/<paper>/`, no
+ * `chapters/`, no `tools/`, so a content sweep here would sweep nothing
+ * and report clean. What was wrong is that no file said so, leaving every
+ * reader — human or agent — to infer automation that does not exist.
+ *
+ * This is the forcing function. Each workflow either has the triggers its
+ * header advertises, or carries a `TRIGGERS, ACTUAL:` note stating what
+ * it really does and why. A new bulk copy cannot quietly land 30 more
+ * dispatch-only files whose prose claims otherwise.
+ */
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "fs";
+import { join } from "path";
+
+const DIR = join(import.meta.dir, "../../.github/workflows");
+const FILES = readdirSync(DIR).filter((f) => f.endsWith(".yml"));
+
+/** The `on:` block's trigger names. */
+function triggers(src: string): Set<string> {
+  const m = src.match(/^on:\s*\n((?:[ \t]+.*\n|\n)*?)(?=^\S)/m);
+  if (m) return new Set([...m[1].matchAll(/^ {2}([a-z_]+):/gm)].map((x) => x[1]));
+  const inline = src.match(/^on:\s*(.+)$/m);
+  return new Set(
+    inline ? inline[1].replace(/[[\]]/g, "").split(",").map((s) => s.trim()).filter(Boolean) : [],
+  );
+}
+
+/** Everything before `on:` — the prose that makes claims. */
+function header(src: string): string {
+  const i = src.indexOf("\non:");
+  return i < 0 ? src : src.slice(0, i);
+}
+
+/** Triggers the prose advertises but the `on:` block lacks. */
+function unbackedClaims(src: string): string[] {
+  const t = triggers(src);
+  const h = header(src);
+  const out: string[] = [];
+  if (/\bPRs?\b|pull request/i.test(h) && !t.has("pull_request")) out.push("pull_request");
+  if (/\bon (each|every) (main )?(commit|push)|push to main|main commit/i.test(h) && !t.has("push"))
+    out.push("push");
+  if (/nightly|schedule|cron|daily|weekly|monthly/i.test(h) && !t.has("schedule"))
+    out.push("schedule");
+  return out;
+}
+
+describe("workflow triggers match what their headers claim", () => {
+  test("every workflow has an `on:` block with at least one trigger", () => {
+    for (const f of FILES) {
+      const t = triggers(readFileSync(join(DIR, f), "utf-8"));
+      expect({ f, count: t.size > 0 }).toEqual({ f, count: true });
+    }
+  });
+
+  test("a header claiming a trigger it lacks must say so explicitly", () => {
+    // The whole point. Prose describing a nightly schedule on a file with
+    // no `schedule:` is how `qa-sweep-nightly` came to exist for months
+    // without ever running — while the staleness it was built to prevent
+    // went on accumulating.
+    const lying: string[] = [];
+    for (const f of FILES) {
+      const src = readFileSync(join(DIR, f), "utf-8");
+      const claims = unbackedClaims(src);
+      if (claims.length === 0) continue;
+      if (src.includes("TRIGGERS, ACTUAL")) continue;
+      lying.push(`${f} claims ${claims.join("+")} but has ${[...triggers(src)].join(",")}`);
+    }
+    expect(lying).toEqual([]);
+  });
+
+  test("the note names why, not just that", () => {
+    // A bare "dispatch only" note would restate the `on:` block and
+    // explain nothing. Each has to say what the workflow needs that the
+    // platform does not have, or that it is a real gap awaiting a call.
+    for (const f of FILES) {
+      const src = readFileSync(join(DIR, f), "utf-8");
+      if (!src.includes("TRIGGERS, ACTUAL")) continue;
+      const note = src.slice(src.indexOf("TRIGGERS, ACTUAL"));
+      expect({ f, explains: /folio|tools\/|platform|owner's decision/i.test(note) }).toEqual({
+        f,
+        explains: true,
+      });
+    }
+  });
+
+  test("the three workflows that DO fire are still wired", () => {
+    // Guards the other direction: this suite must not be satisfiable by
+    // neutering the remaining live triggers and annotating them.
+    const live: Record<string, string[]> = {
+      "code-quality-gates.yml": ["pull_request", "push"],
+      "docs-site.yml": ["push"],
+      "atomic-mass-gen-check.yml": ["pull_request", "push"],
+    };
+    for (const [f, want] of Object.entries(live)) {
+      const t = triggers(readFileSync(join(DIR, f), "utf-8"));
+      for (const w of want) expect({ f, w, has: t.has(w) }).toEqual({ f, w, has: true });
+    }
+  });
+
+  test("no workflow references PR context while unable to receive a PR event", () => {
+    // `wrapper-tests` set `concurrency.group` from
+    // `github.event.pull_request.head.ref` — a field that can never be
+    // populated under dispatch-only, so the expression was dead. Dead
+    // PR-context is the signature of a trigger that was removed without
+    // the body being revisited.
+    const dead: string[] = [];
+    for (const f of FILES) {
+      const src = readFileSync(join(DIR, f), "utf-8");
+      if (triggers(src).has("pull_request") || triggers(src).has("workflow_call")) continue;
+      if (!/github\.event\.pull_request/.test(src)) continue;
+      if (src.includes("TRIGGERS, ACTUAL")) continue;
+      dead.push(f);
+    }
+    expect(dead).toEqual([]);
+  });
+});


### PR DESCRIPTION
Follow-on from the `code-quality-gates` find, one level up. Only **three of 32** workflows have a non-dispatch trigger, and there is no `schedule:` or `cron:` anywhere in the tree — while `qa-sweep-nightly.yml` documents *"schedule — daily at 04:30 UTC"* in its own header.

## It is one migration decision, not 29 oversights

`git log --diff-filter=A` on every workflow: **all 34 arrived in a single commit** — `109a4ff`, the repo split — and every one was `workflow_dispatch`-only at birth, `code-quality-gates` included. Three have acquired a real trigger since, one of them this morning.

The only `cron:` this repo has ever held belonged to a workflow `bc8937a` **deliberately deleted**: a folio's paper-builder image that didn't belong in the platform. The schedules these headers describe were never here to lose.

**And the neutering was right.** The platform carries no `content/<paper>/` (zero paper dirs), no `chapters/`, no `tools/`, no `human-agent-discussions/`. A content sweep here would sweep nothing and report clean — this sweep's own defect class. What was wrong is that *no file said so*, leaving every reader to infer automation that does not exist.

## What changed

Fourteen workflows now carry a `TRIGGERS, ACTUAL:` note naming the real trigger and what the platform lacks. **No trigger was altered.**

`scripts/tests/workflow-triggers.test.ts` is the forcing function: a header may not advertise a trigger its `on:` block lacks unless it carries that note. Verified by stripping the note from `qa-sweep-nightly.yml` and watching the suite go red.

Two of the five tests guard the *other* direction, which matters more — otherwise the suite is satisfiable by neutering the survivors and annotating them:

- the three live workflows must **stay** wired;
- no workflow may reference `github.event.pull_request` while unable to receive a PR event. `wrapper-tests.yml` did exactly that, keying `concurrency.group` off `github.event.pull_request.head.ref`. Dead PR context is the signature of a trigger removed without the body revisited.

## One real gap, deliberately left for you

`build-lean-mcp.yml` is **not** a split artefact. It builds `adapters/mcp-server/Dockerfile` — platform code, present here — and its header promises push-to-main plus twice-weekly rebuilds. It has neither, so the **unified image** that `publish.yml`, `lean-build.yml`, `blueprint.yml` and the local render hooks all depend on is never rebuilt unless someone dispatches it by hand.

I did not wire it. It pushes to GHCR, and its own header says the folio server's self-updater polls for new digests and **auto-deploys**. Enabling that publishes images and triggers live deploys — your call, not mine.

## Guesses checked rather than written down

`deploy-folio.yml` looked like a schedule mismatch; its prose actually says a cron self-updater is *not* needed. `release-please` and `discussions-maintain` looked like outward-facing platform gaps needing a decision — both target directories the platform doesn't carry, so they're ordinary split artefacts.

My first scan also missed `wrapper-tests.yml` outright: the pattern looked for "on every PR" and the header says "Triggered on PRs that…". An incomplete scan reporting as complete — the very thing being fixed — so I widened it to over-report and read every hit by hand.

## Testing

Suite 540 → 545 pass, 0 fail; `tsc --noEmit`, `eslint .`, and a YAML parse over all 33 workflows all clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LL9F9XMXAvKZzjxxhMs2bQ)_