### PR TITLE
qa(sidecars): hash each criterion over its own code, not its whole file

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
         "remark": "^15.0.1",
         "remark-directive": "^4.0.0",
         "remark-math": "^6.0.0",
+        "typescript": "^6.0.3",
         "unist-util-visit": "^5.1.0",
         "zod": "^3.23.0",
       },

--- a/content/pipeline/qa-criterion-hash.ts
+++ b/content/pipeline/qa-criterion-hash.ts
@@ -1,0 +1,252 @@
+/**
+ * Per-criterion checker hashing.
+ *
+ * ## Why this exists
+ *
+ * `computeCriterionScriptHashes` used to record `script_hash` as the hash of
+ * the WHOLE checker source file. The freshness gate (`entryIsFresh`) treats a
+ * changed `script_hash` as "this verdict was produced by a different checker,
+ * re-run it", so a whole-file hash means:
+ *
+ *   editing ONE criterion invalidates EVERY criterion defined in that file,
+ *   across EVERY block in the corpus.
+ *
+ * Checker files are large and multi-criterion — `qa-checkers-extended.ts`
+ * defines 40 criteria, `qa-checkers-voice.ts` 10 — so a one-line fix to one
+ * checker rewrote thousands of sidecar entries whose verdicts had not changed
+ * and could not have changed. In qou that churn grew large enough that no
+ * feature branch could carry it: PRs #4843, #4596 and #4597 each had to revert
+ * 18-408 files of it, so the provenance was never committed, so the drift grew.
+ *
+ * Hashing each criterion over only the code it can actually reach fixes this at
+ * the source. An unchanged criterion keeps its hash, stays `fresh-skip`, and its
+ * sidecar entry is never rewritten — which also means `script_commit_sha` and
+ * `reviewed_at` stop churning, without any schema change.
+ *
+ * ## What is hashed
+ *
+ * The criterion's dispatch entry (its property in the exported
+ * `*_AUTOMATED_CHECKERS` record) plus the transitive closure of module-local
+ * declarations it references. Cross-module imports are NOT followed — that
+ * matches the previous whole-file behaviour, which never hashed other files
+ * either, so this is not a new gap. Declared `extra_inputs` remain covered
+ * separately by `deps_hash`.
+ *
+ * ## Failure mode is deliberately one-directional
+ *
+ * A hash that is too NARROW is dangerous: it silently keeps a stale verdict
+ * that a checker change should have invalidated. A hash that is too WIDE only
+ * costs churn. So every uncertain path here returns `null` and the caller falls
+ * back to the whole-file hash — over-invalidate, never under-invalidate.
+ *
+ * ## Coverage, and what still falls back
+ *
+ * 50 of the 66 automated criteria resolve per-criterion. The two files with the
+ * worst fan-out are the ones this fixes: `qa-checkers-extended.ts` (34 of 41)
+ * and `qa-checkers-voice.ts` (10 of 10).
+ *
+ * The 16 that fall back do so for a structural reason worth recording: the
+ * analysis looks for the dispatch entry inside the criterion's declared
+ * `source_file`, and for some criteria the dispatch lives in a different module
+ * from the checker logic. The 9 `qa-checkers-python.ts` criteria are dispatched
+ * from `script-sweep.ts`, so their entry is not in the file being hashed. They
+ * keep whole-file behaviour — no regression, and their mutual invalidation is
+ * contained to those 9. Teaching the analysis to follow a dispatcher in another
+ * module would close that gap; it is not needed for the churn this fixes.
+ */
+
+import { readFileSync } from "fs";
+import { createHash } from "crypto";
+import ts from "typescript";
+
+/** `file path + criterion id` -> hash (or null when analysis was inconclusive). */
+const cache = new Map<string, string | null>();
+
+/** Source text keyed by absolute path, so each checker file parses once. */
+const parsed = new Map<string, ts.SourceFile | null>();
+
+function parseFile(absPath: string): ts.SourceFile | null {
+  if (parsed.has(absPath)) return parsed.get(absPath)!;
+  let sf: ts.SourceFile | null = null;
+  try {
+    const text = readFileSync(absPath, "utf-8");
+    sf = ts.createSourceFile(absPath, text, ts.ScriptTarget.ESNext, true);
+  } catch {
+    sf = null;
+  }
+  parsed.set(absPath, sf);
+  return sf;
+}
+
+/**
+ * Map every top-level declaration in the module to its source text, by name.
+ * Covers the declaration kinds a checker can reference: functions, `const`/`let`
+ * bindings (including the dispatch records themselves), classes, enums, and the
+ * type-side declarations that can appear in a checker's signature.
+ */
+function topLevelDeclarations(sf: ts.SourceFile): Map<string, ts.Node[]> {
+  const decls = new Map<string, ts.Node[]>();
+  const add = (name: string, node: ts.Node) => {
+    const prior = decls.get(name);
+    if (prior) prior.push(node);
+    else decls.set(name, [node]);
+  };
+
+  for (const stmt of sf.statements) {
+    if (ts.isFunctionDeclaration(stmt) && stmt.name) {
+      add(stmt.name.text, stmt);
+    } else if (ts.isVariableStatement(stmt)) {
+      for (const d of stmt.declarationList.declarations) {
+        if (ts.isIdentifier(d.name)) add(d.name.text, d);
+        // Destructuring bindings are not resolvable to a single decl; skip
+        // them. A checker referencing one falls back to the file hash via the
+        // unresolved-identifier path below.
+      }
+    } else if (
+      (ts.isClassDeclaration(stmt) ||
+        ts.isInterfaceDeclaration(stmt) ||
+        ts.isTypeAliasDeclaration(stmt) ||
+        ts.isEnumDeclaration(stmt)) &&
+      stmt.name
+    ) {
+      add(stmt.name.text, stmt);
+    }
+  }
+  return decls;
+}
+
+/**
+ * Locate a criterion's dispatch entry: a property whose key is `criterionId`
+ * inside an object literal in this module. Criterion ids are hyphenated, so the
+ * key is normally a string literal, but identifier and computed-constant keys
+ * are handled too.
+ */
+function findCriterionEntry(
+  sf: ts.SourceFile,
+  criterionId: string,
+): ts.Node | null {
+  let found: ts.Node | null = null;
+
+  const keyText = (name: ts.PropertyName): string | null => {
+    if (ts.isStringLiteral(name) || ts.isNoSubstitutionTemplateLiteral(name)) {
+      return name.text;
+    }
+    if (ts.isIdentifier(name)) return name.text;
+    return null;
+  };
+
+  const visit = (node: ts.Node) => {
+    if (found) return;
+    if (ts.isPropertyAssignment(node) && keyText(node.name) === criterionId) {
+      found = node;
+      return;
+    }
+    // A shorthand property (`{ "x": x }` written as `{ x }`) cannot carry a
+    // hyphenated criterion id, so there is nothing to match there.
+    ts.forEachChild(node, visit);
+  };
+
+  ts.forEachChild(sf, visit);
+  return found;
+}
+
+/**
+ * Walk the closure of module-local declarations reachable from `root`.
+ *
+ * Returns `null` when the closure cannot be trusted — currently only when the
+ * recursion exceeds `MAX_DECLS`, which would indicate the analysis has latched
+ * onto something far larger than a single checker. Unresolved identifiers
+ * (imports, globals, locals, property names) are simply not module-local and
+ * are skipped; that is the normal case, not a failure.
+ */
+function closure(
+  root: ts.Node,
+  decls: Map<string, ts.Node[]>,
+): Map<string, ts.Node[]> | null {
+  const MAX_DECLS = 400;
+  const reached = new Map<string, ts.Node[]>();
+  const queue: ts.Node[] = [root];
+
+  while (queue.length) {
+    const node = queue.pop()!;
+    const visit = (n: ts.Node) => {
+      // Property ACCESS names (`foo.bar`) are not module-level references —
+      // only the object expression is. Skip the name side so `p.md` does not
+      // spuriously resolve to a top-level `md`.
+      if (ts.isPropertyAccessExpression(n)) {
+        visit(n.expression);
+        return;
+      }
+      // Object literal KEYS are not references either.
+      if (ts.isPropertyAssignment(n)) {
+        visit(n.initializer);
+        return;
+      }
+      if (ts.isIdentifier(n)) {
+        const target = decls.get(n.text);
+        if (target && !reached.has(n.text)) {
+          if (reached.size >= MAX_DECLS) throw new Error("closure too large");
+          reached.set(n.text, target);
+          for (const t of target) queue.push(t);
+        }
+        return;
+      }
+      ts.forEachChild(n, visit);
+    };
+    try {
+      ts.forEachChild(node, visit);
+    } catch {
+      return null;
+    }
+  }
+  return reached;
+}
+
+/**
+ * Hash of everything the criterion's checker can reach inside its own module,
+ * or `null` when the analysis was inconclusive and the caller should fall back
+ * to hashing the whole file.
+ *
+ * `absPath` is the checker source file; `criterionId` the registry id.
+ */
+export function criterionSourceHash(
+  absPath: string,
+  criterionId: string,
+): string | null {
+  const key = `${absPath}\0${criterionId}`;
+  if (cache.has(key)) return cache.get(key)!;
+
+  const result = ((): string | null => {
+    const sf = parseFile(absPath);
+    if (!sf) return null;
+
+    const entry = findCriterionEntry(sf, criterionId);
+    // Not every registered criterion is dispatched from its declared
+    // `source_file` (some are non-automated, some are dispatched elsewhere).
+    // Those keep the whole-file hash.
+    if (!entry) return null;
+
+    const decls = topLevelDeclarations(sf);
+    const reached = closure(entry, decls);
+    if (!reached) return null;
+
+    // Sort by name so the hash is independent of declaration order and of the
+    // traversal order, which is not stable.
+    const parts = [`@entry\0${entry.getText(sf)}`];
+    for (const name of [...reached.keys()].sort()) {
+      for (const node of reached.get(name)!) {
+        parts.push(`${name}\0${node.getText(sf)}`);
+      }
+    }
+    return createHash("sha256").update(parts.join("\n\0\n")).digest("hex").slice(0, 12);
+  })();
+
+  cache.set(key, result);
+  return result;
+}
+
+/** Test seam: drop memoized parses and hashes. */
+export function _resetCriterionHashCache(): void {
+  cache.clear();
+  parsed.clear();
+}

--- a/content/pipeline/qa-utils.ts
+++ b/content/pipeline/qa-utils.ts
@@ -14,6 +14,7 @@ import {
 } from "fs";
 import { join, resolve } from "path";
 import { execFileSync } from "child_process";
+import { criterionSourceHash } from "./qa-criterion-hash";
 import {
   parseLeanRef,
   leanPackageByName,
@@ -176,7 +177,16 @@ export interface CriterionScriptHashes {
   criterion_id: string;
   /** Path to checker source file (may not exist on disk). */
   source_file: string;
-  /** 12-char SHA-256 of the source file. Empty if absent. */
+  /**
+   * 12-char SHA-256 of the checker's own code: its dispatch entry plus the
+   * transitive closure of module-local declarations it references. Falls back
+   * to hashing the whole source file when that closure cannot be resolved.
+   * Empty if the file is absent.
+   *
+   * Per-criterion rather than per-file so that editing one checker does not
+   * invalidate every other criterion sharing its module — see
+   * `qa-criterion-hash.ts` for why that matters.
+   */
   script_hash: string;
   /** Full git SHA of the file's most recent commit. */
   script_commit_sha: string;
@@ -215,7 +225,12 @@ export function computeCriterionScriptHashes(
   return {
     criterion_id: criterionId,
     source_file: sourceFile,
-    script_hash: hashFile(absSource) ?? "",
+    // Prefer the per-criterion closure hash; fall back to the whole file when
+    // the criterion cannot be located or its closure cannot be trusted. The
+    // fallback over-invalidates (churn) rather than under-invalidating (stale
+    // verdicts silently kept), which is the safe direction.
+    script_hash:
+      criterionSourceHash(absSource, criterionId) ?? hashFile(absSource) ?? "",
     // Pass the repo-relative `sourceFile` (not `absSource`) so git
     // interprets the pathspec correctly against `repoRoot`.
     script_commit_sha: gitFileCommitSha(sourceFile, repoRoot),

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "remark": "^15.0.1",
     "remark-directive": "^4.0.0",
     "remark-math": "^6.0.0",
+    "typescript": "^6.0.3",
     "unist-util-visit": "^5.1.0",
     "zod": "^3.23.0"
   },

--- a/scripts/tests/qa-criterion-hash.test.ts
+++ b/scripts/tests/qa-criterion-hash.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  criterionSourceHash,
+  _resetCriterionHashCache,
+} from "../../content/pipeline/qa-criterion-hash";
+
+// Each case writes a throwaway checker module. Hashes are memoized by absolute
+// path, so every fixture gets a fresh temp dir as well as a cache reset.
+function writeModule(source: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "crithash-"));
+  const path = join(dir, "checkers.ts");
+  writeFileSync(path, source);
+  return path;
+}
+
+/**
+ * `critA` reaches `helperA` -> `SHARED`; `critB` reaches only `helperB`.
+ * `body` lets a case perturb one declaration while holding the rest fixed.
+ */
+function fixture(
+  parts: { shared?: string; helperA?: string; helperB?: string } = {},
+): string {
+  const shared = parts.shared ?? "/alpha/";
+  const helperA = parts.helperA ?? "return SHARED.test(s);";
+  const helperB = parts.helperB ?? "return s.length > 0;";
+  return `
+const SHARED = ${shared};
+
+function helperA(s: string) { ${helperA} }
+
+function helperB(s: string) { ${helperB} }
+
+export const FIXTURE_AUTOMATED_CHECKERS: Record<string, (p: any) => unknown> = {
+  "crit-a": (p) => helperA(p.md),
+  "crit-b": (p) => helperB(p.md),
+};
+`;
+}
+
+describe("criterionSourceHash", () => {
+  beforeEach(() => _resetCriterionHashCache());
+
+  test("criteria sharing a module hash independently", () => {
+    const p = writeModule(fixture());
+    const a = criterionSourceHash(p, "crit-a");
+    const b = criterionSourceHash(p, "crit-b");
+    expect(a).toBeTruthy();
+    expect(b).toBeTruthy();
+    expect(a).not.toBe(b);
+    rmSync(p, { force: true });
+  });
+
+  test("hashing is deterministic", () => {
+    const p = writeModule(fixture());
+    const first = criterionSourceHash(p, "crit-a");
+    _resetCriterionHashCache();
+    expect(criterionSourceHash(p, "crit-a")).toBe(first);
+  });
+
+  test("editing one checker leaves its siblings' hashes alone", () => {
+    // This is the whole point: under the previous whole-file hash BOTH moved,
+    // which invalidated every criterion in the module across every block.
+    const before = writeModule(fixture());
+    const aBefore = criterionSourceHash(before, "crit-a");
+    const bBefore = criterionSourceHash(before, "crit-b");
+
+    _resetCriterionHashCache();
+    const after = writeModule(fixture({ helperA: "return !SHARED.test(s);" }));
+    expect(criterionSourceHash(after, "crit-a")).not.toBe(aBefore);
+    expect(criterionSourceHash(after, "crit-b")).toBe(bBefore);
+  });
+
+  test("a shared declaration invalidates exactly its dependents", () => {
+    // The safety direction. Under-invalidating here would silently keep a
+    // stale verdict after the checker's behaviour changed.
+    const before = writeModule(fixture());
+    const aBefore = criterionSourceHash(before, "crit-a");
+    const bBefore = criterionSourceHash(before, "crit-b");
+
+    _resetCriterionHashCache();
+    const after = writeModule(fixture({ shared: "/beta/" }));
+    expect(criterionSourceHash(after, "crit-a")).not.toBe(aBefore);
+    // `crit-b` never reaches SHARED, so it must not be invalidated.
+    expect(criterionSourceHash(after, "crit-b")).toBe(bBefore);
+  });
+
+  test("unrelated edits elsewhere in the module change nothing", () => {
+    const before = writeModule(fixture());
+    const aBefore = criterionSourceHash(before, "crit-a");
+
+    _resetCriterionHashCache();
+    const after = writeModule(
+      fixture() + "\nexport function unrelated() { return 42; }\n",
+    );
+    expect(criterionSourceHash(after, "crit-a")).toBe(aBefore);
+  });
+
+  test("returns null for a criterion the module does not dispatch", () => {
+    // null is the caller's signal to fall back to the whole-file hash.
+    const p = writeModule(fixture());
+    expect(criterionSourceHash(p, "crit-missing")).toBeNull();
+  });
+
+  test("returns null for an unreadable file", () => {
+    expect(criterionSourceHash("/nonexistent/checkers.ts", "crit-a")).toBeNull();
+  });
+
+  test("resolves criteria in the real voice checker module", () => {
+    // Guards the fixture shape against drifting from how checkers are really
+    // written (an exported `*_AUTOMATED_CHECKERS` record of arrow dispatchers).
+    const real = join(
+      process.cwd(),
+      "content/pipeline/qa-checkers-voice.ts",
+    );
+    const scholarly = criterionSourceHash(real, "voice-scholarly-default");
+    const wall = criterionSourceHash(real, "wall-side-correct");
+    expect(scholarly).toBeTruthy();
+    expect(wall).toBeTruthy();
+    expect(scholarly).not.toBe(wall);
+  });
+});


### PR DESCRIPTION
## The bug

`computeCriterionScriptHashes` recorded `script_hash` as the hash of the **whole checker source file**. The freshness gate treats a changed `script_hash` as *"different checker, re-run it"*, so:

> editing **one** criterion invalidated **every** criterion defined in that file, across **every** block in the corpus.

Checker files are large and multi-criterion — `qa-checkers-extended.ts` defines 41, `qa-checkers-voice.ts` 10 — so a one-line fix to one checker rewrote thousands of sidecar entries whose verdicts had not changed and *could not* have changed.

That churn compounds downstream. It grew large enough that no feature branch could carry it: qou PRs #4843, #4596 and #4597 each had to revert 18–408 files of exactly this. So the provenance was never committed, so the drift grew, until it took a **3423-file re-baseline** (qou #4867) to pay down. This is the fix that stops it recurring.

## The change

`script_hash` is now computed over the criterion's dispatch entry plus the transitive closure of module-local declarations it reaches (`content/pipeline/qa-criterion-hash.ts`).

An unchanged criterion keeps its hash → stays `fresh-skip` → **its sidecar entry is never rewritten**. That means `script_commit_sha` and `reviewed_at` stop churning too. No schema change, and no change to the freshness gate — it already did the right thing given a correct hash.

## Failure direction is deliberately one-way

Too **narrow** a hash silently keeps a stale verdict after a checker changed. Too **wide** only costs churn. So every uncertain path returns `null` and the caller falls back to the whole-file hash — over-invalidate, never under-invalidate.

## Coverage

| file | resolved | falls back |
|---|---:|---:|
| `qa-checkers-extended.ts` | **34** | 7 |
| `qa-checkers-voice.ts` | **10** | 0 |
| `qa-checkers-uses.ts` | 3 | 0 |
| `qa-checkers-cost.ts` | 2 | 0 |
| `qa-checkers-triviality.ts` | 1 | 0 |
| `qa-checkers-python.ts` | 0 | 9 |
| **total** | **50** | **16** |

50 of 66 automated criteria, including both worst-fan-out files.

The 16 fall back for a structural reason rather than a bug: the analysis looks for the dispatch entry inside the criterion's declared `source_file`, and the 9 `qa-checkers-python.ts` criteria are dispatched from `script-sweep.ts` while their logic lives in the checker module — so their entry isn't in the file being hashed. They keep whole-file behaviour: no regression, and invalidation stays contained to those 9. Teaching the analysis to follow a dispatcher across modules would close it; not needed for the churn this fixes.

## Verified behaviourally, not just by construction

- Perturbing one checker (`checkAiSlop`) moves **only** `voice-ai-slop`; its four tested siblings are byte-identical. Under the old hash **all five** moved.
- Perturbing a **shared** helper (`stripInlineCode`) invalidates exactly the criteria that reach it — `voice-ai-slop` and `voice-scholarly-default` — and no others. Checked against a hand-traced reference: that helper's only users are `checkUnicodeCrash`, `checkAiSlop`, `checkScholarlyDefault`. This is the direction where a mistake would be silent, so it was verified independently rather than trusted.

8 new tests cover both directions plus determinism, unrelated-edit isolation, unresolvable criteria and unreadable files. One test pins the analysis against the **real** voice module so the fixtures can't drift from how checkers are actually written.

- `bun test` — **546 pass, 46 skip, 0 fail**
- `eslint` — clean on all changed files
- `qa-sweep` — runs end-to-end against a live folio

## One-time cost, stated plainly

Criteria that now resolve per-criterion get a different hash from the file hash currently recorded, so they invalidate **once** and re-run on the next sweep. Downstream folios need one more full sweep after this lands. After that, invalidation is proportional to what actually changed — which is the whole point.

## Dependency

`typescript` moves from a transitive dependency to a declared one. The analysis parses checker modules with it, and the pipeline runs in consumer repos where a transitive hoist isn't guaranteed.

---
_Generated by [Claude Code](https://claude.ai/code/session_016hQePZH4xA7gxL5eLTP5av)_