### PR TITLE
Three gates that could not fail correctly: reseed verify, and the proof-axis dashboard

### DIFF
--- a/content/pipeline/proof-axis-dashboard.ts
+++ b/content/pipeline/proof-axis-dashboard.ts
@@ -23,12 +23,21 @@ interface Args {
 }
 
 function parseArgs(argv: string[]): Args {
-  const out: Args = { root: requirePaper(), json: false };
+  // Read the positional argument FIRST, then fall back to auto-detection.
+  //
+  // This computed `requirePaper()` as the initial value of `out.root`, which
+  // is eager: the fallback ran before the loop could see an explicit
+  // argument, so in any repo with more than one paper `requirePaper` threw
+  // ("N papers found — name one explicitly") even when a paper *was* named.
+  // qou carries five, so the dashboard could not be run there at all.
+  // `requirePaper` already takes `explicit?` for exactly this — pass it.
+  let root: string | undefined;
+  let json = false;
   for (const a of argv) {
-    if (a === "--json") out.json = true;
-    else if (!a.startsWith("-")) out.root = a;
+    if (a === "--json") json = true;
+    else if (!a.startsWith("-")) root = a;
   }
-  return out;
+  return { root: requirePaper(root), json };
 }
 
 interface CriterionSummary {

--- a/content/pipeline/proof-axis-dashboard.ts
+++ b/content/pipeline/proof-axis-dashboard.ts
@@ -68,7 +68,29 @@ import { WATCHER_CRITERIA_BY_AXIS } from "./qa-criteria-registry";
 
 function main() {
   const args = parseArgs(process.argv.slice(2));
-  const rootPath = resolve(REPO_ROOT, "content", args.root);
+
+  // `args.root` may be either a PAPER NAME (resolved under this platform's
+  // own `content/`, which is how it works when the platform repo also holds
+  // the content) or a PATH to a content root. The second case is the normal
+  // one: folio-assistant is the platform, and the folio it serves lives in a
+  // separate repo, so `<platform>/content/<paper>` does not exist there.
+  //
+  // Resolving only the first way meant this dashboard could not be pointed at
+  // a real folio at all — `find` errored, zero blocks were walked, and every
+  // criterion scored 0/0. Accept a path when one is given, like `qa-sweep.ts`
+  // already does.
+  const asPath = resolve(process.cwd(), args.root);
+  const rootPath = existsSync(asPath) ? asPath : resolve(REPO_ROOT, "content", args.root);
+  if (!existsSync(rootPath)) {
+    console.error(
+      `proof-axis-dashboard: no such content root: ${args.root}\n` +
+        `  tried (as path):  ${asPath}\n` +
+        `  tried (as paper): ${resolve(REPO_ROOT, "content", args.root)}\n` +
+        `Pass the path to the folio's content root, e.g.\n` +
+        `  bun run <platform>/content/pipeline/proof-axis-dashboard.ts content/<paper>`,
+    );
+    process.exit(2);
+  }
 
   const proofCriteria = WATCHER_CRITERIA_BY_AXIS["proof"] ?? [];
 
@@ -232,8 +254,24 @@ function main() {
 
   console.log(`\n── Summary ────────────────────────────────────────`);
   const anyFail = Object.values(summaries).some(s => s.fail > 0);
+  const totalFail = Object.values(summaries).reduce((a, s) => a + s.fail, 0);
   const totalWarn = Object.values(summaries).reduce((a,s) => a + s.warn, 0);
-  console.log(`Automated: ${anyFail ? "FAIL" : "PASS"} (0 failures)`);
+
+  // An empty scan is NOT a pass. Every criterion scoring 0/0/0 used to print
+  // "Automated: PASS (0 failures)", which reads as a clean bill of health and
+  // is indistinguishable from one — the single most misleading thing a gate
+  // can do. If nothing was examined, say so and exit non-zero so a caller
+  // (e.g. /prepare-merge) cannot quote it as green.
+  if (totalBlocks === 0) {
+    console.log(`Automated: NO DATA — 0 blocks walked under ${rootPath}`);
+    console.log(`This is not a pass. Check the content root argument.`);
+    console.log(``);
+    process.exit(1);
+  }
+
+  // The count was hardcoded to 0, so a genuine failure printed
+  // "FAIL (0 failures)".
+  console.log(`Automated: ${anyFail ? "FAIL" : "PASS"} (${totalFail} failures)`);
   console.log(`Warnings: ${totalWarn} (${stubs.length} stubs + ${mismatches.length} mismatches)`);
   console.log(`Sorry closure: ${deferred.length} deferred files actionable with Lean`);
   console.log(``);

--- a/docs/reference/skill-instructions/document-intake.md
+++ b/docs/reference/skill-instructions/document-intake.md
@@ -116,17 +116,48 @@ per [`bib-qa.md §Batch intake pipeline`](bib-qa.md#batch-intake-pipeline).
 
 Convert raw format to `extracted-text.md`:
 
+**For PDFs, always start with
+[`scripts/pdf-extract.py`](../../scripts/pdf-extract.py)** — do not reach for a
+Python PDF library directly. It walks a fallback ladder (`pdftotext` → `pypdf` →
+`pdfminer.six` → a zero-dependency content-stream extractor → OCR) and, when it
+cannot read a file, **tells you which rung failed and why** instead of returning
+an empty string:
+
+```bash
+python3 scripts/pdf-extract.py FILE.pdf -o extracted-text.md
+python3 scripts/pdf-extract.py FILE.pdf --diagnose   # structure only
+```
+
+Exit `0` = text; **exit `2` = no text layer (a scan)**; exit `3` = a parser
+problem on a file that does have text.
+
+Two failure modes it exists to prevent, both observed in practice:
+
+* **A silent empty extraction reads exactly like a scan, a broken library, and
+  a malformed PDF.** The script separates them by inspecting the PDF structure
+  (`CCITTFaxDecode` / `JBIG2Decode` / `DCTDecode` counts against `/Font`), so
+  "swap libraries" vs "you need OCR" is decided by evidence rather than guessed.
+* **A broken native extension kills the whole pipeline.** `pypdf` and
+  `pdfminer.six` both fail via pyo3 `PanicException` when `cryptography`'s Rust
+  bindings are broken — and that is a `BaseException`, so an ordinary
+  `except Exception` does **not** catch it. Every rung is guarded accordingly.
+  The zero-dependency rung exists precisely for this case; in the container this
+  was written in it was the only rung that worked.
+
 | Format | Extraction method |
 |--------|-------------------|
-| PDF (text) | `pdftotext` or PDF.js |
-| PDF (scan) | Tesseract OCR / Claude vision |
+| PDF (text) | `scripts/pdf-extract.py` (ladder; `pdftotext` when available) |
+| PDF (scan) | `scripts/pdf-extract.py` → exit 2, then Tesseract OCR / Claude vision |
 | LaTeX | Direct parse (strip preamble) |
 | HTML | Readability + turndown |
 | DOCX | Pandoc → markdown |
 | Images | Claude vision API |
 
-For scanned documents, use Claude's vision capability to extract
-text with structural awareness (headings, lists, tables, boxes).
+For scanned documents the script's OCR rung fires automatically **if**
+`tesseract` and `pdftoppm` are installed (`apt-get install -y tesseract-ocr
+poppler-utils`); it names whichever is missing. Where OCR is unavailable, or
+where layout carries meaning (headings, lists, tables, boxes), fall back to
+Claude's vision capability, which reads structure that OCR flattens.
 
 **Output**: `extracted-text.md` — raw markdown with preserved structure.
 

--- a/scripts/reseed-lean-cache.sh
+++ b/scripts/reseed-lean-cache.sh
@@ -235,6 +235,29 @@ github.com release assets usually are not — check that first."
   fi
 fi
 
+# ── Reading `lake-cache.sh status` ──────────────────────────────────
+#
+# Both phase 2 and phase 5 scrape the SAME human-readable `status`
+# output, so they must share one parser. They did not, and it cost a
+# release: phase 2 was updated when the line changed from
+# `traces: N (P% coverage)` to `traced: N/M oleans (P%)`, phase 5 was
+# not. Phase 5's gate is `[ cov -ge 90 ]` against an unmatched (hence
+# empty, hence 0) capture, so **verify could never pass** and
+# `--promote` / `--auto-promote` were unreachable — on a tree reporting
+# a clean 5267/5267, 100%.
+#
+# Failing to 0 is the safe direction, but only if someone notices. Keep
+# these three readers as the single place that knows the format.
+cache_status_cov()   { # <status output> -> integer percent, empty if unreadable
+  printf '%s\n' "$1" | sed -n 's/^ *traced: *[0-9]*\/[0-9]* oleans *(\([0-9]*\)%).*/\1/p' | head -1
+}
+cache_status_own()   { # <status output> -> own-package olean count
+  printf '%s\n' "$1" | sed -n 's/^ *own pkg: *\([0-9]*\).*/\1/p' | head -1
+}
+cache_status_total() { # <status output> -> total olean count
+  printf '%s\n' "$1" | sed -n 's/^ *oleans: *\([0-9]*\).*/\1/p' | head -1
+}
+
 # ── Phase 2: traced Mathlib ─────────────────────────────────────────
 
 if phase_wanted cache; then
@@ -243,21 +266,16 @@ if phase_wanted cache; then
   # from `git rev-parse` in the current directory, so invoking it from
   # the platform checkout would resolve folio-assistant as the content
   # repo and read the wrong roster.
-  # Scraped from `status`'s human-readable output, so the two are
-  # COUPLED: renaming that line silently degrades this to 0. It already
-  # did once — `traces: N (P% coverage)` became
-  # `traced: N/M oleans (P%)` and this quietly reported 0% on a fully
-  # traced tree. Failing to 0 is the safe direction (it fetches, and
-  # `cache get` is idempotent), but silence hides the breakage, so say so.
+  # Scraped from `status`'s human-readable output — see the shared
+  # readers above; do not inline a second copy of the pattern here.
   status_out=$(cd "$REPO" && bash "$CACHE_SVC" status --package "$PACKAGE" --lake-root "$ABS_LAKE" 2>/dev/null)
-  cov=$(printf '%s\n' "$status_out" \
-        | sed -n 's/^ *traced: *[0-9]*\/[0-9]* oleans *(\([0-9]*\)%).*/\1/p' | head -1)
+  cov=$(cache_status_cov "$status_out")
   if [ -z "$cov" ]; then
     warn "could not read trace coverage from \`$CACHE_SVC status\` — assuming 0%"
     info "(its output format may have changed; this parser needs updating)"
     cov=0
   fi
-  nol=$(printf '%s\n' "$status_out" | sed -n 's/^ *oleans: *\([0-9]*\).*/\1/p' | head -1)
+  nol=$(cache_status_total "$status_out")
   nol="${nol:-0}"
   # Coverage is a RATIO, so a nearly-empty tree scores 100% on a handful
   # of oleans and would skip fetching thousands. Observed: a partially
@@ -335,15 +353,15 @@ if phase_wanted verify || [ "$PROMOTE" -eq 1 ]; then
     printf '%s\n' "$out" | sed 's/^/   /'
     rm -rf "$VDIR"
 
-    own=$(printf '%s' "$out" | sed -n 's/.*own pkg: *\([0-9]*\).*/\1/p')
-    cov=$(printf '%s' "$out" | sed -n 's/.*traces:.*(\([0-9]*\)% coverage).*/\1/p')
+    own=$(cache_status_own "$out")
+    cov=$(cache_status_cov "$out")
     [ "${own:-0}" -gt 0 ] || die "verify FAILED: own-package oleans are 0.
 That is the defect this reseed exists to fix — do not promote."
     [ "${cov:-0}" -ge 90 ] || die "verify FAILED: trace coverage ${cov:-0}%.
 A build would rebuild and evict the shortfall — do not promote."
     info "verified: own=$own, traces=${cov}% ✓"
     # Carried into the regression check below.
-    VERIFIED_OLEANS=$(printf '%s' "$out" | sed -n 's/.*oleans: *\([0-9]*\).*/\1/p' | head -1)
+    VERIFIED_OLEANS=$(cache_status_total "$out")
     VERIFIED_OWN="$own"
   fi
 fi


### PR DESCRIPTION
Found while running `/prepare-merge`'s paper gates against qou. Each of these is a check that could not do its job, and two of them reported success while doing nothing.

## 1. `reseed-lean-cache.sh` verify could never pass

Phase 5 scrapes `lake-cache.sh status` for trace coverage and gates promotion on `[ cov -ge 90 ]`. It matched

```
traces: N (P% coverage)
```

but `status` has printed

```
traced:     N/M oleans  (P%)
```

for some time. The capture was empty, `${cov:-0}` made it `0`, and the gate died with **"verify FAILED: trace coverage 0%"** — on a tree whose own status output two lines above read `traced: 5267/5267 oleans (100%)`.

Since `--promote` and `--auto-promote` both imply verify, **the reseed workflow could not publish at all.** Every run stopped at phase 5 accusing the cache of a defect it did not have. Hit reseeding qou after the build-coverage drain: seed wrote 5267 oleans / 1677 own, the clean-clone restore replayed every one, and verify still refused.

Phase 2 reads the same line and had already been fixed — its comment even records the format change and warns the two are coupled:

```
# It already did once — `traces: N (P% coverage)` became
# `traced: N/M oleans (P%)` and this quietly reported 0% ...
```

The fix was applied in one place and missed in the other, which is the argument for not having two places. Both phases, plus the two count reads feeding the no-shrink regression check, now go through three shared readers (`cache_status_cov` / `_own` / `_total`) defined once next to the note about why they must stay together. Verified against live output: `cov=100, own=1677, total=5267`, where phase 5's pattern returned empty for all three.

Note the failure *direction*. Reading 0 is safe in phase 2 — it just re-fetches, and `cache get` is idempotent — but in phase 5 it is a hard `die`. A parser that silently degrades is fine only where degradation is harmless.

## 2. `proof-axis-dashboard` could not read a folio, and called an empty scan PASS

```ts
const rootPath = resolve(REPO_ROOT, "content", args.root);
```

`REPO_ROOT` is folio-assistant's own root, so pointing this at a folio looked for `<platform>/content/<paper>` — a path that does not exist and cannot, since the platform is not the content. `find` errored to stderr, `walkBlocks` walked nothing, and the run completed.

Then:

```
── Summary ──
Automated: PASS (0 failures)
```

Every criterion scored 0/0/0 because nothing was examined, and the summary was **indistinguishable from a genuinely clean run**. A caller like `/prepare-merge` would quote it as a passing gate. An empty scan now prints `NO DATA — 0 blocks walked under <path>`, says plainly that it is not a pass, and exits 1.

Also in that line: the failure count was the literal `0`, so a real failure printed `FAIL (0 failures)`. It now prints the total.

Effect on qou: before, `PASS (0 failures)` over 0 blocks. After, **3423 blocks / 1216 with a `.lean` sibling, `FAIL (8 failures)`**, plus 19 files / 28 sorries in content-block siblings the dashboard had been reporting as 0.

## 3. …and then an explicit paper argument could never be used

`main` added `repo-root.ts`/`requirePaper()` — a more thorough answer to the same platform-vs-folio problem. But the call site is eager:

```ts
const out: Args = { root: requirePaper(), json: false };
for (const a of argv) { … else if (!a.startsWith("-")) out.root = a; }
```

`requirePaper()` runs *before* the loop can see a positional argument, so in any repo with more than one paper it throws `N papers found — name one explicitly` **even when a paper was named**. qou carries five, so the dashboard aborted in `parseArgs` and could not be run there at all.

`requirePaper` already takes `explicit?` and returns it untouched — read the argument first, then pass it in. Verified: the same 3423 blocks and same 8 failures as the pre-merge run, so this restores the tool rather than changing what it measures.

## The common shape

All three are checks that cannot distinguish *clean* from *did not run*, and two of them resolved that ambiguity as success. That is the same defect the qou work this came from was about — `lake build` reporting green over 53% of the tree — and it is worth stating as a rule: **a gate that can report success without examining anything is not a gate.**

## Also included

`docs/reference/skill-instructions/document-intake.md` regenerated. That drift arrived with main — the skill body gained the `pdf-extract.py` section and the generated reference was not re-run. Not from this branch, but `/prepare-merge` gates on the two being in sync.

## Verification

- [x] `bun test` — 556 pass, 28 skip, **0 fail**
- [x] `eslint .` — 0 errors
- [x] generated docs in sync (after the regeneration above)
- [x] `main` merged in, no conflicts
- [x] reseed verify exercised end-to-end against qou: `verified: own=1677, traces=100% ✓`
- [x] dashboard exercised against qou before and after: identical block counts and failure set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014boi4AkMAATWvkNf9vjVTm

---
_Generated by [Claude Code](https://claude.ai/code/session_014boi4AkMAATWvkNf9vjVTm)_