### PR TITLE
feat(intake): pdf-extract.py — a PDF extraction ladder with OCR that never fails silently

### DIFF
--- a/scripts/pdf-extract.py
+++ b/scripts/pdf-extract.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Extract text from a PDF, or say precisely WHY it could not.
+
+WHY THIS EXISTS.  `document-intake` advertises "Handles OCR extraction" and its
+routing table sends scanned PDFs to "Tesseract OCR / Claude vision" -- but
+nothing implemented that, so in practice an agent reached for a Python PDF
+library, got an empty string or an import crash, and had to guess what went
+wrong.  That guessing is the actual cost: an empty extraction looks identical
+whether the file is a scan, the library is broken, or the PDF is malformed.
+
+So this script's contract is: **never return empty silently.**  It either
+produces text, or exits non-zero with a diagnosis naming which rung of the
+ladder failed and what to do next.
+
+THE LADDER (highest fidelity first; broken rungs are skipped, not fatal):
+
+  1. `pdftotext` (poppler)      -- best layout fidelity when installed
+  2. `pypdf`                     -- pure-python, good on modern PDFs
+  3. `pdfminer.six`              -- slower, better on awkward encodings
+  4. built-in stream extractor   -- ZERO dependencies: inflate the content
+                                    streams and read the text-showing operators
+  5. OCR (`tesseract`)           -- only route for a scan; needs a rasteriser
+
+Rung 4 matters more than it looks.  In the container this was written in,
+rungs 1-3 were ALL unavailable (`poppler` absent; `pypdf` and `pdfminer.six`
+both dead because `cryptography`'s Rust bindings segfault on import), and rung 4
+was the only thing that read the papers.  It has no dependencies beyond the
+standard library by design -- it is the rung that still works when the
+environment is broken.
+
+SCAN DETECTION.  Before declaring failure, the script inspects the PDF's
+structure: a file whose pages are `CCITTFaxDecode` / `JBIG2Decode` /
+`DCTDecode` images with little or no `/Font` has **no text layer at all**, and
+no amount of parser-swapping will help.  Saying that explicitly is the
+difference between "try another library" and "you need OCR or a vision model".
+
+Usage:
+    pdf-extract.py FILE.pdf                 # text to stdout
+    pdf-extract.py FILE.pdf -o out.txt      # text to a file
+    pdf-extract.py FILE.pdf --diagnose      # structure report only, no text
+    pdf-extract.py FILE.pdf --max-pages N   # limit (rungs that support it)
+
+Exit codes:
+    0  text extracted
+    2  no text layer -- the file is a scan; use OCR or a vision model
+    3  every rung failed for another reason (details on stderr)
+    4  bad usage / unreadable file
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+import zlib
+from pathlib import Path
+
+# A rung is considered to have produced usable output only if it clears this.
+# Scanned PDFs often yield a handful of stray characters from page furniture;
+# treating those as success is how an agent ends up "reading" an empty paper.
+MIN_USEFUL_CHARS = 200
+
+
+def _guard(fn, *args):
+    """Run a rung, surviving ANY failure short of the user interrupting.
+
+    Deliberately catches `BaseException`, not `Exception`: a broken native
+    extension raises pyo3's `PanicException`, which derives from BaseException
+    and would otherwise kill the whole ladder. That is not hypothetical -- it
+    is exactly how `pypdf` and `pdfminer.six` fail when `cryptography`'s Rust
+    bindings are broken, and it was found by running this script against a real
+    paper. Interrupt and exit signals are re-raised so Ctrl-C still works.
+    """
+    try:
+        return fn(*args)
+    except (KeyboardInterrupt, SystemExit):
+        raise
+    except BaseException as exc:  # noqa: BLE001 -- see docstring
+        return exc
+
+
+# --------------------------------------------------------------------------- #
+# structure diagnosis
+# --------------------------------------------------------------------------- #
+
+def diagnose(path: Path) -> dict:
+    """Classify the PDF by what its pages are actually made of."""
+    data = path.read_bytes()
+    counts = {
+        "bytes": len(data),
+        "font_refs": len(re.findall(rb"/Font", data)),
+        "image_refs": len(re.findall(rb"/Image", data)),
+        "ccitt_or_jbig2": len(re.findall(rb"CCITTFaxDecode|JBIG2Decode", data)),
+        "jpeg": len(re.findall(rb"DCTDecode", data)),
+        "pages": len(re.findall(rb"/Type\s*/Page[^s]", data)),
+    }
+    scan_blocks = counts["ccitt_or_jbig2"] + counts["jpeg"]
+    # Heuristic: many image blocks and few fonts => a scan. Fonts alone do not
+    # prove a text layer (a scan may still embed a font for an OCR sidecar),
+    # which is why the caller only trusts this after extraction has failed.
+    counts["looks_like_scan"] = scan_blocks > 0 and scan_blocks >= counts["font_refs"]
+    return counts
+
+
+def format_diagnosis(path: Path, d: dict) -> str:
+    return (
+        f"{path.name}: {d['bytes']:,} bytes, ~{d['pages']} pages\n"
+        f"  /Font refs        : {d['font_refs']}\n"
+        f"  /Image refs       : {d['image_refs']}\n"
+        f"  CCITTFax/JBIG2    : {d['ccitt_or_jbig2']}  (fax-style scan blocks)\n"
+        f"  DCTDecode (JPEG)  : {d['jpeg']}\n"
+        f"  verdict           : {'SCANNED (no text layer)' if d['looks_like_scan'] else 'has a text layer'}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# the ladder
+# --------------------------------------------------------------------------- #
+
+def try_pdftotext(path: Path, max_pages: int | None) -> str | None:
+    if not shutil.which("pdftotext"):
+        return None
+    cmd = ["pdftotext", "-layout"]
+    if max_pages:
+        cmd += ["-f", "1", "-l", str(max_pages)]
+    cmd += [str(path), "-"]
+    try:
+        out = subprocess.run(cmd, capture_output=True, timeout=300)
+        return out.stdout.decode("utf-8", "replace")
+    except Exception:
+        return None
+
+
+def try_pypdf(path: Path, max_pages: int | None) -> str | None:
+    try:
+        from pypdf import PdfReader  # noqa: PLC0415
+    except BaseException:  # noqa: BLE001 -- PanicException is not an Exception
+        return None  # not installed, or its native crypto backend is broken
+    try:
+        reader = PdfReader(str(path))
+        pages = reader.pages[:max_pages] if max_pages else reader.pages
+        return "\n".join((p.extract_text() or "") for p in pages)
+    except BaseException:  # noqa: BLE001
+        return None
+
+
+def try_pdfminer(path: Path, max_pages: int | None) -> str | None:
+    try:
+        from pdfminer.high_level import extract_text  # noqa: PLC0415
+    except BaseException:  # noqa: BLE001 -- PanicException is not an Exception
+        return None
+    try:
+        return extract_text(str(path), maxpages=max_pages or 0)
+    except BaseException:  # noqa: BLE001
+        return None
+
+
+def try_streams(path: Path, max_pages: int | None = None) -> str | None:
+    """Zero-dependency fallback: inflate content streams, read text operators.
+
+    Handles the common pdflatex/pdftex output shape. Ligatures and custom
+    encodings can come through imperfectly -- this rung trades fidelity for
+    always being available. It is deliberately last-but-one, before OCR.
+    """
+    try:
+        data = path.read_bytes()
+    except Exception:
+        return None
+    chunks: list[str] = []
+    for m in re.finditer(rb"stream\r?\n", data):
+        start = m.end()
+        end = data.find(b"endstream", start)
+        if end < 0:
+            continue
+        try:
+            dec = zlib.decompress(data[start:end])
+        except Exception:
+            continue  # not Flate-compressed, or an image stream
+        parts: list[str] = []
+        for tm in re.finditer(rb"\((?:\\.|[^\\()])*\)", dec):
+            tok = tm.group()[1:-1]
+            tok = (tok.replace(rb"\(", b"(")
+                      .replace(rb"\)", b")")
+                      .replace(rb"\\", b"\\"))
+            parts.append(tok.decode("latin-1"))
+        if parts:
+            chunks.append("".join(parts))
+        if max_pages and len(chunks) >= max_pages:
+            break
+    return "\n".join(chunks) if chunks else None
+
+
+def try_ocr(path: Path, max_pages: int | None) -> str | None:
+    """OCR a scan. Needs BOTH a rasteriser and tesseract; reports which is absent."""
+    tesseract = shutil.which("tesseract")
+    raster = shutil.which("pdftoppm")
+    if not tesseract or not raster:
+        missing = [n for n, p in (("tesseract", tesseract), ("pdftoppm", raster)) if not p]
+        print(f"[ocr] unavailable, missing: {', '.join(missing)}", file=sys.stderr)
+        return None
+    import tempfile  # noqa: PLC0415
+    with tempfile.TemporaryDirectory() as td:
+        cmd = [raster, "-r", "300", "-png"]
+        if max_pages:
+            cmd += ["-f", "1", "-l", str(max_pages)]
+        cmd += [str(path), f"{td}/page"]
+        try:
+            subprocess.run(cmd, capture_output=True, timeout=1800, check=True)
+        except Exception as exc:
+            print(f"[ocr] rasterising failed: {exc}", file=sys.stderr)
+            return None
+        out: list[str] = []
+        for png in sorted(Path(td).glob("page*.png")):
+            try:
+                r = subprocess.run([tesseract, str(png), "stdout"],
+                                   capture_output=True, timeout=600)
+                out.append(r.stdout.decode("utf-8", "replace"))
+            except Exception:
+                continue
+        return "\n".join(out) if out else None
+
+
+LADDER = [
+    ("pdftotext (poppler)", try_pdftotext),
+    ("pypdf", try_pypdf),
+    ("pdfminer.six", try_pdfminer),
+    ("built-in stream extractor", try_streams),
+    ("OCR (tesseract)", try_ocr),
+]
+
+
+def extract(path: Path, max_pages: int | None, verbose: bool = True):
+    """Walk the ladder. Returns (text, rung_name) or (None, None)."""
+    for name, fn in LADDER:
+        text = _guard(fn, path, max_pages)
+        if isinstance(text, BaseException):
+            if verbose:
+                kind = type(text).__name__
+                print(f"[skip] {name}: {kind}: {text}", file=sys.stderr)
+            continue
+        if text and len(text.strip()) >= MIN_USEFUL_CHARS:
+            if verbose:
+                print(f"[ok] extracted with: {name} "
+                      f"({len(text.strip()):,} chars)", file=sys.stderr)
+            return text, name
+        if verbose:
+            got = len(text.strip()) if text else 0
+            print(f"[skip] {name}: {got} chars (< {MIN_USEFUL_CHARS} threshold)",
+                  file=sys.stderr)
+    return None, None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("pdf", type=Path)
+    ap.add_argument("-o", "--out", type=Path, help="write text here instead of stdout")
+    ap.add_argument("--diagnose", action="store_true", help="structure report only")
+    ap.add_argument("--max-pages", type=int, default=None)
+    ap.add_argument("-q", "--quiet", action="store_true")
+    args = ap.parse_args()
+
+    if not args.pdf.is_file():
+        print(f"error: not a file: {args.pdf}", file=sys.stderr)
+        return 4
+
+    d = diagnose(args.pdf)
+    if args.diagnose:
+        print(format_diagnosis(args.pdf, d))
+        return 0
+
+    text, rung = extract(args.pdf, args.max_pages, verbose=not args.quiet)
+
+    if text is None:
+        print(format_diagnosis(args.pdf, d), file=sys.stderr)
+        if d["looks_like_scan"]:
+            print(
+                "\nNO TEXT LAYER. This file is a scan, so no parser will ever read\n"
+                "it -- swapping PDF libraries is wasted effort. Options:\n"
+                "  * install OCR:  apt-get install -y tesseract-ocr poppler-utils\n"
+                "                  then re-run this script (the OCR rung will fire)\n"
+                "  * or read the pages with a vision model, per\n"
+                "    document-intake.md's routing table.\n",
+                file=sys.stderr)
+            return 2
+        print(
+            "\nEvery rung failed, but the file DOES appear to have a text layer,\n"
+            "so this is a parser problem rather than a scan. Try installing\n"
+            "poppler-utils (rung 1) -- and note rungs 2-3 fail silently when\n"
+            "`cryptography`'s native bindings are broken, which is not obvious\n"
+            "from their error.\n",
+            file=sys.stderr)
+        return 3
+
+    if args.out:
+        args.out.write_text(text, encoding="utf-8")
+        if not args.quiet:
+            print(f"[ok] wrote {args.out} ({len(text):,} chars) via {rung}",
+                  file=sys.stderr)
+    else:
+        sys.stdout.write(text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pdf-extract.py
+++ b/scripts/pdf-extract.py
@@ -28,11 +28,20 @@ was the only thing that read the papers.  It has no dependencies beyond the
 standard library by design -- it is the rung that still works when the
 environment is broken.
 
-SCAN DETECTION.  Before declaring failure, the script inspects the PDF's
-structure: a file whose pages are `CCITTFaxDecode` / `JBIG2Decode` /
-`DCTDecode` images with little or no `/Font` has **no text layer at all**, and
-no amount of parser-swapping will help.  Saying that explicitly is the
-difference between "try another library" and "you need OCR or a vision model".
+SCAN DETECTION, AND ITS ONE TRAP.  The script inspects the PDF's structure:
+pages made of `CCITTFaxDecode` / `JBIG2Decode` / `DCTDecode` images with little
+`/Font` indicate a scan.  **But "is a scan" does NOT imply "has no text
+layer."**  Publisher scans very often carry an embedded OCR sidecar, which
+`pdftotext` reads perfectly while every other rung here returns nothing --
+including rung 4, because the sidecar is not laid out like pdflatex content
+streams.  This was found the hard way: a 1985 Elsevier scan (658 CCITTFax
+blocks) was reported "no parser will ever read this", and then poppler read
+79,231 characters out of it.
+
+So a scan verdict is only ever reported ALONGSIDE which rungs were actually
+available, and if `pdftotext` was missing the script says to install poppler
+FIRST rather than reaching for OCR or a vision model.  Never conclude "no text
+layer" from the image counts alone.
 
 Usage:
     pdf-extract.py FILE.pdf                 # text to stdout
@@ -275,11 +284,28 @@ def main() -> int:
     if text is None:
         print(format_diagnosis(args.pdf, d), file=sys.stderr)
         if d["looks_like_scan"]:
+            have_poppler = shutil.which("pdftotext") is not None
+            if not have_poppler:
+                # The important case: a scan may still carry an embedded OCR
+                # sidecar that ONLY pdftotext reads. Do not send the user to
+                # OCR or a vision model before that has been tried.
+                print(
+                    "\nSCAN-LIKE STRUCTURE, and `pdftotext` is NOT INSTALLED --\n"
+                    "so this is NOT yet evidence that the file lacks a text layer.\n"
+                    "Publisher scans frequently embed an OCR sidecar that poppler\n"
+                    "reads and the other rungs cannot. Do this FIRST:\n"
+                    "    apt-get install -y poppler-utils\n"
+                    "then re-run. Only if rung 1 also comes back empty is the file\n"
+                    "genuinely imageonly, and OCR/vision the right answer:\n"
+                    "    apt-get install -y tesseract-ocr\n",
+                    file=sys.stderr)
+                return 2
             print(
-                "\nNO TEXT LAYER. This file is a scan, so no parser will ever read\n"
-                "it -- swapping PDF libraries is wasted effort. Options:\n"
+                "\nNO TEXT LAYER. `pdftotext` IS installed and still found nothing,\n"
+                "so this file is image-only -- swapping PDF libraries is wasted\n"
+                "effort. Options:\n"
                 "  * install OCR:  apt-get install -y tesseract-ocr poppler-utils\n"
-                "                  then re-run this script (the OCR rung will fire)\n"
+                "                  then re-run (the OCR rung will fire)\n"
                 "  * or read the pages with a vision model, per\n"
                 "    document-intake.md's routing table.\n",
                 file=sys.stderr)

--- a/skills/folio-paper-adapter/document-intake.md
+++ b/skills/folio-paper-adapter/document-intake.md
@@ -118,17 +118,48 @@ per [`bib-qa.md §Batch intake pipeline`](bib-qa.md#batch-intake-pipeline).
 
 Convert raw format to `extracted-text.md`:
 
+**For PDFs, always start with
+[`scripts/pdf-extract.py`](../../scripts/pdf-extract.py)** — do not reach for a
+Python PDF library directly. It walks a fallback ladder (`pdftotext` → `pypdf` →
+`pdfminer.six` → a zero-dependency content-stream extractor → OCR) and, when it
+cannot read a file, **tells you which rung failed and why** instead of returning
+an empty string:
+
+```bash
+python3 scripts/pdf-extract.py FILE.pdf -o extracted-text.md
+python3 scripts/pdf-extract.py FILE.pdf --diagnose   # structure only
+```
+
+Exit `0` = text; **exit `2` = no text layer (a scan)**; exit `3` = a parser
+problem on a file that does have text.
+
+Two failure modes it exists to prevent, both observed in practice:
+
+* **A silent empty extraction reads exactly like a scan, a broken library, and
+  a malformed PDF.** The script separates them by inspecting the PDF structure
+  (`CCITTFaxDecode` / `JBIG2Decode` / `DCTDecode` counts against `/Font`), so
+  "swap libraries" vs "you need OCR" is decided by evidence rather than guessed.
+* **A broken native extension kills the whole pipeline.** `pypdf` and
+  `pdfminer.six` both fail via pyo3 `PanicException` when `cryptography`'s Rust
+  bindings are broken — and that is a `BaseException`, so an ordinary
+  `except Exception` does **not** catch it. Every rung is guarded accordingly.
+  The zero-dependency rung exists precisely for this case; in the container this
+  was written in it was the only rung that worked.
+
 | Format | Extraction method |
 |--------|-------------------|
-| PDF (text) | `pdftotext` or PDF.js |
-| PDF (scan) | Tesseract OCR / Claude vision |
+| PDF (text) | `scripts/pdf-extract.py` (ladder; `pdftotext` when available) |
+| PDF (scan) | `scripts/pdf-extract.py` → exit 2, then Tesseract OCR / Claude vision |
 | LaTeX | Direct parse (strip preamble) |
 | HTML | Readability + turndown |
 | DOCX | Pandoc → markdown |
 | Images | Claude vision API |
 
-For scanned documents, use Claude's vision capability to extract
-text with structural awareness (headings, lists, tables, boxes).
+For scanned documents the script's OCR rung fires automatically **if**
+`tesseract` and `pdftoppm` are installed (`apt-get install -y tesseract-ocr
+poppler-utils`); it names whichever is missing. Where OCR is unavailable, or
+where layout carries meaning (headings, lists, tables, boxes), fall back to
+Claude's vision capability, which reads structure that OCR flattens.
 
 **Output**: `extracted-text.md` — raw markdown with preserved structure.
 


### PR DESCRIPTION
`document-intake` advertises *"Handles OCR extraction"* and routes scanned PDFs to *"Tesseract OCR / Claude vision"* — but **nothing implemented that**. In practice an agent reaches for a Python PDF library, gets an empty string or an import crash, and has to guess which of three very different problems it hit.

That guessing is the real cost: **an empty extraction looks identical whether the file is a scan, the library is broken, or the PDF is malformed.**

The script's contract: **never return empty silently.** Either text, or a non-zero exit naming the rung that failed and the next action.

## The ladder

Broken rungs are skipped, not fatal:

1. `pdftotext` (poppler) — best fidelity, and (see below) the *only* rung that reads OCR sidecars
2. `pypdf`
3. `pdfminer.six`
4. **built-in stream extractor** — zero dependencies: inflate content streams, read text-showing operators
5. **OCR** (`tesseract` + `pdftoppm`)

## Three findings, each from running it rather than reasoning about it

**1. A broken native extension raises `PanicException`, which derives from `BaseException`** — so `except Exception` does *not* catch it and the whole ladder dies. My first version had exactly that bug; testing on a real paper found it. Every rung is now guarded at `BaseException` level, re-raising `KeyboardInterrupt`/`SystemExit`. This is the concrete reason "just use pypdf" isn't a substitute for a ladder.

**2. Rung 4 is not a curiosity.** In the container this was written in, rungs 1–3 were *all* unavailable — poppler absent, `pypdf`/`pdfminer.six` both dead on the `cryptography` panic. Rung 4 was the only thing that read anything.

**3. ⚠️ I shipped a confidently wrong verdict, then disproved it.** The first revision reported Neumann–Zagier 1985 (658 CCITTFax blocks) as **"NO TEXT LAYER … no parser will ever read it"**. I then installed poppler to test the OCR rung — and `pdftotext` read **79,231 characters** out of it.

> **"Is a scan" does NOT imply "has no text layer."** Publisher scans very often carry an embedded **OCR sidecar** that `pdftotext` reads perfectly and every other rung returns nothing for — including rung 4, because the sidecar isn't laid out like pdflatex content streams.

The behaviour was worse than a wrong message: it routed the user **away** from the one tool that works, toward OCR and vision models, for a file plain poppler reads. Fixed — a scan verdict is now reported alongside *which rungs were actually available*:

| state | verdict |
|---|---|
| `pdftotext` **missing** | *"SCAN-LIKE STRUCTURE, and `pdftotext` is NOT INSTALLED — so this is NOT yet evidence of no text layer. Install `poppler-utils` FIRST and re-run."* |
| `pdftotext` present, still empty | *"NO TEXT LAYER … genuinely image-only"* — the original message, now only issued when it's earned |

Never conclude "no text layer" from image counts alone; the docstring says so, with this incident as the reason.

## Verified — all three paths

| case | result |
|---|---|
| Milnor 1982 (text layer) | **40,510 chars** via rung 1, exit 0 |
| Neumann–Zagier 1985 (scan + OCR sidecar) | **79,231 chars** via rung 1, exit 0 |
| same file, `PATH` stripped of poppler | exit 2 with install-poppler-first guidance — i.e. the exact container state that produced the bad verdict now gives correct advice |
| earlier container (rungs 1–3 all broken) | rung 4 extracted 36,209 chars from Milnor, exit 0 |

## Interface

```bash
python3 scripts/pdf-extract.py FILE.pdf -o extracted-text.md
python3 scripts/pdf-extract.py FILE.pdf --diagnose   # structure only
```

Exit `0` text · `2` scan-like and unread · `3` parser problem on a file that *does* have text · `4` bad usage.

`document-intake.md`'s Stage-2 table now routes PDFs here first, instead of naming tools that were never wired up.

## Scope

- Rung 4 trades fidelity for availability — ligatures and custom encodings come through imperfectly. It sits below the real parsers deliberately, above OCR.
- **The OCR rung itself is still not exercised on a genuinely image-only file** — every scan I have carries a sidecar, so rung 1 wins before OCR is reached. What *is* tested is that it detects and names missing binaries. I'd want a truly image-only PDF before calling rung 5 verified.
- No dependency added: rungs 2/3 are used only if already importable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019HNN2UkPQLYjh3REHJboCq