### PR TITLE
Per-block standalone PDFs + the block_pdf_render gate (render half of #65, rebased)

### DIFF
--- a/.claude/commands/prepare-merge.md
+++ b/.claude/commands/prepare-merge.md
@@ -47,6 +47,11 @@ Prefer the MCP tools (structured findings) when connected; otherwise the scripts
 - `qa_sweep` — no critical findings (dry-run).
 - `proof_status` — no regression in sorry/coverage for changed blocks.
 - `latex_preflight` — no new unknown macros / overfull boxes.
+- `block_pdf_render` — for each changed block, compile a standalone PDF and
+  resolve LaTeX errors; overfull boxes on changed content are advisory.
+  Run: `bun run scripts/render-changed-blocks.ts`. Needs local `latexmk` —
+  when it is absent the gate cannot run, and that is reported as **not run**,
+  never as a pass.
 - `lean_build` / `lean_check` — build green (or unchanged) for touched packages.
   **Check what the target covers before quoting its result.** `lake build`
   compiles the root module plus its transitive imports, not the source tree

--- a/.claude/skills/local/prepare-merge.md
+++ b/.claude/skills/local/prepare-merge.md
@@ -56,6 +56,18 @@ the one recipe.
    name), and scope any corpus-wide number you quote to what actually ran. In
    qou, `lake build` reaches 853 of 1618 Lean modules, so a touched file can be
    green purely by never having been compiled.
+
+   For `contentType: paper` branches that touch content blocks, also run the
+   **`block_pdf_render`** gate:
+   ```
+   bun run scripts/render-changed-blocks.ts
+   ```
+   This compiles a standalone PDF for every changed block and scrapes the
+   LaTeX log. Exits 1 on LaTeX errors (fix required); exits 0 with warnings
+   only (advisory); exits 2 on setup problems — including **no local
+   `latexmk`**, which is the common case in a container. Exit 2 means the gate
+   did **not run**; report it that way rather than folding it into a green,
+   per the same honesty rule as the build above.
 6. **Push** the feature branch (retry/backoff as in step 2):
    `git push -u origin <branch>`.
 7. **Dispatch the repo's CI on the pushed branch, and fold the result into the

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ dist/
 *.log
 .DS_Store
 
+# Build outputs — regenerate locally, never commit
+build/
+
 # Generated files — regenerate with `npm run generate:all`
 schemas/generated/
 content/audit-tex-source.json

--- a/adapters/paper/tools/render.ts
+++ b/adapters/paper/tools/render.ts
@@ -12,8 +12,9 @@
 import { z } from "zod";
 import { execSync, spawnSync } from "child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
-import { join } from "path";
+import { join, resolve, dirname } from "path";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Paper } from "../../../schemas/types";
 import { REPO_ROOT, BUILD_DIR, MAIN_TEX, CHAPTERS_DIR } from "../paths.js";
 // Note: paths are resolved from the paper adapter's paths module.
 
@@ -33,13 +34,14 @@ export function registerRenderTools(server: McpServer): void {
 
   server.tool(
     "paper_render_pdf",
-    "Render the paper (or a chapter/section) to PDF using latexmk. " +
-    "Returns the path to the generated PDF.",
+    "Render the paper (or a chapter/section/block) to PDF using latexmk. " +
+    "Returns the path to the generated PDF and a scraped log summary.",
     {
-      scope: z.enum(["full", "chapter", "section"]).default("full")
-        .describe("What to render: full paper, single chapter, or section"),
+      scope: z.enum(["full", "chapter", "section", "block"]).default("full")
+        .describe("What to render: full paper, single chapter, section, or individual content block"),
       target: z.string().optional()
-        .describe("Chapter or section identifier (e.g. 'quantum-observable-universe'). Required if scope != full."),
+        .describe("Chapter, section, or block identifier. Required if scope != full. " +
+          "For blocks, use the block root name (e.g. 'def-observable')."),
       engine: z.enum(["pdflatex", "lualatex", "xelatex"]).default("pdflatex")
         .describe("LaTeX engine to use"),
       clean: z.boolean().default(false)
@@ -62,7 +64,87 @@ export function registerRenderTools(server: McpServer): void {
       if (!existsSync(BUILD_DIR)) mkdirSync(BUILD_DIR, { recursive: true });
 
       try {
-        // Determine what to build
+        // ── Block render ─────────────────────────────────────────────────────
+        if (scope === "block") {
+          if (!target) {
+            return { content: [{ type: "text" as const, text: "Error: --target required for scope=block (block root name, e.g. 'def-observable')" }] };
+          }
+          const blockPdfsDir = join(BUILD_DIR, "block-pdfs");
+          mkdirSync(blockPdfsDir, { recursive: true });
+
+          // Find the block's .ts and .md in content/
+          const contentDir = join(REPO_ROOT, "content");
+          const found = spawnSync("find", [contentDir, "-name", `${target}.ts`, "-not", "-path", "*/node_modules/*"], {
+            stdio: "pipe",
+          });
+          const tsPath = found.stdout?.toString().trim().split("\n").find(p => p);
+          if (!tsPath || !existsSync(tsPath)) {
+            return { content: [{ type: "text" as const, text: `Error: block '${target}' not found under content/` }] };
+          }
+          const blockDir = dirname(tsPath);
+          const mdPath = join(blockDir, `${target}.md`);
+          const preamblePath = join(REPO_ROOT, "latex", "preamble.tex");
+
+          // Load paper manifest (first parent .ts in the paper dir)
+          const paperDirParts = blockDir.replace(contentDir + "/", "").split("/");
+          const paperSlug = paperDirParts[0];
+          const paperManifestPath = join(contentDir, paperSlug, `${paperSlug}.ts`);
+          let paper: Paper;
+          try {
+            const paperMod = await import(paperManifestPath);
+            paper = paperMod.default as Paper;
+          } catch {
+            return { content: [{ type: "text" as const, text: `Error: could not load paper manifest: ${paperManifestPath}` }] };
+          }
+
+          const blockMod = await import(tsPath);
+          const block = blockMod.default;
+          const mdContent = existsSync(mdPath) ? readFileSync(mdPath, "utf-8") : "";
+          const sourceDir = resolve(blockDir).replace(REPO_ROOT + "/", "");
+
+          const { generateBlockStandaloneTex } = await import(
+            join(REPO_ROOT, "content", "pipeline", "generate-block-tex.ts")
+          );
+          const texContent = generateBlockStandaloneTex(
+            paper, block, mdContent, target, sourceDir,
+            { preamblePath, bibliographyPath: join(REPO_ROOT, "references") },
+          );
+          const texPath = join(blockPdfsDir, `${target}.tex`);
+          writeFileSync(texPath, texContent);
+
+          const engineFlag = engine === "pdflatex" ? "-pdf" : engine === "lualatex" ? "-lualatex" : "-xelatex";
+          const compileResult = spawnSync("latexmk", [
+            engineFlag,
+            `-jobname=${target}`,
+            `-output-directory=${blockPdfsDir}`,
+            "-interaction=nonstopmode",
+            "-file-line-error",
+            texPath,
+          ], { cwd: REPO_ROOT, stdio: "pipe", timeout: 120_000 });
+
+          const pdfPath = join(blockPdfsDir, `${target}.pdf`);
+          const logPath = join(blockPdfsDir, `${target}.log`);
+          const logText = existsSync(logPath) ? readFileSync(logPath, "utf-8") : compileResult.stdout?.toString() ?? "";
+
+          // Scrape log for human-relevant output only
+          const relevantLog = logText.split("\n")
+            .filter(l => /^! |^Overfull \\[hv]box|LaTeX Warning: Reference|LaTeX Error:/.test(l))
+            .slice(0, 40).join("\n");
+
+          const ok = compileResult.status === 0 && existsSync(pdfPath);
+
+          return {
+            content: [{
+              type: "text" as const,
+              text: ok
+                ? `Block PDF: ${pdfPath}\nSize: ${(readFileSync(pdfPath).length / 1024).toFixed(0)} KB` +
+                  (relevantLog ? `\n\nLog issues:\n${relevantLog}` : "")
+                : `Block compilation failed (exit ${compileResult.status}).\n\nLog issues:\n${relevantLog || logText.slice(-2000)}`,
+            }],
+          };
+        }
+
+        // ── Full / chapter render ────────────────────────────────────────────
         let texFile = MAIN_TEX;
         let jobName = "quantum-observable-universe";
 

--- a/content/pipeline/generate-block-tex.ts
+++ b/content/pipeline/generate-block-tex.ts
@@ -1,0 +1,201 @@
+/**
+ * Generate a per-block standalone .tex file for independent compilation.
+ *
+ * Each block is wrapped in a minimal but complete LaTeX document that uses
+ * the same shared preamble and paper macros as the full paper, so the
+ * typography, environments (\begin{theorem}, \begin{definition}, etc.) and
+ * custom commands are identical to what the reader will see in the published
+ * PDF.
+ *
+ * Design decisions:
+ *   - \documentclass{book} (not \standalone) so the block environments defined
+ *     in the shared preamble (which targets book/report geometry) compile
+ *     without modification.
+ *   - Margin annotations (\blockannot, \chapterannot, \sectionannot,
+ *     \marginnote, \blockmargin) are stripped: they reference a live GitHub
+ *     repo URL and require the full margin layout — neither is meaningful in
+ *     a single-block preview PDF.
+ *   - Cross-references (\hyperref, \nameref, \uses) are preserved: pdflatex
+ *     will emit "reference undefined" warnings but will NOT error.  The log
+ *     scraper in render-changed-blocks.ts treats these as warnings, not errors.
+ *   - A \bibliographystyle + \bibliography tail is emitted so \cite{} calls
+ *     resolve when a references.bib file is present; if it is absent pdflatex
+ *     only warns.
+ *
+ * Usage (from the CLI in render-changed-blocks.ts, or directly):
+ *   import { generateBlockStandaloneTex } from "./generate-block-tex";
+ *
+ * @module content/pipeline/generate-block-tex
+ */
+
+import { readFileSync } from "fs";
+import type { Paper, Block } from "../../schemas/types";
+import { renderBlock } from "./render-latex";
+
+// ── Annotation macros to strip from standalone output ────────────────────────
+// These macros are defined in the full preamble but depend on full-paper
+// context (margin layout, live GitHub links, tracker integrations).  They are
+// safe to no-op in a standalone block preview.
+const ANNOTATION_MACROS = [
+  "blockannot",
+  "chapterannot",
+  "sectionannot",
+  "blockmargin",
+];
+
+/**
+ * Strip annotation macro calls from rendered LaTeX.
+ *
+ * Handles both optional-argument forms:
+ *   \blockannot[status]{label}{decl}{path}
+ *   \blockannot{label}{decl}{path}
+ * and the simpler:
+ *   \chapterannot{slug}{label}
+ *   \sectionannot{label}
+ *
+ * Strategy: replace each \macroname[...]{...}{...}... call with an empty
+ * string.  We remove the whole call including all brace groups that follow
+ * (up to 4 groups) and an optional [...] prefix argument.
+ */
+function stripAnnotations(latex: string): string {
+  let result = latex;
+  for (const macro of ANNOTATION_MACROS) {
+    // Match: \macroname followed by optional [arg] then 1–4 {arg} groups.
+    // Uses a simple iterative replacement (no regex backtracking on nested
+    // braces) — sufficient because annotation arguments never contain
+    // nested braces deeper than one level.
+    const re = new RegExp(
+      `\\\\${macro}(?:\\[[^\\]]*\\])?(?:\\{[^}]*\\}){1,4}`,
+      "g",
+    );
+    result = result.replace(re, "");
+  }
+  // Also strip bare \marginnote[...]{...} which the preamble defines for
+  // margin content — standalone pages have no margin layout to put it in.
+  result = result.replace(/\\marginnote(?:\[[^\]]*\])?\{[^}]*\}/g, "");
+  return result;
+}
+
+/**
+ * Escape text for use in LaTeX metadata fields (title, author).
+ * Uses a single-pass function callback so backslash is never interpreted
+ * as a replacement pattern (avoids incomplete-sanitization).
+ */
+function escapeLatexMeta(text: string): string {
+  const escapes: Record<string, string> = {
+    "\\": "\\textbackslash{}",
+    "&": "\\&",
+    "#": "\\#",
+    "%": "\\%",
+    "_": "\\_",
+  };
+  return text.replace(/[\\&#%_]/g, (ch) => escapes[ch] ?? ch);
+}
+
+export interface BlockStandaloneOptions {
+  /** Path to the shared preamble.tex. */
+  preamblePath: string;
+  /**
+   * Working directory for \bibliography{references}.
+   * latexmk must be run from a directory where references.bib can be found,
+   * or this path can be an absolute path to the .bib file (without extension).
+   * Defaults to "references" (relative).
+   */
+  bibliographyPath?: string;
+}
+
+/**
+ * Generate a standalone .tex document for a single content block.
+ *
+ * @param paper      - The paper manifest (for title, authors, macros).
+ * @param block      - The block manifest object.
+ * @param mdContent  - The block's .md narrative content.
+ * @param blockName  - The block's root name (e.g. "def-observable").
+ * @param sourceDir  - The block's chapter directory, relative to repo root
+ *                     (e.g. "content/quantum-observable-universe/ch1-setup").
+ *                     Used for the source-link in \blockannot (stripped here,
+ *                     but passed through to renderBlock for completeness).
+ * @param opts       - Options: preamble path, bibliography path.
+ * @returns Complete LaTeX source for a standalone compilable document.
+ */
+export function generateBlockStandaloneTex(
+  paper: Paper,
+  block: Block,
+  mdContent: string,
+  blockName: string,
+  sourceDir: string | undefined,
+  opts: BlockStandaloneOptions,
+): string {
+  const lines: string[] = [];
+
+  // ── 1. Shared preamble (inlined) ──────────────────────────────────────────
+  const preamble = readFileSync(opts.preamblePath, "utf-8");
+  lines.push(preamble.trimEnd());
+  lines.push("");
+
+  // ── 2. Paper macros ───────────────────────────────────────────────────────
+  if (paper.macros && Object.keys(paper.macros).length > 0) {
+    lines.push("% ── Paper macros ────────────────────────────────────────────────────────────");
+    for (const [name, macro] of Object.entries(paper.macros)) {
+      const comment = macro.unicode ? `  % ${macro.unicode}` : "";
+      lines.push(`\\newcommand{\\${name}}{${macro.tex}}${comment}`);
+    }
+    lines.push("");
+  }
+
+  // ── 3. Standalone-mode annotation no-ops ──────────────────────────────────
+  // Re-define annotation macros as no-ops so any stray call that the regex
+  // stripper misses (e.g. in raw \tex blocks) doesn't abort compilation.
+  lines.push("% ── Annotation no-ops (standalone preview) ─────────────────────────────────");
+  lines.push("\\renewcommand{\\blockannot}[4][]{}");
+  lines.push("\\renewcommand{\\chapterannot}[2]{}");
+  lines.push("\\renewcommand{\\sectionannot}[1]{}");
+  lines.push("\\renewcommand{\\marginnote}[2][]{}");
+  lines.push("");
+
+  // ── 4. Metadata ───────────────────────────────────────────────────────────
+  const blockTitle = ("title" in block && block.title)
+    ? String(block.title)
+    : ("label" in block && block.label)
+      ? String(block.label)
+      : blockName;
+  const authorName = escapeLatexMeta(paper.authors[0] || "");
+  lines.push("% ── Metadata ────────────────────────────────────────────────────────────────");
+  lines.push(`\\title{${escapeLatexMeta(blockTitle)} \\\\ {\\small ${escapeLatexMeta(paper.title)}}}`);
+  lines.push(`\\author{${authorName}}`);
+  lines.push(`\\date{${paper.date ? escapeLatexMeta(paper.date) : "\\today"}}`);
+  lines.push("");
+  lines.push("\\hypersetup{");
+  lines.push(`  pdftitle  = {${escapeLatexMeta(blockTitle)}},`);
+  lines.push(`  pdfauthor = {${escapeLatexMeta(paper.authors.join(", "))}},`);
+  lines.push("  colorlinks = true,");
+  lines.push("  linkcolor  = blue,");
+  lines.push("  citecolor  = blue,");
+  lines.push("  urlcolor   = blue,");
+  lines.push("}");
+  lines.push("");
+
+  // ── 5. Document body ──────────────────────────────────────────────────────
+  lines.push("\\begin{document}");
+  lines.push("\\maketitle");
+  lines.push("");
+
+  // Render the block using the same pipeline as the full paper.
+  const blockLatex = renderBlock(block, mdContent, sourceDir, blockName);
+  // Strip margin annotations (belt-and-suspenders on top of the \renewcommand
+  // no-ops above — the regex catches calls emitted by renderBlock itself).
+  const cleanLatex = stripAnnotations(blockLatex);
+  lines.push(cleanLatex);
+  lines.push("");
+
+  // ── 6. Bibliography tail ──────────────────────────────────────────────────
+  // Emitting these unconditionally is harmless when no .bib is present —
+  // pdflatex warns but does not error.
+  const bibPath = opts.bibliographyPath ?? "references";
+  lines.push("\\bibliographystyle{plain}");
+  lines.push(`\\bibliography{${bibPath}}`);
+  lines.push("");
+  lines.push("\\end{document}");
+
+  return lines.join("\n") + "\n";
+}

--- a/scripts/docker-latex-build/build-pdf.sh
+++ b/scripts/docker-latex-build/build-pdf.sh
@@ -136,4 +136,16 @@ for tex in standalone-*.tex; do
     latexmk $LATEXMK_FLAGS "$tex"
 done
 
+# ── Step 4: Split PDF by chapter ─────────────────────────────────
+PDF_SPLIT_DIR="$REPO_ROOT/build/pdf-split"
+if command -v python3 &>/dev/null; then
+  echo "==> Splitting main.pdf by chapter..."
+  mkdir -p "$PDF_SPLIT_DIR"
+  python3 "$REPO_ROOT/scripts/split-pdf-by-chapter.py" \
+    --pdf "$REPO_ROOT/main.pdf" \
+    --paper "$PAPER" \
+    --out-dir "$PDF_SPLIT_DIR" \
+    || echo "  ⚠ PDF split failed (non-fatal)"
+fi
+
 echo "==> Build complete."

--- a/scripts/render-changed-blocks.ts
+++ b/scripts/render-changed-blocks.ts
@@ -1,0 +1,453 @@
+#!/usr/bin/env bun
+/**
+ * render-changed-blocks.ts — Render per-block standalone PDFs for every
+ * content block touched by the current branch (or an explicit file list),
+ * and scrape the LaTeX logs for human-relevant feedback.
+ *
+ * This script is the key loop in the `block_pdf_render` prepare-merge gate
+ * (see .claude/commands/prepare-merge.md) and is also called from the
+ * render-on-change hook after every content edit.
+ *
+ * Output is local only: PDFs land under `build/block-pdfs/` and a JSON
+ * report beside them. Nothing leaves the machine.
+ *
+ * Usage:
+ *   bun run scripts/render-changed-blocks.ts
+ *   bun run scripts/render-changed-blocks.ts --paper quantum-observable-universe
+ *   bun run scripts/render-changed-blocks.ts --base main
+ *   bun run scripts/render-changed-blocks.ts --files content/paper/ch/block.ts
+ *   bun run scripts/render-changed-blocks.ts --all   # render every block in paper
+ *
+ * Exit codes:
+ *   0  all blocks rendered clean (or only warnings)
+ *   1  one or more blocks had LaTeX errors
+ *   2  setup error (no manifest, no pdflatex, etc.)
+ *
+ * @module scripts/render-changed-blocks
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "fs";
+import { join, resolve, relative, basename } from "path";
+import { spawnSync } from "child_process";
+import type { Paper } from "../schemas/types";
+
+// ── Repo layout ──────────────────────────────────────────────────────────────
+
+const REPO_ROOT = resolve(import.meta.dir, "..");
+const CONTENT_DIR = join(REPO_ROOT, "content");
+const PREAMBLE_PATH = join(REPO_ROOT, "latex", "preamble.tex");
+const BLOCK_PDFS_DIR = join(REPO_ROOT, "build", "block-pdfs");
+
+// ── Arg parsing ──────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+
+function argVal(flag: string, fallback?: string): string | undefined {
+  const idx = args.indexOf(flag);
+  return idx >= 0 && args[idx + 1] ? args[idx + 1] : fallback;
+}
+function hasFlag(flag: string): boolean {
+  return args.includes(flag);
+}
+
+const PAPER = argVal("--paper", "quantum-observable-universe")!;
+const BASE = argVal("--base", "");               // git base ref for diff
+const RENDER_ALL = hasFlag("--all");
+const EXPLICIT_FILES = args.filter(a => !a.startsWith("--") && (a.endsWith(".ts") || a.endsWith(".md")));
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function hasCommand(cmd: string): boolean {
+  const r = spawnSync("which", [cmd], { stdio: "pipe" });
+  return r.status === 0;
+}
+
+// ── Find changed block files via git diff ────────────────────────────────────
+
+function getChangedBlockFiles(): string[] {
+  if (EXPLICIT_FILES.length > 0) return EXPLICIT_FILES.map(f => resolve(f));
+
+  const paperDir = join(CONTENT_DIR, PAPER);
+  if (!existsSync(paperDir)) {
+    console.error(`[render-changed-blocks] Paper directory not found: ${paperDir}`);
+    process.exit(2);
+  }
+
+  // Determine base ref: explicit --base, or merge-base with default branch, or HEAD~1
+  let base = BASE;
+  if (!base) {
+    // Try to find the remote default branch merge-base
+    const defaultBranch = spawnSync("git", ["remote", "show", "origin"], {
+      cwd: REPO_ROOT, stdio: "pipe",
+    });
+    const m = defaultBranch.stdout?.toString().match(/HEAD branch: (\S+)/);
+    const defaultRef = m ? `origin/${m[1]}` : "origin/main";
+    const mergeBase = spawnSync("git", ["merge-base", "HEAD", defaultRef], {
+      cwd: REPO_ROOT, stdio: "pipe",
+    });
+    base = mergeBase.status === 0
+      ? mergeBase.stdout.toString().trim()
+      : "HEAD~1";
+  }
+
+  const diff = spawnSync("git", ["diff", "--name-only", `${base}...HEAD`], {
+    cwd: REPO_ROOT, stdio: "pipe",
+  });
+  if (diff.status !== 0) {
+    // Fallback: uncommitted changes
+    const status = spawnSync("git", ["diff", "--name-only"], {
+      cwd: REPO_ROOT, stdio: "pipe",
+    });
+    if (status.status !== 0) return [];
+    return parseBlockPaths(status.stdout.toString(), paperDir);
+  }
+  return parseBlockPaths(diff.stdout.toString(), paperDir);
+}
+
+/**
+ * Given the raw output of `git diff --name-only`, return absolute paths of
+ * block .ts/.md files (excluding chapter manifests and paper manifests).
+ */
+function parseBlockPaths(diffOutput: string, paperDir: string): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const line of diffOutput.split("\n")) {
+    const rel = line.trim();
+    if (!rel) continue;
+    const abs = join(REPO_ROOT, rel);
+
+    // Must be under content/<paper>/
+    if (!abs.startsWith(paperDir + "/")) continue;
+
+    // Must end in .ts or .md
+    if (!abs.endsWith(".ts") && !abs.endsWith(".md")) continue;
+
+    // Compute parts relative to paperDir: <chapterDir>/<file>
+    const relToPaper = relative(paperDir, abs);
+    const parts = relToPaper.split("/");
+    // Depth 1 = paper manifest (e.g. paper.ts) — skip
+    // Depth 2 = chapter-level file (e.g. ch1/ch1.ts) — skip if name matches dir
+    if (parts.length < 2) continue;
+    const chapterDir = parts[0];
+    const fileName = basename(rel, ".ts").replace(/\.md$/, "");
+    // Skip if file base-name === chapter dir name (it's the chapter manifest)
+    if (fileName === chapterDir) continue;
+    // Skip if it's the paper manifest itself
+    if (fileName === PAPER) continue;
+
+    const blockName = basename(rel).replace(/\.(ts|md)$/, "");
+    if (seen.has(blockName)) continue;
+    seen.add(blockName);
+
+    result.push(abs);
+  }
+  return result;
+}
+
+// ── Load paper manifest and block registry ───────────────────────────────────
+
+interface BlockEntry {
+  blockName: string;
+  tsPath: string;
+  mdPath: string;
+  chapterDir: string;
+  sourceDir: string; // relative to repo root
+}
+
+async function loadAllBlocks(): Promise<{
+  paper: Paper;
+  entries: Map<string, BlockEntry>;
+}> {
+  const { buildPaper } = await import(
+    join(CONTENT_DIR, "pipeline", "build.ts")
+  );
+  const paperManifestPath = join(CONTENT_DIR, PAPER, `${PAPER}.ts`);
+  if (!existsSync(paperManifestPath)) {
+    console.error(`[render-changed-blocks] Paper manifest not found: ${paperManifestPath}`);
+    process.exit(2);
+  }
+
+  // Called for its side effects — it resolves and validates the manifest
+  // before we read blocks off it. The return value is not needed here.
+  await buildPaper(paperManifestPath);
+  const paperMod = await import(paperManifestPath);
+  const paper = paperMod.default as Paper;
+
+  // Build a flat map blockName → entry by scanning paper chapter dirs
+  const entries = new Map<string, BlockEntry>();
+  const paperDir = join(CONTENT_DIR, PAPER);
+
+  for (const chapterRef of paper.chapters ?? []) {
+    const chDir = join(paperDir, chapterRef.dir);
+    // Discover blocks by listing .ts files that are not chapter manifests
+    const chManifest = chapterRef.dir + ".ts";
+    const chTsFiles = (await import("fs")).readdirSync(chDir)
+      .filter((f: string) => f.endsWith(".ts") && f !== chManifest && !f.endsWith(".d.ts"));
+
+    for (const tsFile of chTsFiles) {
+      const blockName = tsFile.replace(/\.ts$/, "");
+      const tsPath = join(chDir, tsFile);
+      const mdPath = join(chDir, `${blockName}.md`);
+      const sourceDir = relative(REPO_ROOT, chDir);
+      entries.set(blockName, { blockName, tsPath, mdPath, chapterDir: chapterRef.dir, sourceDir });
+    }
+  }
+
+  return { paper, entries };
+}
+
+// ── Log scraper ──────────────────────────────────────────────────────────────
+
+export interface LogIssue {
+  kind: "error" | "warning";
+  category: "latex-error" | "overfull" | "undefined-ref" | "missing-file" | "other-warning";
+  message: string;
+}
+
+/**
+ * Parse a pdflatex/latexmk .log file and return only human-relevant issues.
+ * Suppresses: package loading messages, font substitution, kpathsea lookups,
+ * overfull-in-preamble noise, and other boilerplate.
+ */
+export function scrapeLog(logText: string): LogIssue[] {
+  const issues: LogIssue[] = [];
+  const lines = logText.split("\n");
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // Hard LaTeX errors — always surface
+    if (/^! /.test(line)) {
+      // Collect context (next 1–2 lines for "l.<n>" context)
+      const ctx = lines.slice(i + 1, i + 3)
+        .filter(l => l.trim())
+        .join(" | ");
+      const msg = ctx ? `${line.trim()} → ${ctx}` : line.trim();
+      issues.push({ kind: "error", category: "latex-error", message: msg });
+      continue;
+    }
+
+    // Overfull hbox/vbox
+    if (/^Overfull \\[hv]box/.test(line)) {
+      issues.push({ kind: "warning", category: "overfull", message: line.trim() });
+      continue;
+    }
+
+    // Undefined cross-references
+    if (/^LaTeX Warning: Reference `.+' on page \d+ undefined/.test(line)) {
+      issues.push({ kind: "warning", category: "undefined-ref", message: line.trim() });
+      continue;
+    }
+    if (/^LaTeX Warning: Citation `.+' on page \d+ undefined/.test(line)) {
+      issues.push({ kind: "warning", category: "undefined-ref", message: line.trim() });
+      continue;
+    }
+
+    // Missing file errors
+    if (/LaTeX Error: File .+ not found/.test(line)) {
+      issues.push({ kind: "error", category: "missing-file", message: line.trim() });
+      continue;
+    }
+
+    // Other LaTeX warnings worth surfacing (not the noisy package ones)
+    if (
+      /^LaTeX Warning:/.test(line) &&
+      !/Font shape/.test(line) &&
+      !/Size substitution/.test(line) &&
+      !/You have requested/.test(line) &&
+      !/Label(s) may have changed/.test(line)
+    ) {
+      issues.push({ kind: "warning", category: "other-warning", message: line.trim() });
+    }
+  }
+
+  return issues;
+}
+
+// ── Compile a single block ───────────────────────────────────────────────────
+
+interface BlockResult {
+  blockName: string;
+  texPath: string;
+  pdfPath: string | null;
+  issues: LogIssue[];
+  compileOk: boolean;
+}
+
+async function renderBlock(entry: BlockEntry, paper: Paper): Promise<BlockResult> {
+  const { generateBlockStandaloneTex } = await import(
+    join(CONTENT_DIR, "pipeline", "generate-block-tex.ts")
+  );
+
+  // Load block
+  const blockMod = await import(entry.tsPath);
+  const block = blockMod.default;
+  const mdContent = existsSync(entry.mdPath)
+    ? readFileSync(entry.mdPath, "utf-8")
+    : "";
+
+  // Generate .tex
+  mkdirSync(BLOCK_PDFS_DIR, { recursive: true });
+  const texPath = join(BLOCK_PDFS_DIR, `${entry.blockName}.tex`);
+  const bibPath = join(REPO_ROOT, "references");
+
+  const tex = generateBlockStandaloneTex(
+    paper, block, mdContent, entry.blockName, entry.sourceDir,
+    { preamblePath: PREAMBLE_PATH, bibliographyPath: bibPath },
+  );
+  writeFileSync(texPath, tex);
+
+  // Compile
+  const compile = spawnSync("latexmk", [
+    "-pdf",
+    "-interaction=nonstopmode",
+    `-jobname=${entry.blockName}`,
+    `-output-directory=${BLOCK_PDFS_DIR}`,
+    texPath,
+  ], {
+    cwd: REPO_ROOT,
+    stdio: "pipe",
+    timeout: 120_000,
+  });
+
+  const pdfPath = join(BLOCK_PDFS_DIR, `${entry.blockName}.pdf`);
+  const logPath = join(BLOCK_PDFS_DIR, `${entry.blockName}.log`);
+  const logText = existsSync(logPath)
+    ? readFileSync(logPath, "utf-8")
+    : compile.stdout?.toString() ?? "";
+
+  const issues = scrapeLog(logText);
+  const compileOk = compile.status === 0 && existsSync(pdfPath);
+
+  return {
+    blockName: entry.blockName,
+    texPath,
+    pdfPath: compileOk ? pdfPath : null,
+    issues,
+    compileOk,
+  };
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  // Pre-flight
+  if (!hasCommand("latexmk")) {
+    console.error("[render-changed-blocks] latexmk not found. Install TeX Live or run scripts/install-tex.sh");
+    process.exit(2);
+  }
+  if (!existsSync(PREAMBLE_PATH)) {
+    console.error(`[render-changed-blocks] Preamble not found: ${PREAMBLE_PATH}`);
+    process.exit(2);
+  }
+
+  console.log(`[render-changed-blocks] Paper: ${PAPER}`);
+
+  // Load paper
+  const { paper, entries } = await loadAllBlocks();
+
+  // Determine which blocks to render
+  let blockNames: string[];
+  if (RENDER_ALL) {
+    blockNames = [...entries.keys()];
+    console.log(`[render-changed-blocks] Rendering all ${blockNames.length} blocks`);
+  } else {
+    const changedFiles = getChangedBlockFiles();
+    if (changedFiles.length === 0) {
+      console.log("[render-changed-blocks] No changed content blocks found — nothing to render");
+      writeJsonReport([], BLOCK_PDFS_DIR);
+      process.exit(0);
+    }
+    // Map changed files → block names that exist in the paper
+    const changedNames = new Set(
+      changedFiles.map(f => basename(f).replace(/\.(ts|md)$/, ""))
+    );
+    blockNames = [...changedNames].filter(n => entries.has(n));
+    const unknown = [...changedNames].filter(n => !entries.has(n));
+    if (unknown.length > 0) {
+      console.log(`  ⚠ Skipping non-block files: ${unknown.join(", ")}`);
+    }
+    console.log(`[render-changed-blocks] Rendering ${blockNames.length} changed block(s)`);
+  }
+
+  if (blockNames.length === 0) {
+    console.log("[render-changed-blocks] No renderable blocks found");
+    writeJsonReport([], BLOCK_PDFS_DIR);
+    process.exit(0);
+  }
+
+  // Render blocks
+  mkdirSync(BLOCK_PDFS_DIR, { recursive: true });
+  const results: BlockResult[] = [];
+  let anyError = false;
+
+  for (const name of blockNames) {
+    const entry = entries.get(name)!;
+    process.stdout.write(`  rendering ${name} … `);
+    try {
+      const result = await renderBlock(entry, paper);
+      results.push(result);
+
+      const errors = result.issues.filter(i => i.kind === "error");
+      const warnings = result.issues.filter(i => i.kind === "warning");
+      const status = result.compileOk
+        ? (errors.length === 0 ? "✓" : "✗")
+        : "✗";
+      process.stdout.write(`${status}\n`);
+
+      if (errors.length > 0) {
+        anyError = true;
+        for (const e of errors) console.log(`    ✗ [${e.category}] ${e.message}`);
+      }
+      if (warnings.length > 0) {
+        for (const w of warnings) console.log(`    ⚠ [${w.category}] ${w.message}`);
+      }
+    } catch (e) {
+      console.log(`✗ (exception: ${e instanceof Error ? e.message : String(e)})`);
+      results.push({
+        blockName: name, texPath: "", pdfPath: null, issues: [
+          { kind: "error", category: "other-warning", message: String(e) },
+        ], compileOk: false,
+      });
+      anyError = true;
+    }
+  }
+
+  // Summary
+  const ok = results.filter(r => r.compileOk).length;
+  const fail = results.filter(r => !r.compileOk).length;
+  const warns = results.reduce((s, r) => s + r.issues.filter(i => i.kind === "warning").length, 0);
+  console.log(`\n[render-changed-blocks] ${ok} ok, ${fail} failed, ${warns} warning(s)`);
+
+  writeJsonReport(results, BLOCK_PDFS_DIR);
+  process.exit(anyError ? 1 : 0);
+}
+
+function writeJsonReport(results: BlockResult[], outDir: string): void {
+  mkdirSync(outDir, { recursive: true });
+  const report = {
+    timestamp: new Date().toISOString(),
+    paper: PAPER,
+    blocks: results.map(r => ({
+      blockName: r.blockName,
+      compileOk: r.compileOk,
+      pdfPath: r.pdfPath,
+      errorCount: r.issues.filter(i => i.kind === "error").length,
+      warningCount: r.issues.filter(i => i.kind === "warning").length,
+      issues: r.issues,
+    })),
+  };
+  writeFileSync(join(outDir, "render-report.json"), JSON.stringify(report, null, 2));
+  console.log(`[render-changed-blocks] Report: ${join(outDir, "render-report.json")}`);
+}
+
+main().catch(e => {
+  console.error("[render-changed-blocks] Fatal:", e);
+  process.exit(2);
+});

--- a/scripts/render-on-change.sh
+++ b/scripts/render-on-change.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 #
-# Hook script: re-render TeX blocks and export JSON when content .md files change.
+# Hook script: re-render content when .ts/.md files under content/ change.
 #
 # Called by Claude Code PostToolUse hook after Edit/Write operations.
-# Checks if any .md files under content/ were modified and triggers:
+# Checks if any files under content/ were modified and triggers:
 #   1. TeX block rendering (local pdflatex or Docker paper-assistant fallback)
 #   2. JSON export for the viewer
+#   3. Per-block standalone PDF render for each changed block  [if latexmk available]
 #
 # Exit 0 always — rendering failures should not block the edit.
 #
@@ -14,29 +15,40 @@ set -uo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 source "$REPO_ROOT/scripts/lib/docker-tex.sh"
 
-# Only trigger for content .md file changes
-if ! git diff --name-only 2>/dev/null | grep -q '^content/.*\.md$'; then
+# Only trigger for content file changes (.ts or .md under content/)
+if ! git diff --name-only 2>/dev/null | grep -q '^content/.*\.\(md\|ts\)$'; then
   exit 0
 fi
 
-echo "[render-on-change] Content .md file changed, re-rendering..."
+echo "[render-on-change] Content file changed, re-rendering..."
 
-# Re-render TeX blocks (local TeX or Docker fallback)
-if tex_local; then
-  bun run "$REPO_ROOT/scripts/render-tex/render-tex-blocks.ts" 2>&1 | sed 's/^/  /' || true
-elif tex_docker_ready; then
-  echo "[render-on-change] Using Docker paper-assistant image for TeX rendering..."
-  docker_tex_run bun run scripts/render-tex/render-tex-blocks.ts 2>&1 | sed 's/^/  /' || true
-elif tex_docker_available; then
-  echo "[render-on-change] WARNING: TeX not installed locally and Docker image not pulled."
-  echo "[render-on-change] Run: docker pull $PAPER_IMAGE"
-else
-  echo "[render-on-change] WARNING: No TeX available (local or Docker), SVGs may be stale"
+# ── Step 1: Re-render TeX inline blocks (```tex…``` → SVG) ───────────────────
+if git diff --name-only 2>/dev/null | grep -q '^content/.*\.md$'; then
+  if tex_local; then
+    bun run "$REPO_ROOT/scripts/render-tex/render-tex-blocks.ts" 2>&1 | sed 's/^/  /' || true
+  elif tex_docker_ready; then
+    echo "[render-on-change] Using Docker paper-assistant image for TeX rendering..."
+    docker_tex_run bun run scripts/render-tex/render-tex-blocks.ts 2>&1 | sed 's/^/  /' || true
+  elif tex_docker_available; then
+    echo "[render-on-change] WARNING: TeX not installed locally and Docker image not pulled."
+    echo "[render-on-change] Run: docker pull $PAPER_IMAGE"
+  else
+    echo "[render-on-change] WARNING: No TeX available (local or Docker), SVGs may be stale"
+  fi
 fi
 
-# Re-export JSON for viewer
+# ── Step 2: Re-export JSON for viewer ────────────────────────────────────────
 if command -v bun &>/dev/null; then
   bun run "$REPO_ROOT/content/pipeline/export-json.ts" 2>&1 | sed 's/^/  /' || true
+fi
+
+# ── Step 3: Per-block standalone PDF render ──────────────────────────────────
+# Local latexmk only: render-changed-blocks needs bun + latexmk in-process.
+if command -v bun &>/dev/null && tex_local; then
+  echo "[render-on-change] Rendering changed block PDFs..."
+  bun run "$REPO_ROOT/scripts/render-changed-blocks.ts" 2>&1 | sed 's/^/  /' || true
+elif tex_docker_ready && command -v bun &>/dev/null; then
+  echo "[render-on-change] latexmk not local — block PDF render skipped (Docker tex available but render-changed-blocks needs local bun+latexmk)"
 fi
 
 echo "[render-on-change] Done."


### PR DESCRIPTION
## Summary

Compiles a **standalone PDF for a single content block**, so a LaTeX error in one block surfaces on the edit that caused it rather than at the next full build.

This is the **render half of #65** (Copilot, opened 2026-08-01), rebased onto current main. #65 was **114 commits behind with 3 conflicts**; the Google Drive sync it bundled is deliberately **not** included — see *What was left out*.

## What lands

| Piece | What it does |
|---|---|
| `content/pipeline/generate-block-tex.ts` | Wraps one block in a compilable `\documentclass` + the shared preamble. Annotation macros (`\blockannot`, `\chapterannot`, `\marginnote`) are `\renewcommand`-ed to no-ops; the bibliography tail is kept so `\cite{}` still resolves. |
| `scripts/render-changed-blocks.ts` | Drives it from the git diff → latexmk → log scrape → JSON report. |
| `paper_render_pdf` | Gains `scope: "block"` with `target` = block root name. |
| Wiring | `render-on-change` hook (local latexmk only) + named as the `block_pdf_render` gate in `prepare-merge`. |

Output is local — `build/block-pdfs/`, now gitignored. **Nothing leaves the machine.**

Exit codes: `0` clean or warnings only · `1` LaTeX errors · `2` setup problem.

## What was left out, and why

**The Google Drive sync is not here.** In #65 it pushed block PDFs to a third-party service on **every content edit**, gated only on `folio.config.json` carrying a `folderPath` — no per-upload confirmation. For an unpublished paper that is a policy decision for the author, not a detail to ride in on a render change. It is unchanged and available on `claude/block-pdf-drive-rebase-2026-08-08` (also rebased onto main) if you want it.

Dropped with it: `src/google-drive-mcp.py`, `scripts/google-drive-mcp.sh`, the `.mcp.json` server entry, and the `googleDrive` block in `folio.config.example.json`. **Zero Drive references remain** in this branch (grepped).

## #65 fails the gates that main has since added

Worth recording, since it explains why #65 shows no check runs: its base predates `code-quality-gates.yml`. Run against current main it produces **5 lint errors** under rules main has since promoted to *errors* — three `@typescript-eslint/no-explicit-any` and two `no-unused-vars`. Fixed here rather than carried:

- paper manifests typed `Paper` (a real exported type in `schemas/types.ts`) instead of `any`, in both `render.ts` and `render-changed-blocks.ts`
- `buildPaper`'s unused return dropped, keeping the call for its validation side effect (commented, so it is not later "cleaned up")
- unused `dirname` / `basename` imports removed — main removed `basename` from `render.ts` in `958c29e` for exactly this reason, which was one of the 3 conflicts

## One judgment call in the gate docs

The gate needs local `latexmk`, which is absent in most containers. The docs state that a missing `latexmk` means the gate **did not run** and must be reported as such — never folded into a green. That matches the existing honesty rule about build coverage in the same file, and matters more than usual given CI auto-triggers are off and verification is agent-owned.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bunx eslint` on every changed TS file — clean (was 5 errors before the fixes above)
- [x] `bash -n` on both changed shell scripts — clean
- [x] `bun test` — **538 pass / 35 skip / 7 fail**
- [x] Verified zero `googleDrive` / `google-drive` / `upload_drive` / `GDRIVE` references remain

⚠️ The 7 failures are **pre-existing and unrelated** — the `lean-triviality-probe` splice tests, which need a Lean toolchain this container does not have. Identical count on clean `main`.

⚠️ **Not exercised end-to-end:** no local `latexmk` here, so no block PDF was actually compiled in this container. The change is verified by typecheck, lint, and the suite; the compile path itself is unrun. Worth one manual `bun run scripts/render-changed-blocks.ts` on a machine with TeX before relying on the gate.

## Files

- [`content/pipeline/generate-block-tex.ts`](https://github.com/litlfred/folio-assistant/blob/claude/block-pdf-render-2026-08-08/content/pipeline/generate-block-tex.ts)
- [`scripts/render-changed-blocks.ts`](https://github.com/litlfred/folio-assistant/blob/claude/block-pdf-render-2026-08-08/scripts/render-changed-blocks.ts)
- [`adapters/paper/tools/render.ts`](https://github.com/litlfred/folio-assistant/blob/claude/block-pdf-render-2026-08-08/adapters/paper/tools/render.ts)
- [`scripts/render-on-change.sh`](https://github.com/litlfred/folio-assistant/blob/claude/block-pdf-render-2026-08-08/scripts/render-on-change.sh)
- [`scripts/docker-latex-build/build-pdf.sh`](https://github.com/litlfred/folio-assistant/blob/claude/block-pdf-render-2026-08-08/scripts/docker-latex-build/build-pdf.sh)
- [`.claude/commands/prepare-merge.md`](https://github.com/litlfred/folio-assistant/blob/claude/block-pdf-render-2026-08-08/.claude/commands/prepare-merge.md)
- [`.claude/skills/local/prepare-merge.md`](https://github.com/litlfred/folio-assistant/blob/claude/block-pdf-render-2026-08-08/.claude/skills/local/prepare-merge.md)

Supersedes the render half of #65.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jd1YQmjcqq9zhAwYPYpnjS)_