### PR TITLE
qa(sweep): a re-run that reproduces a verdict is not a change

### DIFF
--- a/content/pipeline/qa-sweep.ts
+++ b/content/pipeline/qa-sweep.ts
@@ -110,6 +110,7 @@ import {
   entryIsFresh,
   freshnessKeys,
   preserveNonScriptEntries,
+  sameScriptVerdict,
   computeCriterionScriptHashes,
   saveQaScriptSidecar,
   type CriterionScriptHashes,
@@ -310,6 +311,16 @@ function run(): void {
     report.paths = newPaths;
     report.source_hashes = currentHashes;
 
+    // Did any criterion's VERDICT actually move this run? Re-running a checker
+    // is not by itself a change: a criterion that re-evaluates to exactly what
+    // the sidecar already records must keep its existing entry, timestamps and
+    // all. Without this, the `staleNa` re-check below (which deliberately
+    // re-evaluates every applicable `n/a` on every sweep) restamps
+    // `reviewed_at` forever, so every sidecar's `updated_at` moved on every
+    // sweep and feature branches carried the churn regardless of the
+    // per-criterion `script_hash` fix.
+    let verdictChanged = false;
+
     const sweepResult: BlockSweepResult = {
       label: block.label,
       kind: block.kind,
@@ -406,7 +417,13 @@ function run(): void {
           reviewed_sha: headSha,
           notes: "block has no .md sibling",
         };
-        report.criteria[criterionId] = [...nonScriptExisting, naEntry];
+        const priorNa = existing.find((e) => e?.reviewer?.kind === "script");
+        report.criteria[criterionId] = [
+          ...nonScriptExisting,
+          sameScriptVerdict(priorNa, naEntry)
+            ? priorNa!
+            : ((verdictChanged = true), naEntry),
+        ];
         sweepResult.details.push({
           criterion: criterionId,
           outcome: "n/a-no-md",
@@ -422,7 +439,13 @@ function run(): void {
           reviewed_sha: headSha,
           notes: "block has no .lean sibling",
         };
-        report.criteria[criterionId] = [...nonScriptExisting, naEntry];
+        const priorNa = existing.find((e) => e?.reviewer?.kind === "script");
+        report.criteria[criterionId] = [
+          ...nonScriptExisting,
+          sameScriptVerdict(priorNa, naEntry)
+            ? priorNa!
+            : ((verdictChanged = true), naEntry),
+        ];
         sweepResult.details.push({
           criterion: criterionId,
           outcome: "n/a-no-lean",
@@ -470,8 +493,15 @@ function run(): void {
       }
 
       // Write the fresh script entry, REPLACING the prior script entry
-      // (agent + human entries are preserved via `nonScriptExisting`).
-      report.criteria[criterionId] = [...nonScriptExisting, entry];
+      // (agent + human entries are preserved via `nonScriptExisting`). When
+      // the re-run reproduces what the sidecar already records, keep the
+      // existing entry verbatim so its timestamps survive — a re-run is not a
+      // change.
+      const priorScript = existing.find((e) => e?.reviewer?.kind === "script");
+      const settled = sameScriptVerdict(priorScript, entry)
+        ? priorScript!
+        : ((verdictChanged = true), entry);
+      report.criteria[criterionId] = [...nonScriptExisting, settled];
 
       sweepResult.details.push({
         criterion: criterionId,
@@ -486,18 +516,19 @@ function run(): void {
       });
     }
 
-    report.updated_at = nowIso;
     // Save when any of the following changed since the loaded sidecar:
-    //   - new automated criterion entry written (criteria_run > 0)
-    //   - new n/a marker written for an inapplicable criterion
+    //   - a criterion's verdict (or its inputs / checker identity) moved
     //   - sidecar metadata drifted (file moved, kind/label changed,
     //     source-file content hash changed)
-    const wroteSomething =
-      sweepResult.criteria_run > 0 ||
-      sweepResult.details.some(
-        (d) => d.outcome === "n/a-no-md" || d.outcome === "n/a-no-lean",
-      ) ||
-      metadataDrifted;
+    //
+    // Note this is NOT `criteria_run > 0`. Running a checker and reproducing
+    // the recorded verdict leaves the sidecar semantically identical, and
+    // saving it anyway rewrote `updated_at` on every block on every sweep —
+    // which is what made an otherwise no-op sweep dirty the whole corpus.
+    const wroteSomething = verdictChanged || metadataDrifted;
+    // Only advance the file's own timestamp when its content actually moved,
+    // for the same reason.
+    if (wroteSomething) report.updated_at = nowIso;
     if (!args.dryRun && wroteSomething) {
       saveQaReport(qaPath, report);
     }

--- a/content/pipeline/qa-utils.ts
+++ b/content/pipeline/qa-utils.ts
@@ -833,6 +833,56 @@ export function preserveNonScriptEntries(
 }
 
 /**
+ * Does a freshly-computed script entry say the same thing as the one already
+ * recorded?
+ *
+ * Compares everything that carries meaning — verdict, the input hashes it was
+ * computed from, the reviewer identity and its script/deps hashes, and the
+ * checker's own output (notes, evidence, metrics, severity) — while ignoring
+ * `reviewed_at` and `reviewed_sha`, which say only WHEN the sweep last ran.
+ *
+ * Callers use this to keep the existing entry verbatim when a re-run reproduces
+ * it, so re-running a checker is not by itself a change to the sidecar. That
+ * matters because some criteria are deliberately re-evaluated on every sweep
+ * (an `n/a` whose `depends_on` is now satisfied must be re-checked in case it
+ * became applicable); without this, each such re-check restamped the entry and
+ * dirtied the file forever.
+ *
+ * `reviewed_sha` is deliberately NOT refreshed on an unchanged verdict: the
+ * matching `field_hash` already proves the inputs are identical, so the older
+ * sha remains a truthful record of when the verdict was established.
+ *
+ * `script_commit_sha` is excluded for the same reason. It is a FILE-level
+ * pointer — the last commit to touch the checker module — so it moves when a
+ * neighbouring criterion is edited, and comparing it would reintroduce exactly
+ * the file-level coupling that per-criterion `script_hash` exists to remove.
+ * `script_hash` is the field that actually answers "did this criterion's code
+ * change", and it IS compared.
+ */
+export function sameScriptVerdict(
+  a: QaCriterionEntry | undefined,
+  b: QaCriterionEntry,
+): boolean {
+  if (!a) return false;
+  const shape = (e: QaCriterionEntry) => ({
+    result: e.result,
+    field_hash: e.field_hash,
+    notes: e.notes,
+    evidence: e.evidence,
+    metrics: e.metrics,
+    severity: e.severity,
+    reviewer: {
+      kind: e.reviewer?.kind,
+      id: e.reviewer?.id,
+      version: e.reviewer?.version,
+      script_hash: e.reviewer?.script_hash,
+      deps_hash: e.reviewer?.deps_hash,
+    },
+  });
+  return JSON.stringify(shape(a)) === JSON.stringify(shape(b));
+}
+
+/**
  * Per-criterion freshness summary for one block.
  *
  * - `fresh-entries`: reviewer entries whose field_hash matches.

--- a/scripts/tests/qa-same-script-verdict.test.ts
+++ b/scripts/tests/qa-same-script-verdict.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import { sameScriptVerdict } from "../../content/pipeline/qa-utils";
+import type { QaCriterionEntry } from "../../schemas/block-qa";
+
+function entry(over: Partial<QaCriterionEntry> = {}): QaCriterionEntry {
+  return {
+    field_hash: { md: "aaaaaaaaaaaa", ts: "bbbbbbbbbbbb" },
+    result: "pass",
+    reviewer: {
+      kind: "script",
+      id: "content/pipeline/qa-checkers-voice.ts",
+      version: "v1",
+      script_hash: "111111111111",
+      script_commit_sha: "cafebabecafebabecafebabecafebabecafebabe",
+    },
+    reviewed_at: "2026-01-01T00:00:00.000Z",
+    reviewed_sha: "1111111111111111111111111111111111111111",
+    ...over,
+  } as QaCriterionEntry;
+}
+
+describe("sameScriptVerdict", () => {
+  test("a re-run that reproduces the verdict is not a change", () => {
+    // Only the timestamps differ, which is what a no-op sweep produces.
+    const prior = entry();
+    const fresh = entry({
+      reviewed_at: "2026-08-09T12:00:00.000Z",
+      reviewed_sha: "2222222222222222222222222222222222222222",
+    });
+    expect(sameScriptVerdict(prior, fresh)).toBe(true);
+  });
+
+  test("a moved verdict is a change", () => {
+    expect(sameScriptVerdict(entry(), entry({ result: "fail" }))).toBe(false);
+  });
+
+  test("moved inputs are a change even at the same verdict", () => {
+    // Same `pass`, but computed from different content — the sidecar must
+    // record the new field_hash or it would claim to have checked the old text.
+    const fresh = entry({ field_hash: { md: "cccccccccccc", ts: "bbbbbbbbbbbb" } });
+    expect(sameScriptVerdict(entry(), fresh)).toBe(false);
+  });
+
+  test("a changed checker is a change", () => {
+    const fresh = entry({
+      reviewer: { ...entry().reviewer, script_hash: "999999999999" },
+    });
+    expect(sameScriptVerdict(entry(), fresh)).toBe(false);
+  });
+
+  test("changed evidence, notes, metrics or severity are changes", () => {
+    for (const over of [
+      { notes: "different" },
+      { evidence: "a.md:1: x" },
+      { metrics: { energy: 2 } },
+      { severity: "critical" },
+    ] as Partial<QaCriterionEntry>[]) {
+      expect(sameScriptVerdict(entry(), entry(over))).toBe(false);
+    }
+  });
+
+  test("script_commit_sha alone is NOT a change", () => {
+    // It is a FILE-level pointer: it moves when a neighbouring criterion is
+    // edited. Treating it as a change would reintroduce exactly the file-level
+    // coupling that per-criterion script_hash removes.
+    const fresh = entry({
+      reviewer: {
+        ...entry().reviewer,
+        script_commit_sha: "0000000000000000000000000000000000000000",
+      },
+    });
+    expect(sameScriptVerdict(entry(), fresh)).toBe(true);
+  });
+
+  test("no prior entry is always a change", () => {
+    expect(sameScriptVerdict(undefined, entry())).toBe(false);
+  });
+});


### PR DESCRIPTION
## #89 did not actually fix the churn — I checked, and it didn't

#89 made `script_hash` per-criterion so editing one checker stops invalidating its file-mates. That fixed the mass **invalidation**, and I said it fixed the **churn**. Measuring after it merged says otherwise: sweeping one chapter twice in a row still rewrote all 26 sidecars on the second pass.

The residual cause is separate and simpler:

- `staleNa` deliberately re-evaluates any `n/a` entry whose `depends_on` is now satisfied — correct, since the criterion may have become applicable.
- But when it re-evaluated to `n/a` **again**, the sweep still wrote a new entry stamped with a fresh `reviewed_at`.
- Then `report.updated_at = nowIso` ran unconditionally, and the save gate fired on `criteria_run > 0`.

So an entirely no-op sweep dirtied every sidecar in the corpus, and feature branches carried it exactly as before. On the chapter I measured, that was 4 restamped entries per block (`detangler-section-band`, `detangler-no-xchapter-fwd`, `detangler-topic-coherence`, `lean-ref-owns-decl`) plus `updated_at` — enough to make every file dirty.

## The change

When a re-run reproduces what the sidecar already records, the existing entry is kept **verbatim**, timestamps and all. `updated_at` advances and the file saves only when a verdict, its inputs, or the sidecar's metadata actually moved.

`sameScriptVerdict` compares result, `field_hash`, reviewer identity, `script_hash`, `deps_hash`, notes, evidence, metrics and severity.

Two fields are deliberately excluded:

- **`reviewed_at` / `reviewed_sha`** record only when the sweep last ran. A matching `field_hash` already proves the inputs are identical, so the older sha stays a truthful record of when the verdict was established.
- **`script_commit_sha`** is a FILE-level pointer — it moves when a *neighbouring* criterion is edited. Comparing it would reintroduce the very file-level coupling #89 removed. `script_hash` is the field that answers "did this criterion's code change", and it is compared.

## Verified against a live folio, not by construction

| property | before | after |
|---|---|---|
| sweep an unchanged chapter twice | 26 files rewritten | **byte-identical**, stable across 3 sweeps |
| edit one `.md`, sweep | whole chapter moves | **exactly 1 sidecar** moves |

And the direction that would be dangerous if `sameScriptVerdict` were too permissive: the edited block's `source_hashes.md` (`13104f66cc1e` → `80bcf9773413`) and its verdict **do** move, so real changes are not being silently swallowed.

7 new tests pin both directions — including that `script_commit_sha` alone is not a change, and that a same-verdict-but-different-inputs re-run **is** one.

- `bun test` — **553 pass, 46 skip, 0 fail**
- `tsc --noEmit` — clean
- `eslint .` — clean

## Together with #89

#89 stopped one checker edit from invalidating its file-mates. This stops a re-run from rewriting anything it didn't change. Both are needed: with only #89 the sweep still dirtied every file; with only this one, a checker edit would still invalidate 40 criteria at once and legitimately rewrite them all.

Downstream folios still need the one full sweep #89 called for — after which sweeps are no-ops unless something really changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_016hQePZH4xA7gxL5eLTP5av)_