### PR TITLE
qa(canonical): stop failing prose that disclaims a coincidence

### DIFF
--- a/content/pipeline/qa-checkers-extended.ts
+++ b/content/pipeline/qa-checkers-extended.ts
@@ -970,26 +970,88 @@ const NUMEROLOGY_PHRASES = [
   /\baccidental(?:ly)?\s+match/i,
 ];
 
+/**
+ * Prose that DISCLAIMS a coincidence rather than trading on it.
+ *
+ * The signal phrases above are exactly the vocabulary an honest caveat uses —
+ * naming a coincidence as a coincidence is the behaviour this criterion exists
+ * to reward, not to punish. Observed live in qou
+ * (`mass-theory/toroidal-harmonics-delta-lambda`), where
+ *
+ *   "It is a numerical coincidence at an unrelated anchor, not a parameter-free
+ *    evaluation on the substrate, and it does not determine Δ_λ, which stays
+ *    open"
+ *
+ * failed `critical` — the criterion firing on the paper being careful.
+ *
+ * These patterns are deliberately narrow: a bare `not` anywhere nearby is NOT
+ * enough (it would suppress "the agreement is not accidental — it is
+ * miraculous"). The negation has to deny that the coincidence ESTABLISHES
+ * something, which is what separates a caveat from a claim.
+ */
+const NUMEROLOGY_DISCLAIMERS = [
+  /\bnot\s+(?:a\s+|an\s+)?(?:derivation|proof|prediction|explanation|evidence|derived|parameter-free|first-principles)\b/i,
+  /\bdoes\s+not\s+(?:determine|derive|prove|establish|explain|predict|imply|follow)\b/i,
+  /\bis\s+not\s+claimed\b/i,
+  /\bno\s+(?:derivation|mechanism|explanation)\b/i,
+  /\bcoincidence,\s*not\b/i,
+  /\bnot\s+a\s+substitute\s+for\b/i,
+];
+
+/**
+ * Markdown paragraphs (runs of contiguous non-blank lines) with the 1-based
+ * line each starts on.
+ *
+ * Scope matters here: the signal phrase and its disclaimer routinely land on
+ * DIFFERENT physical lines because prose is hard-wrapped, so a per-line test
+ * structurally cannot see the caveat attached to the sentence it is judging.
+ */
+function markdownParagraphs(
+  md: string,
+): Array<{ text: string; startLine: number; lines: string[] }> {
+  const out: Array<{ text: string; startLine: number; lines: string[] }> = [];
+  let current: string[] = [];
+  let start = 1;
+  const flush = () => {
+    if (current.length) out.push({ text: current.join(" "), startLine: start, lines: current });
+    current = [];
+  };
+  md.split("\n").forEach((line, i) => {
+    if (line.trim() === "") {
+      flush();
+      start = i + 2;
+    } else {
+      if (!current.length) start = i + 1;
+      current.push(line);
+    }
+  });
+  flush();
+  return out;
+}
+
 export function checkCanonicalNoNumerology(
   mdPath: string | undefined,
 ): CheckerResult {
   const md = readMaybe(mdPath);
   if (!md) return { result: "pass", hits: [] };
   const hits: CheckerHit[] = [];
-  let lineNo = 0;
-  for (const line of md.split("\n")) {
-    lineNo++;
-    for (const re of NUMEROLOGY_PHRASES) {
-      const m = line.match(re);
-      if (m) {
-        hits.push({
-          file: mdPath ?? "(unknown)",
-          line: lineNo,
-          text: `numerology signal phrase: "${m[0]}"`,
-        });
-        break;
+  for (const para of markdownParagraphs(md)) {
+    // A paragraph that explicitly denies the coincidence establishes anything
+    // is the discipline working; do not flag it.
+    if (NUMEROLOGY_DISCLAIMERS.some((re) => re.test(para.text))) continue;
+    para.lines.forEach((line, offset) => {
+      for (const re of NUMEROLOGY_PHRASES) {
+        const m = line.match(re);
+        if (m) {
+          hits.push({
+            file: mdPath ?? "(unknown)",
+            line: para.startLine + offset,
+            text: `numerology signal phrase: "${m[0]}"`,
+          });
+          break;
+        }
       }
-    }
+    });
   }
   return { result: hits.length > 0 ? "fail" : "pass", hits };
 }

--- a/scripts/tests/qa-canonical-no-numerology.test.ts
+++ b/scripts/tests/qa-canonical-no-numerology.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { checkCanonicalNoNumerology } from "../../content/pipeline/qa-checkers-extended";
+
+function md(body: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "numerology-"));
+  const p = join(dir, "block.md");
+  writeFileSync(p, body);
+  return p;
+}
+
+describe("checkCanonicalNoNumerology", () => {
+  test("flags numerology asserted as significant", () => {
+    expect(
+      checkCanonicalNoNumerology(
+        md("The predicted ratio miraculously agrees with the measured value.\n"),
+      ).result,
+    ).toBe("fail");
+  });
+
+  test("flags a bare happens-to-equal claim", () => {
+    expect(
+      checkCanonicalNoNumerology(
+        md("The constant happens to equal the observed slope, which supports it.\n"),
+      ).result,
+    ).toBe("fail");
+  });
+
+  test("does NOT flag prose that disclaims the coincidence", () => {
+    // The criterion exists to reward exactly this. Firing here punishes the
+    // paper for being careful.
+    expect(
+      checkCanonicalNoNumerology(
+        md(
+          "It is a numerical coincidence at an unrelated anchor, not a\n" +
+            "parameter-free evaluation on the substrate.\n",
+        ),
+      ).result,
+    ).toBe("pass");
+  });
+
+  test("sees a disclaimer that wraps onto a later line", () => {
+    // The regression that motivated this: hard-wrapped prose puts the phrase
+    // and its caveat on different physical lines, so a per-line check
+    // structurally cannot see the caveat.
+    const body =
+      "The evaluation anchors on a value which is not the substrate modulus.\n" +
+      "It is a numerical coincidence at an unrelated anchor,\n" +
+      "and it does not determine the constant, which stays open.\n";
+    expect(checkCanonicalNoNumerology(md(body)).result).toBe("pass");
+  });
+
+  test("a disclaimer in a DIFFERENT paragraph does not launder a claim", () => {
+    // Scope is the paragraph. A caveat elsewhere in the file must not excuse
+    // numerology asserted here.
+    const body =
+      "The ratio miraculously agrees with experiment.\n" +
+      "\n" +
+      "Elsewhere: this is not a derivation and does not determine anything.\n";
+    expect(checkCanonicalNoNumerology(md(body)).result).toBe("fail");
+  });
+
+  test("negation alone does not suppress a boast", () => {
+    // "not accidental" is a negation, but it does not deny that the match
+    // establishes something — it asserts the opposite. Must still fail.
+    const body =
+      "The agreement here is not accidental — the match is miraculous\n" +
+      "and confirms the mechanism outright.\n";
+    expect(checkCanonicalNoNumerology(md(body)).result).toBe("fail");
+  });
+
+  test("reports the line the phrase is actually on", () => {
+    const body = "intro\n\nfiller line\nthe fit is miraculous here\n";
+    const r = checkCanonicalNoNumerology(md(body));
+    expect(r.result).toBe("fail");
+    expect(r.hits[0].line).toBe(4);
+  });
+
+  test("clean prose passes", () => {
+    expect(
+      checkCanonicalNoNumerology(md("The bound follows from the lemma.\n")).result,
+    ).toBe("pass");
+  });
+});


### PR DESCRIPTION
## The criterion was firing on the paper being careful

`canonical-no-numerology` matched signal phrases line by line with no notion of context. Live example, which failed at **`critical`** in qou (`mass-theory/toroidal-harmonics-delta-lambda`):

> It is a **numerical coincidence** at an unrelated anchor, **not** a parameter-free evaluation on the substrate, and it does **not** determine $\Delta_\lambda$, which stays open under the three-calibration discipline

That is exactly the discipline the criterion exists to enforce — naming a coincidence as a coincidence and refusing to trade on it.

The problem is structural, not incidental: phrases like *"numerical coincidence"* and *"accidental match"* are the vocabulary an **honest caveat** uses. The checker was systematically biased against the writing it is meant to reward. Left alone it invites the worst possible fix — rewording an honest caveat to dodge a checker, which would delete the disclaimer and make the paper less accurate.

## Two changes

**Scope is now the markdown paragraph, not the line.** The phrase and its disclaimer routinely land on different physical lines because prose is hard-wrapped — in the case above they are one line apart:

```
It is a numerical coincidence at an unrelated anchor,
not a parameter-free evaluation on the substrate, and it does not determine
```

A per-line test *structurally cannot* see the caveat attached to the sentence it is judging. This was not a tuning problem.

**A paragraph that explicitly denies the coincidence establishes anything is skipped.**

## The disclaimer patterns are deliberately narrow

A bare `not` nearby is **not** enough — that would suppress real numerology. The negation has to deny derivation / proof / determination, which is what separates a caveat from a claim.

Verified adversarially:

| prose | verdict |
|---|---|
| "It is a numerical coincidence … not a parameter-free evaluation" | **pass** ✓ |
| "The predicted ratio miraculously agrees with the measured value" | **fail** ✓ |
| "The constant happens to equal the observed slope, which supports it" | **fail** ✓ |
| "The agreement is **not accidental** — the match is **miraculous** and confirms the mechanism" | **fail** ✓ |

That last one is the case a naive negation check would get wrong: `not accidental` asserts significance rather than denying it, so it must not suppress.

## Blast radius

The change can only ever **suppress** a hit, never add one, so it cannot introduce a new failure.

Measured against the qou corpus:

- **3512** `.md` files scanned
- the **single** pre-existing failure was this false positive — now clear
- **0** genuine numerology findings were being masked
- **0** blocks newly fail

Worth stating plainly: I had earlier suggested this criterion's *other* hits should be re-read for the same bias. There were no other hits — corpus-wide it had fired exactly once, on the false positive. The bias was real but its footprint was one block.

## Tests

8 new tests pin both directions, including that a disclaimer in a **different** paragraph does not launder a claim made in this one, and that reported line numbers still point at the phrase.

- `bun test` — **561 pass, 46 skip, 0 fail**
- `tsc --noEmit` — clean
- `eslint .` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_016hQePZH4xA7gxL5eLTP5av)_