### PR TITLE
Google Drive sync for block + paper PDFs (#65 rebased whole, stacked on #86)

### DIFF
--- a/.claude/commands/prepare-merge.md
+++ b/.claude/commands/prepare-merge.md
@@ -49,9 +49,10 @@ Prefer the MCP tools (structured findings) when connected; otherwise the scripts
 - `latex_preflight` — no new unknown macros / overfull boxes.
 - `block_pdf_render` — for each changed block, compile a standalone PDF and
   resolve LaTeX errors; overfull boxes on changed content are advisory.
-  Run: `bun run scripts/render-changed-blocks.ts`. Needs local `latexmk` —
-  when it is absent the gate cannot run, and that is reported as **not run**,
-  never as a pass.
+  Run: `bun run scripts/render-changed-blocks.ts` (add `--upload-drive` to
+  also push to Drive when `googleDrive.folderPath` is configured). Needs
+  local `latexmk` — when it is absent the gate cannot run, and that is
+  reported as **not run**, never as a pass.
 - `lean_build` / `lean_check` — build green (or unchanged) for touched packages.
   **Check what the target covers before quoting its result.** `lake build`
   compiles the root module plus its transitive imports, not the source tree

--- a/.claude/skills/local/prepare-merge.md
+++ b/.claude/skills/local/prepare-merge.md
@@ -60,10 +60,11 @@ the one recipe.
    For `contentType: paper` branches that touch content blocks, also run the
    **`block_pdf_render`** gate:
    ```
-   bun run scripts/render-changed-blocks.ts
+   bun run scripts/render-changed-blocks.ts [--upload-drive]
    ```
    This compiles a standalone PDF for every changed block and scrapes the
-   LaTeX log. Exits 1 on LaTeX errors (fix required); exits 0 with warnings
+   LaTeX log; `--upload-drive` additionally pushes clean PDFs to Google Drive
+   when it is configured. Exits 1 on LaTeX errors (fix required); exits 0 with warnings
    only (advisory); exits 2 on setup problems — including **no local
    `latexmk`**, which is the common case in a container. Exit 2 means the gate
    did **not run**; report it that way rather than folding it into a green,

--- a/.mcp.json
+++ b/.mcp.json
@@ -6,6 +6,11 @@
       "env": {
         "SAGE_DOCKER_IMAGE": "sagemath/sagemath:latest"
       }
+    },
+    "google-drive": {
+      "command": "scripts/google-drive-mcp.sh",
+      "args": [],
+      "env": {}
     }
   }
 }

--- a/adapters/paper/tools/render.ts
+++ b/adapters/paper/tools/render.ts
@@ -48,8 +48,12 @@ export function registerRenderTools(server: McpServer): void {
         .describe("Run latexmk -C first to clean auxiliary files"),
       print_mode: z.enum(["formal", "compact"]).default("compact")
         .describe("Print mode: formal (with affiliations) or compact (dense, no affiliations)"),
+      upload_drive: z.boolean().default(false)
+        .describe("Push the rendered PDF to Google Drive (requires Drive MCP configured)"),
+      drive_folder: z.string().optional()
+        .describe("Override Drive destination folder (default: from folio.config.json googleDrive.folderPath)"),
     },
-    async ({ scope, target, engine, clean, print_mode }) => {
+    async ({ scope, target, engine, clean, print_mode, upload_drive, drive_folder }) => {
       // Check deps
       if (!hasCommand("latexmk")) {
         return {
@@ -62,6 +66,34 @@ export function registerRenderTools(server: McpServer): void {
       }
 
       if (!existsSync(BUILD_DIR)) mkdirSync(BUILD_DIR, { recursive: true });
+
+      // Helper: push a PDF to Drive (fire-and-forget, returns link or error string)
+      const pushToDrive = (pdfPath: string, subfolder: string): string => {
+        const gdriveMcp = join(REPO_ROOT, "src", "google-drive-mcp.py");
+        if (!existsSync(gdriveMcp)) return "(Drive MCP not found)";
+        // Read base folder from folio.config.json or env
+        let baseFolder = process.env.GDRIVE_FOLDER_PATH ?? "";
+        if (!baseFolder) {
+          const cfgPath = join(REPO_ROOT, "folio.config.json");
+          if (existsSync(cfgPath)) {
+            try {
+              const cfg = JSON.parse(readFileSync(cfgPath, "utf-8"));
+              baseFolder = cfg?.googleDrive?.folderPath ?? "";
+            } catch { /* ignore */ }
+          }
+        }
+        const folder = drive_folder ?? (baseFolder ? `${baseFolder}/${subfolder}` : subfolder);
+        const r = spawnSync("python3", [gdriveMcp, "--upload", pdfPath, "--folder", folder, "--json"], {
+          stdio: "pipe", timeout: 60_000,
+        });
+        if (r.status !== 0) return `Drive upload failed: ${r.stderr?.toString().trim()}`;
+        try {
+          const out = JSON.parse(r.stdout.toString().trim());
+          return out.webViewLink ?? out.link ?? "(uploaded, no link returned)";
+        } catch {
+          return "(upload complete, response not JSON)";
+        }
+      };
 
       try {
         // ── Block render ─────────────────────────────────────────────────────
@@ -132,12 +164,17 @@ export function registerRenderTools(server: McpServer): void {
             .slice(0, 40).join("\n");
 
           const ok = compileResult.status === 0 && existsSync(pdfPath);
+          let driveMsg = "";
+          if (upload_drive && ok) {
+            const link = pushToDrive(pdfPath, "blocks");
+            driveMsg = `\nDrive: ${link}`;
+          }
 
           return {
             content: [{
               type: "text" as const,
               text: ok
-                ? `Block PDF: ${pdfPath}\nSize: ${(readFileSync(pdfPath).length / 1024).toFixed(0)} KB` +
+                ? `Block PDF: ${pdfPath}\nSize: ${(readFileSync(pdfPath).length / 1024).toFixed(0)} KB${driveMsg}` +
                   (relevantLog ? `\n\nLog issues:\n${relevantLog}` : "")
                 : `Block compilation failed (exit ${compileResult.status}).\n\nLog issues:\n${relevantLog || logText.slice(-2000)}`,
             }],
@@ -209,11 +246,17 @@ export function registerRenderTools(server: McpServer): void {
         const log = result.stderr?.toString().slice(-2000) || "";
 
         if (result.status === 0 && existsSync(pdfPath)) {
+          let driveMsg = "";
+          if (upload_drive) {
+            const subfolder = scope === "chapter" ? "chapters" : "";
+            const link = pushToDrive(pdfPath, subfolder);
+            driveMsg = `\nDrive: ${link}`;
+          }
           return {
             content: [{
               type: "text" as const,
               text: `PDF rendered successfully: ${pdfPath}\n` +
-                `Size: ${(readFileSync(pdfPath).length / 1024).toFixed(0)} KB`,
+                `Size: ${(readFileSync(pdfPath).length / 1024).toFixed(0)} KB${driveMsg}`,
             }],
           };
         } else {

--- a/folio.config.example.json
+++ b/folio.config.example.json
@@ -12,5 +12,9 @@
   "simulators": {
     "dir": "folio-assistant/simulators",
     "pyodideCache": true
+  },
+  "googleDrive": {
+    "_comment": "Optional. Set folderPath to auto-push PDFs to Google Drive on every content edit and full build. Credentials are resolved from GOOGLE_APPLICATION_CREDENTIALS env var, ~/.config/google-drive-mcp/credentials.json (OAuth2), or gcloud ADC — never stored here.",
+    "folderPath": ""
   }
 }

--- a/scripts/docker-latex-build/build-pdf.sh
+++ b/scripts/docker-latex-build/build-pdf.sh
@@ -148,4 +148,52 @@ if command -v python3 &>/dev/null; then
     || echo "  ⚠ PDF split failed (non-fatal)"
 fi
 
+# ── Step 5: Sync PDFs to Google Drive (if configured) ────────────
+# Reads target folder from GDRIVE_FOLDER_PATH env var or
+# folio.config.json googleDrive.folderPath field. Unset = no egress.
+_gdrive_folder=""
+if [[ -n "${GDRIVE_FOLDER_PATH:-}" ]]; then
+  _gdrive_folder="$GDRIVE_FOLDER_PATH"
+elif [[ -f "$REPO_ROOT/folio.config.json" ]] && command -v python3 &>/dev/null; then
+  _gdrive_folder="$(python3 -c "
+import json
+try:
+  cfg=json.load(open('$REPO_ROOT/folio.config.json'))
+  print((cfg.get('googleDrive') or {}).get('folderPath',''))
+except Exception:
+  pass
+" 2>/dev/null || true)"
+fi
+
+if [[ -n "${_gdrive_folder:-}" ]] && command -v python3 &>/dev/null; then
+  GDRIVE_MCP="$REPO_ROOT/src/google-drive-mcp.py"
+  if [[ -f "$GDRIVE_MCP" ]]; then
+    echo "==> Syncing PDFs to Google Drive folder: $_gdrive_folder"
+
+    # main.pdf → root folder
+    python3 "$GDRIVE_MCP" --upload "$REPO_ROOT/main.pdf" \
+      --folder "$_gdrive_folder" || echo "  ⚠ main.pdf Drive upload failed (non-fatal)"
+
+    # standalone appendix PDFs → appendices/
+    for pdf in "$REPO_ROOT"/standalone-*.pdf; do
+      [ -f "$pdf" ] || continue
+      python3 "$GDRIVE_MCP" --upload "$pdf" \
+        --folder "$_gdrive_folder/appendices" || echo "  ⚠ appendix Drive upload failed (non-fatal)"
+    done
+
+    # Chapter/section PDFs from split manifest → chapters/ and root
+    if [[ -f "$PDF_SPLIT_DIR/pdf-split-manifest.json" ]]; then
+      python3 "$GDRIVE_MCP" \
+        --sync-manifest "$PDF_SPLIT_DIR/pdf-split-manifest.json" \
+        --folder "$_gdrive_folder" || echo "  ⚠ Split-manifest Drive sync failed (non-fatal)"
+    fi
+
+    echo "==> Drive sync complete."
+  else
+    echo "==> Drive MCP not found at $GDRIVE_MCP — skipping Drive sync"
+  fi
+else
+  echo "==> Google Drive not configured (set GDRIVE_FOLDER_PATH or folio.config.json googleDrive.folderPath to enable)"
+fi
+
 echo "==> Build complete."

--- a/scripts/google-drive-mcp.sh
+++ b/scripts/google-drive-mcp.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Launch the Google Drive MCP server (stdio transport).
+#
+# Registered in the project .mcp.json as the "google-drive" server.
+# This wrapper just locates a Python 3 interpreter and execs
+# src/google-drive-mcp.py — all auth resolution (service account /
+# OAuth / gcloud ADC) and Drive API initialisation happen lazily on
+# the FIRST actual tool call.  Registering this server in .mcp.json
+# costs nothing; if you never call a Drive tool, no credentials are
+# read and no network requests are made.
+#
+# Credential setup (one-time, outside the repo):
+#
+#   Option A — Service account (recommended for CI / headless agents):
+#     1. Create a service account in Google Cloud Console.
+#     2. Grant it "Editor" access by sharing the target Drive folder
+#        with the service account email.
+#     3. Download the JSON key file.
+#     4. export GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa-key.json
+#        (add to ~/.bashrc or the agent's environment).
+#
+#   Option B — OAuth2 (interactive, for personal use):
+#     1. Create OAuth2 credentials in Google Cloud Console
+#        (application type: Desktop).
+#     2. Download and save to:
+#        ~/.config/google-drive-mcp/credentials.json
+#     3. On first tool call the server opens a browser consent page
+#        once; the token is cached at
+#        ~/.config/google-drive-mcp/token.json.
+#
+#   Option C — gcloud Application Default Credentials:
+#     gcloud auth application-default login
+#
+# Configure the target Drive folder via folio.config.json:
+#   { "googleDrive": { "folderPath": "MyProject/folio-pdfs" } }
+# or via environment variable:
+#   export GDRIVE_FOLDER_PATH="MyProject/folio-pdfs"
+#
+# Override the Drive root folder ID (e.g. for Shared Drives):
+#   export GDRIVE_ROOT_FOLDER_ID="<folder-id>"
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/src/google-drive-mcp.py"
+
+PY="$(command -v python3 || command -v python || true)"
+if [[ -z "$PY" ]]; then
+  echo "google-drive-mcp: no python3/python on PATH" >&2
+  exit 1
+fi
+
+# Read GDRIVE_FOLDER_PATH from folio.config.json if not already set
+if [[ -z "${GDRIVE_FOLDER_PATH:-}" ]]; then
+  CONFIG="$REPO_ROOT/folio.config.json"
+  if [[ -f "$CONFIG" ]]; then
+    GDRIVE_FOLDER_PATH="$(
+      python3 -c "
+import json, sys
+cfg = json.load(open('$CONFIG'))
+base = (cfg.get('googleDrive') or {}).get('folderPath','')
+print(base)
+" 2>/dev/null || true)"
+    export GDRIVE_FOLDER_PATH
+  fi
+fi
+
+exec "$PY" "$SCRIPT" --stdio

--- a/scripts/render-changed-blocks.ts
+++ b/scripts/render-changed-blocks.ts
@@ -2,20 +2,25 @@
 /**
  * render-changed-blocks.ts — Render per-block standalone PDFs for every
  * content block touched by the current branch (or an explicit file list),
- * and scrape the LaTeX logs for human-relevant feedback.
+ * scrape the LaTeX logs for human-relevant feedback, and optionally push
+ * the clean PDFs to Google Drive.
  *
  * This script is the key loop in the `block_pdf_render` prepare-merge gate
  * (see .claude/commands/prepare-merge.md) and is also called from the
  * render-on-change hook after every content edit.
  *
- * Output is local only: PDFs land under `build/block-pdfs/` and a JSON
- * report beside them. Nothing leaves the machine.
+ * By default output is local: PDFs land under `build/block-pdfs/` with a
+ * JSON report beside them, and nothing leaves the machine. `--upload-drive`
+ * additionally pushes each clean PDF to Google Drive — third-party egress,
+ * so it is opt-in at the call site.
  *
  * Usage:
  *   bun run scripts/render-changed-blocks.ts
  *   bun run scripts/render-changed-blocks.ts --paper quantum-observable-universe
  *   bun run scripts/render-changed-blocks.ts --base main
  *   bun run scripts/render-changed-blocks.ts --files content/paper/ch/block.ts
+ *   bun run scripts/render-changed-blocks.ts --upload-drive
+ *   bun run scripts/render-changed-blocks.ts --upload-drive --drive-folder "QOU/blocks"
  *   bun run scripts/render-changed-blocks.ts --all   # render every block in paper
  *
  * Exit codes:
@@ -42,6 +47,7 @@ const REPO_ROOT = resolve(import.meta.dir, "..");
 const CONTENT_DIR = join(REPO_ROOT, "content");
 const PREAMBLE_PATH = join(REPO_ROOT, "latex", "preamble.tex");
 const BLOCK_PDFS_DIR = join(REPO_ROOT, "build", "block-pdfs");
+const GOOGLE_DRIVE_MCP = join(REPO_ROOT, "src", "google-drive-mcp.py");
 
 // ── Arg parsing ──────────────────────────────────────────────────────────────
 
@@ -57,10 +63,28 @@ function hasFlag(flag: string): boolean {
 
 const PAPER = argVal("--paper", "quantum-observable-universe")!;
 const BASE = argVal("--base", "");               // git base ref for diff
+const UPLOAD_DRIVE = hasFlag("--upload-drive");
+const DRIVE_FOLDER = argVal("--drive-folder")    // explicit folder override
+  ?? resolveConfigDriveFolder()
+  ?? "folio-pdfs/blocks";
 const RENDER_ALL = hasFlag("--all");
 const EXPLICIT_FILES = args.filter(a => !a.startsWith("--") && (a.endsWith(".ts") || a.endsWith(".md")));
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
+
+function resolveConfigDriveFolder(): string | undefined {
+  // Read folio.config.json if present.
+  const cfgPath = join(REPO_ROOT, "folio.config.json");
+  if (!existsSync(cfgPath)) return undefined;
+  try {
+    const cfg = JSON.parse(readFileSync(cfgPath, "utf-8"));
+    if (cfg?.googleDrive?.folderPath) {
+      const base = String(cfg.googleDrive.folderPath).replace(/\/$/, "");
+      return `${base}/blocks`;
+    }
+  } catch { /* ignore */ }
+  return undefined;
+}
 
 function hasCommand(cmd: string): boolean {
   const r = spawnSync("which", [cmd], { stdio: "pipe" });
@@ -270,6 +294,36 @@ export function scrapeLog(logText: string): LogIssue[] {
   return issues;
 }
 
+// ── Drive upload ─────────────────────────────────────────────────────────────
+
+function uploadToDrive(localPath: string, driveFolder: string): {
+  ok: boolean;
+  link?: string;
+  error?: string;
+} {
+  if (!existsSync(GOOGLE_DRIVE_MCP)) {
+    return { ok: false, error: "google-drive-mcp.py not found — Drive upload skipped" };
+  }
+  const py = spawnSync("python3", [
+    GOOGLE_DRIVE_MCP,
+    "--upload", localPath,
+    "--folder", driveFolder,
+    "--json",
+  ], { stdio: "pipe", timeout: 60_000 });
+
+  if (py.status !== 0) {
+    const err = py.stderr?.toString().trim() || "unknown error";
+    return { ok: false, error: err };
+  }
+
+  try {
+    const out = JSON.parse(py.stdout.toString().trim());
+    return { ok: true, link: out.webViewLink ?? out.link };
+  } catch {
+    return { ok: false, error: `Drive upload returned non-JSON: ${py.stdout.toString().trim()}` };
+  }
+}
+
 // ── Compile a single block ───────────────────────────────────────────────────
 
 interface BlockResult {
@@ -277,6 +331,8 @@ interface BlockResult {
   texPath: string;
   pdfPath: string | null;
   issues: LogIssue[];
+  driveLink?: string;
+  driveError?: string;
   compileOk: boolean;
 }
 
@@ -325,11 +381,25 @@ async function renderBlock(entry: BlockEntry, paper: Paper): Promise<BlockResult
   const issues = scrapeLog(logText);
   const compileOk = compile.status === 0 && existsSync(pdfPath);
 
+  let driveLink: string | undefined;
+  let driveError: string | undefined;
+
+  if (UPLOAD_DRIVE && compileOk) {
+    const up = uploadToDrive(pdfPath, DRIVE_FOLDER);
+    if (up.ok) {
+      driveLink = up.link;
+    } else {
+      driveError = up.error;
+    }
+  }
+
   return {
     blockName: entry.blockName,
     texPath,
     pdfPath: compileOk ? pdfPath : null,
     issues,
+    driveLink,
+    driveError,
     compileOk,
   };
 }
@@ -348,6 +418,7 @@ async function main(): Promise<void> {
   }
 
   console.log(`[render-changed-blocks] Paper: ${PAPER}`);
+  if (UPLOAD_DRIVE) console.log(`[render-changed-blocks] Drive folder: ${DRIVE_FOLDER}`);
 
   // Load paper
   const { paper, entries } = await loadAllBlocks();
@@ -399,7 +470,10 @@ async function main(): Promise<void> {
       const status = result.compileOk
         ? (errors.length === 0 ? "✓" : "✗")
         : "✗";
-      process.stdout.write(`${status}\n`);
+      process.stdout.write(`${status}`);
+      if (result.driveLink) process.stdout.write(` → ${result.driveLink}`);
+      if (result.driveError) process.stdout.write(` ⚠ Drive: ${result.driveError}`);
+      process.stdout.write("\n");
 
       if (errors.length > 0) {
         anyError = true;
@@ -434,6 +508,8 @@ function writeJsonReport(results: BlockResult[], outDir: string): void {
   const report = {
     timestamp: new Date().toISOString(),
     paper: PAPER,
+    uploadDrive: UPLOAD_DRIVE,
+    driveFolderBase: UPLOAD_DRIVE ? DRIVE_FOLDER : null,
     blocks: results.map(r => ({
       blockName: r.blockName,
       compileOk: r.compileOk,
@@ -441,6 +517,8 @@ function writeJsonReport(results: BlockResult[], outDir: string): void {
       errorCount: r.issues.filter(i => i.kind === "error").length,
       warningCount: r.issues.filter(i => i.kind === "warning").length,
       issues: r.issues,
+      driveLink: r.driveLink ?? null,
+      driveError: r.driveError ?? null,
     })),
   };
   writeFileSync(join(outDir, "render-report.json"), JSON.stringify(report, null, 2));

--- a/scripts/render-on-change.sh
+++ b/scripts/render-on-change.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 #
-# Hook script: re-render content when .ts/.md files under content/ change.
+# Hook script: re-render content on .ts/.md changes and sync to Google Drive.
 #
 # Called by Claude Code PostToolUse hook after Edit/Write operations.
 # Checks if any files under content/ were modified and triggers:
 #   1. TeX block rendering (local pdflatex or Docker paper-assistant fallback)
 #   2. JSON export for the viewer
 #   3. Per-block standalone PDF render for each changed block  [if latexmk available]
+#   4. Push changed block PDFs to Google Drive                 [if Drive configured]
 #
 # Exit 0 always — rendering failures should not block the edit.
 #
@@ -42,11 +43,42 @@ if command -v bun &>/dev/null; then
   bun run "$REPO_ROOT/content/pipeline/export-json.ts" 2>&1 | sed 's/^/  /' || true
 fi
 
-# ── Step 3: Per-block standalone PDF render ──────────────────────────────────
+# ── Step 3 + 4: Per-block standalone PDF render + optional Drive push ─────────
 # Local latexmk only: render-changed-blocks needs bun + latexmk in-process.
+#
+# NOTE ON EGRESS: when Drive is configured, this pushes rendered block PDFs
+# to a third-party service on EVERY content edit, with no per-upload
+# confirmation. Configuring `googleDrive.folderPath` (or GDRIVE_FOLDER_PATH)
+# is what turns that on; leaving it unset keeps everything local.
 if command -v bun &>/dev/null && tex_local; then
   echo "[render-on-change] Rendering changed block PDFs..."
-  bun run "$REPO_ROOT/scripts/render-changed-blocks.ts" 2>&1 | sed 's/^/  /' || true
+
+  # Check whether Drive is configured
+  DRIVE_CONFIGURED=false
+  if [[ -n "${GDRIVE_FOLDER_PATH:-}" ]]; then
+    DRIVE_CONFIGURED=true
+  elif [[ -f "$REPO_ROOT/folio.config.json" ]]; then
+    FOLDER="$(python3 -c "
+import json
+try:
+  cfg=json.load(open('$REPO_ROOT/folio.config.json'))
+  print((cfg.get('googleDrive') or {}).get('folderPath',''))
+except Exception:
+  pass
+" 2>/dev/null || true)"
+    [[ -n "${FOLDER:-}" ]] && DRIVE_CONFIGURED=true
+  fi
+
+  DRIVE_FLAG=""
+  if [[ "$DRIVE_CONFIGURED" == "true" ]]; then
+    DRIVE_FLAG="--upload-drive"
+    echo "[render-on-change] Google Drive configured — will push block PDFs"
+  fi
+
+  # shellcheck disable=SC2086
+  bun run "$REPO_ROOT/scripts/render-changed-blocks.ts" \
+    $DRIVE_FLAG \
+    2>&1 | sed 's/^/  /' || true
 elif tex_docker_ready && command -v bun &>/dev/null; then
   echo "[render-on-change] latexmk not local — block PDF render skipped (Docker tex available but render-changed-blocks needs local bun+latexmk)"
 fi

--- a/src/google-drive-mcp.py
+++ b/src/google-drive-mcp.py
@@ -1,0 +1,687 @@
+#!/usr/bin/env python3
+"""
+Google Drive MCP server — upload and manage PDFs in a Drive folder.
+
+Operates in two modes:
+
+  MCP server (stdio)  — registered in .mcp.json; any agent (Claude Code,
+                        Copilot, Antigravity, Gemini) calls Drive tools via
+                        the Model Context Protocol without knowing about
+                        credentials.  All backend selection and auth happen
+                        lazily on first tool call.
+
+  CLI mode            — called from bash hooks/scripts when Drive operations
+                        are needed inside the render pipeline:
+                          --upload  <file>   upload a single file
+                          --sync-dir <dir>   upload all PDFs in a directory
+                          --sync-manifest <json>  upload from pdf-split-manifest.json
+                          --list   <folder>  list a Drive folder
+                          --status           report auth status, no upload
+                          --json             emit machine-readable JSON output
+
+Credential resolution (first hit wins):
+  1. $GOOGLE_APPLICATION_CREDENTIALS  → service account JSON key file
+  2. ~/.config/google-drive-mcp/credentials.json  → OAuth2 client JSON
+     (triggers a browser consent flow on first use; token cached at
+      ~/.config/google-drive-mcp/token.json — never committed)
+  3. google.auth.default()             → Application Default Credentials
+     (works when `gcloud auth application-default login` has been run)
+
+All credentials live outside the repository.  The script never reads or
+writes any file under the repo root except PDFs it is explicitly told to upload.
+
+Drive folder structure managed by this server (under GDRIVE_ROOT_FOLDER):
+  <root>/
+    main.pdf                # full paper PDF
+    front-matter.pdf        # front matter bundle
+    chapters/
+      introduction.pdf
+      ch1-setup.pdf
+      ...
+    appendices/
+      standalone-glossary.pdf
+      ...
+    blocks/
+      def-observable.pdf
+      thm-main.pdf
+      ...
+
+MCP transport: stdio (newline-delimited JSON-RPC 2.0).
+
+Usage:
+    python3 src/google-drive-mcp.py              # MCP server (default)
+    python3 src/google-drive-mcp.py --status     # auth check, no upload
+    python3 src/google-drive-mcp.py --upload file.pdf --folder "QOU/blocks"
+    python3 src/google-drive-mcp.py --sync-dir build/block-pdfs/ --folder "QOU/blocks"
+    python3 src/google-drive-mcp.py --sync-manifest build/pdf-split-manifest.json
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import pathlib
+from typing import Any
+
+PROTOCOL_VERSION = "2024-11-05"
+SERVER_INFO = {"name": "google-drive-mcp", "version": "0.1.0"}
+
+# ── Config from environment ──────────────────────────────────────────────────
+
+# Root folder path in Drive, e.g. "QOU/folio-pdfs".
+# Segments are created if absent.  Override with --folder in CLI mode.
+GDRIVE_FOLDER_ENV = os.environ.get("GDRIVE_FOLDER_PATH", "folio-pdfs")
+
+# Optional: explicit Drive root folder ID to use as the starting point
+# instead of "My Drive".  Useful when sharing a Team Drive.
+GDRIVE_ROOT_ID = os.environ.get("GDRIVE_ROOT_FOLDER_ID", "root")
+
+# Credential paths
+_CONFIG_DIR = pathlib.Path.home() / ".config" / "google-drive-mcp"
+_OAUTH_CREDS = _CONFIG_DIR / "credentials.json"
+_OAUTH_TOKEN = _CONFIG_DIR / "token.json"
+
+# ── Stderr logging (never corrupts stdout MCP channel) ──────────────────────
+
+def eprint(*args: object) -> None:
+    print(*args, file=sys.stderr, flush=True)
+
+
+# ── Lazy Drive client ────────────────────────────────────────────────────────
+
+_service: Any = None          # googleapiclient.discovery.Resource
+_auth_error: str | None = None
+
+
+def _resolve_credentials():
+    """Return google.oauth2 credentials or raise ImportError / RuntimeError."""
+    # Attempt 1: service account via GOOGLE_APPLICATION_CREDENTIALS
+    sa_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+    if sa_path and pathlib.Path(sa_path).exists():
+        from google.oauth2 import service_account
+        return service_account.Credentials.from_service_account_file(
+            sa_path,
+            scopes=["https://www.googleapis.com/auth/drive.file"],
+        )
+
+    # Attempt 2: OAuth2 client credentials (interactive on first run)
+    if _OAUTH_CREDS.exists():
+        from google_auth_oauthlib.flow import InstalledAppFlow
+        from google.oauth2.credentials import Credentials
+        from google.auth.transport.requests import Request
+
+        scopes = ["https://www.googleapis.com/auth/drive.file"]
+        creds = None
+        if _OAUTH_TOKEN.exists():
+            creds = Credentials.from_authorized_user_file(str(_OAUTH_TOKEN), scopes)
+        if not creds or not creds.valid:
+            if creds and creds.expired and creds.refresh_token:
+                creds.refresh(Request())
+            else:
+                flow = InstalledAppFlow.from_client_secrets_file(
+                    str(_OAUTH_CREDS), scopes
+                )
+                # Run local server flow; opens browser for consent once
+                creds = flow.run_local_server(port=0)
+            _CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+            _OAUTH_TOKEN.write_text(creds.to_json())
+        return creds
+
+    # Attempt 3: Application Default Credentials (gcloud auth application-default)
+    from google.auth import default as gauth_default
+    creds, _ = gauth_default(
+        scopes=["https://www.googleapis.com/auth/drive.file"]
+    )
+    return creds
+
+
+def get_service():
+    """Return (and cache) an authenticated Drive v3 service client."""
+    global _service, _auth_error
+    if _service is not None:
+        return _service
+    if _auth_error is not None:
+        raise RuntimeError(_auth_error)
+    try:
+        from googleapiclient.discovery import build as gdiscovery_build
+        creds = _resolve_credentials()
+        _service = gdiscovery_build("drive", "v3", credentials=creds, cache_discovery=False)
+        eprint("[google-drive-mcp] Drive client authenticated")
+        return _service
+    except ImportError as e:
+        _auth_error = (
+            f"Google API client libraries not installed: {e}\n"
+            "Install with: pip install google-api-python-client google-auth-httplib2 "
+            "google-auth-oauthlib"
+        )
+        raise RuntimeError(_auth_error)
+    except Exception as e:
+        _auth_error = str(e)
+        raise
+
+
+# ── Folder resolution / creation ─────────────────────────────────────────────
+
+def _find_or_create_folder(service, name: str, parent_id: str) -> str:
+    """Return the Drive folder ID for `name` under `parent_id`, creating it if absent."""
+    q = (
+        f"name = {json.dumps(name)} "
+        f"and '{parent_id}' in parents "
+        f"and mimeType = 'application/vnd.google-apps.folder' "
+        f"and trashed = false"
+    )
+    resp = service.files().list(q=q, fields="files(id,name)", spaces="drive").execute()
+    files = resp.get("files", [])
+    if files:
+        return files[0]["id"]
+    # Create the folder
+    meta = {
+        "name": name,
+        "mimeType": "application/vnd.google-apps.folder",
+        "parents": [parent_id],
+    }
+    folder = service.files().create(body=meta, fields="id").execute()
+    eprint(f"[google-drive-mcp] Created folder '{name}' under parent {parent_id}")
+    return folder["id"]
+
+
+def resolve_folder_path(service, folder_path: str, root_id: str = "root") -> str:
+    """
+    Traverse (and create) a slash-separated folder path, starting from root_id.
+    e.g. "QOU/folio-pdfs/blocks" → Drive folder ID for "blocks".
+    Returns the folder ID of the deepest segment.
+    """
+    segments = [s for s in folder_path.replace("\\", "/").split("/") if s]
+    current = root_id
+    for seg in segments:
+        current = _find_or_create_folder(service, seg, current)
+    return current
+
+
+# ── File upload / upsert ─────────────────────────────────────────────────────
+
+def upload_file(local_path: str, folder_path: str, root_id: str = "root") -> dict:
+    """
+    Upload (or update) a local file to the specified Drive folder path.
+    If a file with the same name already exists in the folder, a new
+    revision is created (upsert behaviour).
+
+    Returns a dict with keys: id, name, webViewLink, size.
+    """
+    import mimetypes
+    from googleapiclient.http import MediaFileUpload
+
+    service = get_service()
+    folder_id = resolve_folder_path(service, folder_path, root_id)
+    file_name = pathlib.Path(local_path).name
+    mime, _ = mimetypes.guess_type(local_path)
+    mime = mime or "application/octet-stream"
+    size = pathlib.Path(local_path).stat().st_size
+
+    # Check for existing file with the same name in the folder
+    q = (
+        f"name = {json.dumps(file_name)} "
+        f"and '{folder_id}' in parents "
+        f"and trashed = false"
+    )
+    resp = service.files().list(q=q, fields="files(id,name)", spaces="drive").execute()
+    existing = resp.get("files", [])
+
+    media = MediaFileUpload(local_path, mimetype=mime, resumable=True)
+
+    if existing:
+        # Update existing file
+        file_id = existing[0]["id"]
+        updated = service.files().update(
+            fileId=file_id,
+            media_body=media,
+            fields="id,name,webViewLink,size",
+        ).execute()
+        eprint(f"[google-drive-mcp] Updated: {file_name} (id={file_id})")
+        return updated
+    else:
+        # Create new file
+        meta = {"name": file_name, "parents": [folder_id]}
+        created = service.files().create(
+            body=meta,
+            media_body=media,
+            fields="id,name,webViewLink,size",
+        ).execute()
+        eprint(f"[google-drive-mcp] Uploaded: {file_name} (id={created['id']})")
+        # Make the file readable by anyone with the link
+        try:
+            service.permissions().create(
+                fileId=created["id"],
+                body={"type": "anyone", "role": "reader"},
+            ).execute()
+        except Exception:
+            pass  # non-fatal — file is still accessible to owner
+        return created
+
+
+def list_folder(folder_path: str, root_id: str = "root") -> list[dict]:
+    """List files in a Drive folder path. Returns list of {name, id, webViewLink, mimeType}."""
+    service = get_service()
+    folder_id = resolve_folder_path(service, folder_path, root_id)
+    q = f"'{folder_id}' in parents and trashed = false"
+    resp = service.files().list(
+        q=q,
+        fields="files(id,name,webViewLink,mimeType,size)",
+        spaces="drive",
+        pageSize=1000,
+    ).execute()
+    return resp.get("files", [])
+
+
+def check_auth_status() -> dict:
+    """Check auth without uploading. Returns status dict."""
+    try:
+        get_service()
+        return {"authenticated": True, "error": None}
+    except Exception as e:
+        # Redact the raw exception string to avoid leaking credential path/content.
+        error_type = type(e).__name__
+        return {
+            "authenticated": False,
+            "error": error_type,
+            "hint": (
+                "Set GOOGLE_APPLICATION_CREDENTIALS to a service account key, "
+                "or place OAuth2 client credentials at "
+                "~/.config/google-drive-mcp/credentials.json, "
+                "or run: gcloud auth application-default login"
+            ),
+        }
+
+
+# ── Manifest sync ─────────────────────────────────────────────────────────────
+
+def sync_from_manifest(manifest_path: str, root_folder: str, root_id: str = "root") -> list[dict]:
+    """
+    Sync PDFs listed in a pdf-split-manifest.json to Drive.
+
+    Folder structure under root_folder:
+      root_folder/main.pdf              (or front-matter.pdf — the bundle)
+      root_folder/chapters/<slug>.pdf   (content chapters)
+      root_folder/appendices/<slug>.pdf (standalone appendices, if slug starts with 'appendix-')
+
+    Returns a list of upload result dicts.
+    """
+    data = json.loads(pathlib.Path(manifest_path).read_text())
+    out_dir = str(pathlib.Path(manifest_path).parent)
+    results = []
+
+    for entry in data.get("outputs", []):
+        slug = entry.get("slug", "")
+        pdf_name = entry.get("path", "")
+        local_path = str(pathlib.Path(out_dir) / pdf_name)
+        if not pathlib.Path(local_path).exists():
+            eprint(f"[google-drive-mcp] Skipping missing file: {local_path}")
+            continue
+
+        # Determine subfolder
+        if slug in ("main", "front-matter"):
+            folder = root_folder
+        elif slug.startswith("appendix-"):
+            folder = f"{root_folder}/appendices"
+        else:
+            folder = f"{root_folder}/chapters"
+
+        try:
+            result = upload_file(local_path, folder, root_id)
+            results.append({**result, "slug": slug, "localPath": local_path})
+        except Exception as e:
+            eprint(f"[google-drive-mcp] Upload failed for {pdf_name}: {e}")
+            results.append({"slug": slug, "error": str(e)})
+
+    return results
+
+
+def sync_directory(local_dir: str, drive_folder: str, root_id: str = "root",
+                   pattern: str = "*.pdf") -> list[dict]:
+    """Upload all PDFs in a local directory to a Drive folder."""
+    import glob as globmod
+    results = []
+    for path in globmod.glob(str(pathlib.Path(local_dir) / pattern)):
+        try:
+            result = upload_file(path, drive_folder, root_id)
+            results.append({**result, "localPath": path})
+        except Exception as e:
+            eprint(f"[google-drive-mcp] Upload failed for {path}: {e}")
+            results.append({"localPath": path, "error": str(e)})
+    return results
+
+
+# ── MCP Tool definitions ──────────────────────────────────────────────────────
+
+TOOLS = [
+    {
+        "name": "drive_status",
+        "description": (
+            "Check Google Drive authentication status without uploading anything. "
+            "Returns whether credentials are configured and which method is active."
+        ),
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "drive_upload_file",
+        "description": (
+            "Upload (or update) a local file to a Google Drive folder path. "
+            "Creates intermediate folders if they don't exist. "
+            "If a file with the same name already exists, it is updated (upserted). "
+            "Returns the Drive file ID and a shareable web link."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "local_path": {"type": "string", "description": "Absolute path to the local file"},
+                "drive_folder": {
+                    "type": "string",
+                    "description": (
+                        "Destination folder path in Drive, e.g. 'QOU/blocks'. "
+                        f"Defaults to the configured folder ({GDRIVE_FOLDER_ENV})."
+                    ),
+                },
+            },
+            "required": ["local_path"],
+        },
+    },
+    {
+        "name": "drive_list_folder",
+        "description": "List the contents of a Google Drive folder path. Returns file names and links.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "drive_folder": {
+                    "type": "string",
+                    "description": "Drive folder path to list, e.g. 'QOU/blocks'",
+                },
+            },
+            "required": ["drive_folder"],
+        },
+    },
+    {
+        "name": "drive_sync_manifest",
+        "description": (
+            "Sync PDFs from a pdf-split-manifest.json to Google Drive. "
+            "Uploads main.pdf, front-matter.pdf, chapter PDFs, and appendix PDFs "
+            "to the appropriate subfolders under the root Drive folder."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "manifest_path": {
+                    "type": "string",
+                    "description": "Path to pdf-split-manifest.json",
+                },
+                "root_folder": {
+                    "type": "string",
+                    "description": (
+                        "Root folder in Drive under which chapters/, appendices/ etc. live. "
+                        f"Defaults to {GDRIVE_FOLDER_ENV}."
+                    ),
+                },
+            },
+            "required": ["manifest_path"],
+        },
+    },
+    {
+        "name": "drive_sync_block_pdfs",
+        "description": (
+            "Upload all block PDFs from a local directory to the Drive blocks/ subfolder. "
+            "Typically called after render-changed-blocks.ts to push newly-compiled block PDFs."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "local_dir": {
+                    "type": "string",
+                    "description": "Local directory containing block PDFs (default: build/block-pdfs/)",
+                },
+                "root_folder": {
+                    "type": "string",
+                    "description": f"Root Drive folder. Defaults to {GDRIVE_FOLDER_ENV}.",
+                },
+            },
+        },
+    },
+]
+
+
+def handle_tool_call(name: str, arguments: dict) -> str:
+    if name == "drive_status":
+        return json.dumps(check_auth_status(), indent=2)
+
+    if name == "drive_upload_file":
+        local_path = arguments["local_path"]
+        folder = arguments.get("drive_folder", GDRIVE_FOLDER_ENV)
+        try:
+            result = upload_file(local_path, folder, GDRIVE_ROOT_ID)
+            return json.dumps(result, indent=2)
+        except Exception as e:
+            return json.dumps({"error": str(e)})
+
+    if name == "drive_list_folder":
+        folder = arguments.get("drive_folder", GDRIVE_FOLDER_ENV)
+        try:
+            files = list_folder(folder, GDRIVE_ROOT_ID)
+            return json.dumps({"folder": folder, "files": files}, indent=2)
+        except Exception as e:
+            return json.dumps({"error": str(e)})
+
+    if name == "drive_sync_manifest":
+        manifest = arguments["manifest_path"]
+        root = arguments.get("root_folder", GDRIVE_FOLDER_ENV)
+        try:
+            results = sync_from_manifest(manifest, root, GDRIVE_ROOT_ID)
+            return json.dumps({"synced": len(results), "results": results}, indent=2)
+        except Exception as e:
+            return json.dumps({"error": str(e)})
+
+    if name == "drive_sync_block_pdfs":
+        import os as _os
+        repo_root = str(pathlib.Path(__file__).resolve().parent.parent)
+        local_dir = arguments.get("local_dir", _os.path.join(repo_root, "build", "block-pdfs"))
+        root = arguments.get("root_folder", GDRIVE_FOLDER_ENV)
+        folder = f"{root}/blocks"
+        try:
+            results = sync_directory(local_dir, folder, GDRIVE_ROOT_ID)
+            return json.dumps({"synced": len(results), "folder": folder, "results": results}, indent=2)
+        except Exception as e:
+            return json.dumps({"error": str(e)})
+
+    return json.dumps({"error": f"Unknown tool: {name}"})
+
+
+# ── MCP stdio transport (JSON-RPC 2.0) ───────────────────────────────────────
+
+def _result(req_id, result):
+    return {"jsonrpc": "2.0", "id": req_id, "result": result}
+
+
+def _error(req_id, code: int, message: str):
+    return {"jsonrpc": "2.0", "id": req_id, "error": {"code": code, "message": message}}
+
+
+def handle_message(msg: dict):
+    method = msg.get("method")
+    req_id = msg.get("id")
+    params = msg.get("params") or {}
+    is_notification = "id" not in msg
+
+    if method == "initialize":
+        return _result(req_id, {
+            "protocolVersion": PROTOCOL_VERSION,
+            "capabilities": {"tools": {}},
+            "serverInfo": SERVER_INFO,
+        })
+    if method in ("notifications/initialized", "initialized", "ping"):
+        return None if is_notification else _result(req_id, {})
+    if method == "tools/list":
+        return _result(req_id, {"tools": TOOLS})
+    if method == "tools/call":
+        tool_name = params.get("name", "")
+        arguments = params.get("arguments") or {}
+        try:
+            text = handle_tool_call(tool_name, arguments)
+            payload = json.loads(text)
+            is_err = isinstance(payload, dict) and "error" in payload
+            return _result(req_id, {
+                "content": [{"type": "text", "text": text}],
+                "isError": is_err,
+            })
+        except Exception as e:
+            return _result(req_id, {
+                "content": [{"type": "text", "text": json.dumps({"error": str(e)})}],
+                "isError": True,
+            })
+    if method == "shutdown":
+        return _result(req_id, {})
+    if is_notification:
+        return None
+    return _error(req_id, -32601, f"Method not found: {method}")
+
+
+def serve_stdio() -> None:
+    eprint(
+        f"[google-drive-mcp] ready (stdio). Auth resolves lazily on first tool call. "
+        f"Default folder: {GDRIVE_FOLDER_ENV}"
+    )
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        response = handle_message(msg)
+        if response is not None:
+            sys.stdout.write(json.dumps(response) + "\n")
+            sys.stdout.flush()
+        if msg.get("method") == "shutdown":
+            break
+
+
+# ── CLI mode ──────────────────────────────────────────────────────────────────
+
+def cli_main(argv: list[str]) -> int:
+    """
+    CLI entry point for use from bash scripts.
+    Returns exit code (0 = success).
+    """
+    as_json = "--json" in argv
+
+    def out(data: dict) -> None:
+        if as_json:
+            print(json.dumps(data))
+        else:
+            if "error" in data:
+                eprint(f"ERROR: {data['error']}")
+                if "hint" in data:
+                    eprint(f"  {data['hint']}")
+            elif "webViewLink" in data:
+                print(data["webViewLink"])
+            elif "synced" in data:
+                print(f"Synced {data['synced']} file(s)")
+                for r in data.get("results", []):
+                    link = r.get("webViewLink", "")
+                    name = r.get("name", r.get("localPath", ""))
+                    if "error" in r:
+                        eprint(f"  ✗ {name}: {r['error']}")
+                    else:
+                        print(f"  ✓ {name}  {link}")
+            elif "files" in data:
+                for f in data["files"]:
+                    print(f"  {f.get('name','')}  {f.get('webViewLink','')}")
+            else:
+                print(json.dumps(data, indent=2))
+
+    if "--status" in argv:
+        status = check_auth_status()
+        out(status)
+        return 0 if status["authenticated"] else 1
+
+    folder = GDRIVE_FOLDER_ENV
+    # --folder overrides env for this invocation
+    if "--folder" in argv:
+        idx = argv.index("--folder")
+        if idx + 1 < len(argv):
+            folder = argv[idx + 1]
+
+    if "--upload" in argv:
+        idx = argv.index("--upload")
+        if idx + 1 >= len(argv):
+            eprint("--upload requires a file path argument")
+            return 2
+        local_path = argv[idx + 1]
+        try:
+            result = upload_file(local_path, folder, GDRIVE_ROOT_ID)
+            out(result)
+            return 0
+        except Exception as e:
+            out({"error": str(e)})
+            return 1
+
+    if "--sync-dir" in argv:
+        idx = argv.index("--sync-dir")
+        if idx + 1 >= len(argv):
+            eprint("--sync-dir requires a directory path argument")
+            return 2
+        local_dir = argv[idx + 1]
+        try:
+            results = sync_directory(local_dir, folder, GDRIVE_ROOT_ID)
+            errors = [r for r in results if "error" in r]
+            out({"synced": len(results) - len(errors), "results": results})
+            return 1 if errors else 0
+        except Exception as e:
+            out({"error": str(e)})
+            return 1
+
+    if "--sync-manifest" in argv:
+        idx = argv.index("--sync-manifest")
+        if idx + 1 >= len(argv):
+            eprint("--sync-manifest requires a manifest path argument")
+            return 2
+        manifest_path = argv[idx + 1]
+        try:
+            results = sync_from_manifest(manifest_path, folder, GDRIVE_ROOT_ID)
+            errors = [r for r in results if "error" in r]
+            out({"synced": len(results) - len(errors), "results": results})
+            return 1 if errors else 0
+        except Exception as e:
+            out({"error": str(e)})
+            return 1
+
+    if "--list" in argv:
+        idx = argv.index("--list")
+        list_folder_path = argv[idx + 1] if idx + 1 < len(argv) else folder
+        try:
+            files = list_folder(list_folder_path, GDRIVE_ROOT_ID)
+            out({"folder": list_folder_path, "files": files})
+            return 0
+        except Exception as e:
+            out({"error": str(e)})
+            return 1
+
+    eprint("No CLI action specified.  Use --upload, --sync-dir, --sync-manifest, --list, or --status")
+    eprint("For MCP server mode, omit all CLI flags.")
+    return 2
+
+
+# ── Entry point ───────────────────────────────────────────────────────────────
+
+def main() -> None:
+    argv = sys.argv[1:]
+    cli_flags = {"--upload", "--sync-dir", "--sync-manifest", "--list", "--status",
+                 "--folder", "--json"}
+    is_cli = any(f in argv for f in cli_flags)
+
+    if is_cli:
+        sys.exit(cli_main(argv))
+    else:
+        serve_stdio()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

**#65 rebased whole onto current main** — the render half plus the Google Drive sync it bundled. It was 114 commits behind with 3 conflicts; all resolved.

**Stacked on #86.** The first commit here is #86's render work; the second adds Drive. Review #86 first — if it merges, this reduces to the Drive commit alone.

> 🟡 **This PR is not ready to merge on my judgment — it needs an explicit decision from you.** See *The egress decision* below. Everything mechanical is done and green; the open question is policy, not code.

## The egress decision

Once `googleDrive.folderPath` (or `GDRIVE_FOLDER_PATH`) is set, **every content edit pushes rendered PDFs of that content to Google Drive**, via the `PostToolUse` hook, with **no per-upload confirmation**. Configuring the path is the only gate. Leaving it unset keeps everything local.

For an unpublished paper that is a real decision about where the manuscript lives, so it is called out rather than left implicit in a config key. The trigger is now commented at both call sites (`render-on-change.sh`, `build-pdf.sh`) so it is visible where it fires, not just where it is configured.

Credentials are never stored in the repo — resolved lazily from `GOOGLE_APPLICATION_CREDENTIALS`, `~/.config/google-drive-mcp/credentials.json`, or gcloud ADC.

## What lands (second commit)

| Piece | What |
|---|---|
| `src/google-drive-mcp.py` | Dual-mode: **MCP stdio** (`drive_status`, `drive_upload_file`, `drive_list_folder`, `drive_sync_manifest`, `drive_sync_block_pdfs`) and a **CLI** (`--upload` / `--sync-dir` / `--sync-manifest` / `--list` / `--status`) for the bash hooks. |
| `scripts/google-drive-mcp.sh` | MCP launcher; reads `folio.config.json` → `googleDrive.folderPath`. |
| `render-changed-blocks.ts` | `--upload-drive` / `--drive-folder`. |
| `paper_render_pdf` | `upload_drive` / `drive_folder` params. |
| `build-pdf.sh` | Step 5: syncs `main.pdf`, appendices, and the split manifest. |
| `.mcp.json` | Registers the Drive server. |

Drive layout: `/blocks/<name>.pdf`, `/chapters/`, `/appendices/`, `main.pdf`.

## One hard-gate failure fixed

`src/google-drive-mcp.py` carried an unused `import shutil` — **ruff F401**, which main runs as a **hard gate**. #65 predates that gate, which is why it never showed a check run; run against current main it fails. Fixed here.

(The render half had five more, all lint errors under rules main has since promoted — fixed in #86.)

## Test plan

- [x] `ruff check --select F401,F403` over the repo's own six Python trees (the workflow's exact rule and target list) — **All checks passed**
- [x] `python3 -m py_compile src/google-drive-mcp.py` — clean
- [x] `bun run typecheck` — clean
- [x] `bunx eslint` on changed TS — clean
- [x] `bash -n` on all three changed shell scripts — clean
- [x] `bun test` — **538 pass / 35 skip / 7 fail**

⚠️ The 7 failures are **pre-existing and unrelated** — `lean-triviality-probe` splice tests needing a Lean toolchain. Identical count on clean `main`.

⚠️ **The upload path is unrun.** No Google credentials and no `latexmk` in this container, so no PDF was compiled and nothing was uploaded. Static checks only — the Drive round-trip needs exercising on a configured machine before this is trusted. I am not reporting it as verified.

## Files

- [`src/google-drive-mcp.py`](https://github.com/litlfred/folio-assistant/blob/claude/block-pdf-drive-rebase-2026-08-08/src/google-drive-mcp.py)
- [`scripts/google-drive-mcp.sh`](https://github.com/litlfred/folio-assistant/blob/claude/block-pdf-drive-rebase-2026-08-08/scripts/google-drive-mcp.sh)
- [`scripts/render-changed-blocks.ts`](https://github.com/litlfred/folio-assistant/blob/claude/block-pdf-drive-rebase-2026-08-08/scripts/render-changed-blocks.ts)
- [`adapters/paper/tools/render.ts`](https://github.com/litlfred/folio-assistant/blob/claude/block-pdf-drive-rebase-2026-08-08/adapters/paper/tools/render.ts)
- [`scripts/render-on-change.sh`](https://github.com/litlfred/folio-assistant/blob/claude/block-pdf-drive-rebase-2026-08-08/scripts/render-on-change.sh)
- [`scripts/docker-latex-build/build-pdf.sh`](https://github.com/litlfred/folio-assistant/blob/claude/block-pdf-drive-rebase-2026-08-08/scripts/docker-latex-build/build-pdf.sh)

Supersedes #65 (rebased whole). #86 is the same work minus Drive.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jd1YQmjcqq9zhAwYPYpnjS)_