### PR TITLE
qa(detangler): invalidate graph-scoped criteria when the uses[] graph moves

### DIFF
--- a/content/pipeline/qa-criteria-registry.ts
+++ b/content/pipeline/qa-criteria-registry.ts
@@ -1216,6 +1216,12 @@ const DETANGLER: QaCriterionDefinition[] = [
     default_severity: "major",
     depends_on: ["ts"],
     automated: true,
+    // Verdict is a property of the chapter uses[] GRAPH, so an edit to
+    // ANOTHER block's uses[] changes it while this block's own files are
+    // untouched. Without this the entry stays fresh-skip and keeps a stale
+    // verdict — seen live in qou, where breaking 3 cycles left 15 blocks
+    // still recording a cycle that no longer existed.
+    also_invalidated_by: ["graph"],
   },
   {
     id: "detangler-section-band",
@@ -1230,6 +1236,12 @@ const DETANGLER: QaCriterionDefinition[] = [
     default_severity: "minor",
     depends_on: ["ts"],
     automated: true,
+    // Verdict is a property of the chapter uses[] GRAPH, so an edit to
+    // ANOTHER block's uses[] changes it while this block's own files are
+    // untouched. Without this the entry stays fresh-skip and keeps a stale
+    // verdict — seen live in qou, where breaking 3 cycles left 15 blocks
+    // still recording a cycle that no longer existed.
+    also_invalidated_by: ["graph"],
   },
   {
     id: "detangler-no-xchapter-fwd",
@@ -1241,6 +1253,12 @@ const DETANGLER: QaCriterionDefinition[] = [
     default_severity: "major",
     depends_on: ["ts"],
     automated: true,
+    // Verdict is a property of the chapter uses[] GRAPH, so an edit to
+    // ANOTHER block's uses[] changes it while this block's own files are
+    // untouched. Without this the entry stays fresh-skip and keeps a stale
+    // verdict — seen live in qou, where breaking 3 cycles left 15 blocks
+    // still recording a cycle that no longer existed.
+    also_invalidated_by: ["graph"],
   },
   {
     id: "detangler-archimedean-wall",
@@ -1255,6 +1273,12 @@ const DETANGLER: QaCriterionDefinition[] = [
     default_severity: "major",
     depends_on: ["ts", "lean"],
     automated: true,
+    // Verdict is a property of the chapter uses[] GRAPH, so an edit to
+    // ANOTHER block's uses[] changes it while this block's own files are
+    // untouched. Without this the entry stays fresh-skip and keeps a stale
+    // verdict — seen live in qou, where breaking 3 cycles left 15 blocks
+    // still recording a cycle that no longer existed.
+    also_invalidated_by: ["graph"],
   },
   {
     id: "detangler-block-tanglement",
@@ -1270,6 +1294,12 @@ const DETANGLER: QaCriterionDefinition[] = [
     default_severity: "major",
     depends_on: ["ts"],
     automated: true,
+    // Verdict is a property of the chapter uses[] GRAPH, so an edit to
+    // ANOTHER block's uses[] changes it while this block's own files are
+    // untouched. Without this the entry stays fresh-skip and keeps a stale
+    // verdict — seen live in qou, where breaking 3 cycles left 15 blocks
+    // still recording a cycle that no longer existed.
+    also_invalidated_by: ["graph"],
   },
   {
     id: "detangler-graph-energy",
@@ -1293,6 +1323,12 @@ const DETANGLER: QaCriterionDefinition[] = [
     default_severity: "major",
     depends_on: ["ts"],
     automated: true,
+    // Verdict is a property of the chapter uses[] GRAPH, so an edit to
+    // ANOTHER block's uses[] changes it while this block's own files are
+    // untouched. Without this the entry stays fresh-skip and keeps a stale
+    // verdict — seen live in qou, where breaking 3 cycles left 15 blocks
+    // still recording a cycle that no longer existed.
+    also_invalidated_by: ["graph"],
   },
   {
     id: "detangler-topic-coherence",
@@ -1309,6 +1345,12 @@ const DETANGLER: QaCriterionDefinition[] = [
     default_severity: "minor",
     depends_on: ["md"],
     automated: true,
+    // Verdict is a property of the chapter uses[] GRAPH, so an edit to
+    // ANOTHER block's uses[] changes it while this block's own files are
+    // untouched. Without this the entry stays fresh-skip and keeps a stale
+    // verdict — seen live in qou, where breaking 3 cycles left 15 blocks
+    // still recording a cycle that no longer existed.
+    also_invalidated_by: ["graph"],
   },
   {
     id: "detangler-no-dependency-cycle",
@@ -1326,6 +1368,12 @@ const DETANGLER: QaCriterionDefinition[] = [
     default_severity: "major",
     depends_on: ["ts"],
     automated: true,
+    // Verdict is a property of the chapter uses[] GRAPH, so an edit to
+    // ANOTHER block's uses[] changes it while this block's own files are
+    // untouched. Without this the entry stays fresh-skip and keeps a stale
+    // verdict — seen live in qou, where breaking 3 cycles left 15 blocks
+    // still recording a cycle that no longer existed.
+    also_invalidated_by: ["graph"],
   },
 ];
 

--- a/content/pipeline/qa-sweep.ts
+++ b/content/pipeline/qa-sweep.ts
@@ -123,12 +123,15 @@ import {
   getCriterionExtraInputs,
 } from "./qa-criteria-registry";
 import { AUTOMATED_CHECKERS } from "./qa-checkers-voice";
+import { usesGraphHash } from "./uses-graph-hash";
+
 import type { CheckerResult } from "./qa-checkers-extended";
 import type {
   BlockQaReport,
   QaCriterionEntry,
   QaScriptSidecar,
 } from "../../schemas/block-qa";
+
 
 // ── CLI parsing ─────────────────────────────────────────────────
 
@@ -262,6 +265,20 @@ function run(): void {
   }
   const engineVersion = `bun-${Bun.version}`;
 
+  // Hash of the `uses[]` edge set under sweep, computed once per run.
+  //
+  // The detangler criteria answer questions about the GRAPH — forward
+  // references, dependency cycles, cone depth, graph energy — so editing block
+  // A's `uses[]` changes block B's verdict while B's own files are untouched.
+  // Keyed only on its own `field_hash`, B stays `fresh-skip` and keeps a
+  // verdict that is now wrong. Criteria opt in with
+  // `also_invalidated_by: ["graph"]`; only their entries carry and compare it.
+  //
+  // The edge SET is hashed rather than the `.ts` files, so an edit that does
+  // not touch `uses[]` does not invalidate the axis — hashing the manifests
+  // would reintroduce exactly the churn per-criterion `script_hash` removed.
+  const graphHash = usesGraphHash(walkRoot);
+
   const results: BlockSweepResult[] = [];
 
   let totalBlocks = 0;
@@ -351,6 +368,14 @@ function run(): void {
       // newly applicable — typically because `depends_on` was
       // relaxed in the registry) must NOT short-circuit the sweep;
       // it has to be re-evaluated against the actual checker.
+      // Graph-scoped criteria (the detangler axis) compare an extra `graph`
+      // key so that a `uses[]` edit ANYWHERE in the chapter invalidates them.
+      // Only their entries carry it — adding it unconditionally would grow
+      // every field_hash on every block for no signal.
+      const graphScoped = freshnessKeys(def).includes("graph");
+      const fieldHash = graphScoped
+        ? { ...currentHashes, graph: graphHash }
+        : currentHashes;
       const existing = report.criteria[criterionId] ?? [];
       // A script re-run is a REFRESH, not a new opinion: it must REPLACE the
       // prior script entry rather than append. Only agent-kind reviewers
@@ -363,7 +388,7 @@ function run(): void {
       const nonScriptExisting = preserveNonScriptEntries(existing);
       const scriptHashes = scriptHashesByCriterion[criterionId];
       const freshExisting = existing.find((e) =>
-        entryIsFresh(e, currentHashes, freshnessKeys(def), scriptHashes, def.lean_granularity),
+        entryIsFresh(e, fieldHash, freshnessKeys(def), scriptHashes, def.lean_granularity),
       );
       const dependsOnSatisfied = def.depends_on.every(
         (k) => currentHashes[k] !== undefined,
@@ -410,7 +435,7 @@ function run(): void {
 
       if (def.depends_on.includes("md") && !block.md) {
         const naEntry: QaCriterionEntry = {
-          field_hash: currentHashes,
+          field_hash: fieldHash,
           result: "n/a",
           reviewer: { ...scriptReviewer },
           reviewed_at: nowIso,
@@ -432,7 +457,7 @@ function run(): void {
       }
       if (def.depends_on.includes("lean") && !block.lean) {
         const naEntry: QaCriterionEntry = {
-          field_hash: currentHashes,
+          field_hash: fieldHash,
           result: "n/a",
           reviewer: { ...scriptReviewer },
           reviewed_at: nowIso,
@@ -457,7 +482,7 @@ function run(): void {
       sweepResult.criteria_run++;
       const checkRes = checker(paths);
       const entry: QaCriterionEntry = {
-        field_hash: currentHashes,
+        field_hash: fieldHash,
         result: checkRes.result,
         reviewer: { ...scriptReviewer },
         reviewed_at: nowIso,

--- a/content/pipeline/qa-utils.ts
+++ b/content/pipeline/qa-utils.ts
@@ -724,8 +724,8 @@ export function saveQaReport(path: string, report: BlockQaReport): void {
  */
 export function freshnessKeys(def: {
   depends_on: Array<"md" | "ts" | "lean">;
-  also_invalidated_by?: Array<"md" | "ts" | "lean">;
-}): Array<"md" | "ts" | "lean"> {
+  also_invalidated_by?: Array<"md" | "ts" | "lean" | "graph">;
+}): Array<"md" | "ts" | "lean" | "graph"> {
   return [...new Set([...def.depends_on, ...(def.also_invalidated_by ?? [])])];
 }
 
@@ -741,7 +741,7 @@ export function freshnessKeys(def: {
 export function entryIsFresh(
   entry: QaCriterionEntry,
   current: QaFieldHash,
-  depends_on: Array<"md" | "ts" | "lean">,
+  depends_on: Array<"md" | "ts" | "lean" | "graph">,
   current_script_hashes?: CriterionScriptHashes,
   lean_granularity?: "file" | "statement",
 ): boolean {

--- a/content/pipeline/uses-graph-hash.ts
+++ b/content/pipeline/uses-graph-hash.ts
@@ -1,0 +1,63 @@
+/**
+ * Hash of a chapter's `uses[]` edge set — the invalidation signal for
+ * graph-scoped QA criteria.
+ *
+ * The detangler axis answers questions about the GRAPH: forward references,
+ * dependency cycles, cone depth, graph energy. Editing block A's `uses[]`
+ * therefore changes block B's verdict while B's own `.md` / `.ts` / `.lean` are
+ * untouched. Keyed only on its own files, B stays `fresh-skip` and keeps a
+ * verdict that is now wrong — observed live in qou, where breaking three
+ * dependency cycles left 15 blocks still recording
+ * `detangler-no-dependency-cycle: fail` for cycles that no longer existed.
+ *
+ * Criteria opt in via `also_invalidated_by: ["graph"]`; only their entries
+ * carry and compare the resulting `field_hash.graph`.
+ *
+ * Its own module rather than part of `qa-sweep` so it is importable without
+ * executing that CLI, and rather than part of `qa-utils` because
+ * `content-graph` already imports `walkBlocks` from there — this would close an
+ * import cycle.
+ *
+ * @module content/pipeline/uses-graph-hash
+ */
+
+import { readFileSync } from "fs";
+import { relative } from "path";
+import { createHash } from "crypto";
+import { walkBlocks } from "./qa-utils";
+import { parseUses } from "./content-graph";
+
+/**
+ * 12-char hash of the `uses[]` edge set beneath `root`.
+ *
+ * Defined here rather than in `qa-utils` because `content-graph` already
+ * imports `walkBlocks` from there; putting it in `qa-utils` would close an
+ * import cycle. `qa-sweep` is a leaf consumer of both.
+ *
+ * Hashes the EDGES, not the manifests: an edit to a `.ts` that leaves `uses[]`
+ * alone must not invalidate the detangler axis, or this would reintroduce the
+ * churn that per-criterion `script_hash` was added to remove. Sorted so the
+ * hash is independent of walk order.
+ */
+export function usesGraphHash(root: string): string {
+  const edges: string[] = [];
+  for (const block of walkBlocks(root)) {
+    let src = "";
+    try {
+      src = readFileSync(block.ts, "utf-8");
+    } catch {
+      continue;
+    }
+    const uses = parseUses(src);
+    // Label the edge by a path RELATIVE to the sweep root, never the absolute
+    // one: an absolute path bakes the checkout location into the hash, so the
+    // same corpus would hash differently on another machine or in a worktree
+    // and invalidate the whole axis for no reason. Same rule `deps_hash`
+    // already follows.
+    if (uses.length) {
+      edges.push(`${relative(root, block.root)} ${[...uses].sort().join(",")}`);
+    }
+  }
+  edges.sort();
+  return createHash("sha256").update(edges.join("\n")).digest("hex").slice(0, 12);
+}

--- a/schemas/block-qa.ts
+++ b/schemas/block-qa.ts
@@ -93,6 +93,23 @@ export interface QaFieldHash {
   ts?: string;
   lean?: string;
   /**
+   * Hash of the chapter's `uses[]` edge set, for criteria whose verdict is a
+   * property of the GRAPH rather than of this block's own files.
+   *
+   * The detangler axis is the case: forward references, dependency cycles,
+   * cone depth and graph energy are all computed across the whole chapter, so
+   * editing block A's `uses[]` changes block B's verdict while B's own `.md` /
+   * `.ts` / `.lean` are untouched. Keyed only on its own files, B stays
+   * `fresh-skip` and keeps a verdict that is now wrong — observed live in qou,
+   * where breaking three dependency cycles left 15 blocks still recording
+   * `detangler-no-dependency-cycle: fail` for cycles that no longer existed.
+   *
+   * Present only on entries for graph-scoped criteria (those declaring
+   * `also_invalidated_by: ["graph"]`), so ordinary criteria neither carry nor
+   * compare it.
+   */
+  graph?: string;
+  /**
    * Hash of only the **declaration signatures** in the `.lean` file —
    * everything up to each declaration's `:=` / `where`.
    *
@@ -270,7 +287,7 @@ export interface QaCriterionDefinition {
    * Consulted by `entryIsFresh` via `freshnessKeys()`; ignored by the
    * applicability gates.
    */
-  also_invalidated_by?: Array<"md" | "ts" | "lean">;
+  also_invalidated_by?: Array<"md" | "ts" | "lean" | "graph">;
   /**
    * Whether a deterministic script can run this criterion (true) or
    * it requires agent / human adjudication (false).

--- a/scripts/tests/qa-freshness-keys.test.ts
+++ b/scripts/tests/qa-freshness-keys.test.ts
@@ -103,7 +103,12 @@ describe("registry invariant", () => {
     // Harmless (freshnessKeys de-dupes) but always a mistake: it means the
     // author was unsure which half they wanted.
     const offenders = Object.values(QA_CRITERIA_BY_ID)
-      .filter((d) => (d.also_invalidated_by ?? []).some((k) => d.depends_on.includes(k)))
+      .filter((d) =>
+        (d.also_invalidated_by ?? []).some(
+          // "graph" is not a file, so it can never appear in depends_on.
+          (k) => k !== "graph" && d.depends_on.includes(k),
+        ),
+      )
       .map((d) => d.id);
     expect(offenders).toEqual([]);
   });

--- a/scripts/tests/qa-graph-invalidation.test.ts
+++ b/scripts/tests/qa-graph-invalidation.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { entryIsFresh, freshnessKeys } from "../../content/pipeline/qa-utils";
+import { usesGraphHash } from "../../content/pipeline/uses-graph-hash";
+import { QA_CRITERIA_BY_ID } from "../../content/pipeline/qa-criteria-registry";
+import type { QaCriterionEntry } from "../../schemas/block-qa";
+
+const DETANGLER = [
+  "detangler-no-forward-ref",
+  "detangler-section-band",
+  "detangler-no-xchapter-fwd",
+  "detangler-archimedean-wall",
+  "detangler-block-tanglement",
+  "detangler-graph-energy",
+  "detangler-topic-coherence",
+  "detangler-no-dependency-cycle",
+];
+
+/** A chapter of blocks, each `<name>.ts` + `<name>.md`. */
+function chapter(blocks: Record<string, string[]>): string {
+  const root = mkdtempSync(join(tmpdir(), "graphhash-"));
+  mkdirSync(root, { recursive: true });
+  for (const [name, uses] of Object.entries(blocks)) {
+    const list = uses.map((u) => `"${u}"`).join(", ");
+    writeFileSync(
+      join(root, `${name}.ts`),
+      `export default prose({ label: "rem:${name}", uses: [${list}] });\n`,
+    );
+    writeFileSync(join(root, `${name}.md`), `Body of ${name}.\n`);
+  }
+  return root;
+}
+
+describe("usesGraphHash", () => {
+  test("changes when an edge is added or removed", () => {
+    const a = chapter({ one: ["rem:two"], two: [] });
+    const b = chapter({ one: ["rem:two", "rem:three"], two: [] });
+    expect(usesGraphHash(a)).not.toBe(usesGraphHash(b));
+    rmSync(a, { recursive: true, force: true });
+    rmSync(b, { recursive: true, force: true });
+  });
+
+  test("is stable when a manifest changes but uses[] does not", () => {
+    // The whole point of hashing edges rather than files: an unrelated .ts
+    // edit must not invalidate the detangler axis, or the churn that
+    // per-criterion script_hash removed comes straight back.
+    const root = chapter({ one: ["rem:two"], two: [] });
+    const before = usesGraphHash(root);
+    writeFileSync(
+      join(root, "one.ts"),
+      `// a comment that changes the file but not the edges\n` +
+        `export default prose({ label: "rem:one", uses: ["rem:two"] });\n`,
+    );
+    expect(usesGraphHash(root)).toBe(before);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("is independent of block ordering", () => {
+    const a = chapter({ alpha: ["rem:beta"], beta: [] });
+    const b = chapter({ beta: [], alpha: ["rem:beta"] });
+    expect(usesGraphHash(a)).toBe(usesGraphHash(b));
+    rmSync(a, { recursive: true, force: true });
+    rmSync(b, { recursive: true, force: true });
+  });
+});
+
+describe("graph-scoped criteria", () => {
+  test("every detangler criterion is graph-scoped", () => {
+    for (const id of DETANGLER) {
+      const def = QA_CRITERIA_BY_ID[id];
+      expect(def, `${id} missing from registry`).toBeTruthy();
+      expect(freshnessKeys(def), id).toContain("graph");
+    }
+  });
+
+  test("a non-detangler criterion is NOT graph-scoped", () => {
+    expect(freshnessKeys(QA_CRITERIA_BY_ID["voice-ai-slop"])).not.toContain("graph");
+  });
+});
+
+describe("entryIsFresh with a graph key", () => {
+  const entry = (graph?: string): QaCriterionEntry =>
+    ({
+      field_hash: { md: "aaaaaaaaaaaa", ts: "bbbbbbbbbbbb", ...(graph ? { graph } : {}) },
+      result: "fail",
+      reviewer: { kind: "script", id: "x", version: "v1" },
+      reviewed_at: "2026-01-01T00:00:00.000Z",
+      reviewed_sha: "1".repeat(40),
+    }) as QaCriterionEntry;
+
+  const keys = ["md", "ts", "graph"] as Array<"md" | "ts" | "graph">;
+
+  test("a changed graph makes the entry stale", () => {
+    // The regression this exists for: breaking a cycle in block A left 15
+    // OTHER blocks recording a cycle that no longer existed, because their
+    // own md/ts were untouched.
+    const current = { md: "aaaaaaaaaaaa", ts: "bbbbbbbbbbbb", graph: "999999999999" };
+    expect(entryIsFresh(entry("111111111111"), current, keys)).toBe(false);
+  });
+
+  test("an unchanged graph leaves it fresh", () => {
+    const current = { md: "aaaaaaaaaaaa", ts: "bbbbbbbbbbbb", graph: "111111111111" };
+    expect(entryIsFresh(entry("111111111111"), current, keys)).toBe(true);
+  });
+
+  test("an entry predating the graph key is stale once a graph hash exists", () => {
+    // Over-invalidate rather than present a stale verdict as current.
+    const current = { md: "aaaaaaaaaaaa", ts: "bbbbbbbbbbbb", graph: "111111111111" };
+    expect(entryIsFresh(entry(undefined), current, keys)).toBe(false);
+  });
+});


### PR DESCRIPTION
## The bug: verdicts that go wrong and never notice

The detangler criteria answer questions about the **graph** — forward references, dependency cycles, cone depth, graph energy. But `entryIsFresh` keyed them on each block's **own** `field_hash` (`md`/`ts`/`lean`).

So editing block A's `uses[]` changes block B's verdict while B's own files are untouched. B stays `fresh-skip` and keeps a verdict that is now false.

**Seen live.** qou #4872 broke three dependency cycles, and **15 blocks went on recording `detangler-no-dependency-cycle: fail` for cycles that no longer existed.** Confirmed before this fix that `markov-trace-inductive-limit`, `braid-group-n-strand` and `markov-axioms-primitive` were off every cycle in the post-edit graph while still reporting `fail`.

Same class as the `voice-scholarly-default` bug (qou #4673), but not expressible the same way: `also_invalidated_by` named only file kinds of the **same** block, and no file of B changed.

## The fix

`QaFieldHash` gains a `graph` key — a hash of the chapter's `uses[]` edge set — and `also_invalidated_by` accepts `"graph"`. The eight detangler criteria opt in.

`entryIsFresh` needed **no new logic**: its loop already compares whatever keys `freshnessKeys` returns.

Three design points that each cost a rewrite:

**Only graph-scoped entries carry the key.** `field_hash` is now computed per criterion rather than once per block, because entries store the whole hash object — adding `graph` unconditionally would grow every `field_hash` across ~3400 blocks × ~96 criteria for no signal.

**The edge set is hashed, not the manifests.** A `.ts` edit that leaves `uses[]` alone must not invalidate the axis, or this reintroduces exactly the churn #89 and #90 were added to remove. Tested explicitly.

**Edges are labelled by a path relative to the sweep root.** My first version used `block.root` absolute, which bakes the checkout location into the hash — the same corpus would hash differently in another clone or a git worktree and invalidate the axis for nothing. The order-independence test caught it. Same rule `deps_hash` already follows.

It lives in its own module: importable without executing the `qa-sweep` CLI, and not in `qa-utils` because `content-graph` imports `walkBlocks` from there, which would close an import cycle.

## Verified end to end, not just by unit test

Swept a real qou chapter:

| block | before | after |
|---|---|---|
| `markov-trace-inductive-limit` | `fail`, no graph key | **`pass`**, graph key present |
| `braid-group-n-strand` | `fail` | **`pass`** |
| `markov-axioms-primitive` | `fail` | **`pass`** |

Sweeping the same chapter **twice remains byte-identical**, so the new key did not cost the idempotency #90 established. `run-validate` exits 0 with the same 5 pre-existing issues.

## Tests

8 new: the hash moves on an edge change, holds on an unrelated manifest edit, is order-independent; every detangler criterion is graph-scoped and a non-detangler one is not; `entryIsFresh` goes stale on a moved graph and on an entry predating the key.

- `bun test` — **569 pass, 46 skip, 0 fail**
- `tsc --noEmit` — clean
- `eslint .` — clean

## One-time cost

The eight detangler criteria carry a new `field_hash` shape, so they invalidate once and re-run on the next sweep. That is the point — it is what heals the 15 stale verdicts in qou.

---
_Generated by [Claude Code](https://claude.ai/code/session_016hQePZH4xA7gxL5eLTP5av)_