### PR TITLE
validate: no-orphan-sidecar — a QA report with no manifest is an error

### DIFF
--- a/content/pipeline/validate.ts
+++ b/content/pipeline/validate.ts
@@ -86,6 +86,46 @@ async function loadBlocksFromDir(
   const blocks = new Map<string, Block>();
   const names = blockNames ?? discoverManifests(dir);
 
+  // ── no-orphan-sidecar ────────────────────────────────────────
+  //
+  // A `<block>.qa.json` whose `.ts` manifest is gone is an audit report about
+  // a block that does not exist. It can never be refreshed — no sweep will
+  // ever visit it — and it silently inflates every corpus census taken over
+  // `**/*.qa.json`, which is how QA state is normally counted.
+  //
+  // Same principle as `no-orphan-lean`: a `.lean` file is never standalone,
+  // and neither is a QA report. These accumulate when a block MOVES between
+  // chapters — the block picks up a fresh sidecar at its new path while the
+  // old file stays behind, holding verdicts computed against content that has
+  // since changed. Found live in qou: 18 orphans, 5 of them from moves.
+  //
+  // Runs on every directory load, including chapter mode where `blockNames`
+  // restricts which manifests are validated. That restriction is irrelevant
+  // here: orphanhood asks whether `<base>.ts` exists ON DISK, not whether the
+  // caller asked for it — a sidecar whose manifest exists but was not
+  // requested still finds its `.ts` and is not flagged. Gating on
+  // `blockNames === null` made this a silent no-op for every real paper,
+  // since only legacy flat mode passes null.
+  //
+  // Non-recursive, matching `discoverManifests`: sidecars in nested dirs are
+  // caught when those dirs are themselves scanned.
+  if (existsSync(dir)) {
+    for (const f of readdirSync(dir)) {
+      if (!f.endsWith(".qa.json")) continue;
+      const base = f.slice(0, -".qa.json".length);
+      if (existsSync(join(dir, `${base}.ts`))) continue;
+      issues.push({
+        level: "error",
+        block: base,
+        message:
+          `orphan QA sidecar: ${f} has no sibling ${base}.ts. ` +
+          `The block was deleted or moved; delete the sidecar (git history ` +
+          `keeps it) or restore the manifest.`,
+        file: f,
+      });
+    }
+  }
+
   for (const name of names) {
     const tsPath = join(dir, `${name}.ts`);
     if (!existsSync(tsPath)) {

--- a/scripts/tests/validate-orphan-sidecar.test.ts
+++ b/scripts/tests/validate-orphan-sidecar.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join, basename } from "path";
+import { validateObjects } from "../../content/pipeline/validate";
+
+/**
+ * A chapter directory containing `blocks` as `.ts` + `.md` pairs, plus any
+ * bare `sidecars` written with no manifest behind them.
+ */
+function chapter(blocks: string[], sidecars: string[] = []): string {
+  const root = mkdtempSync(join(tmpdir(), "orphan-"));
+  for (const b of blocks) {
+    writeFileSync(
+      join(root, `${b}.ts`),
+      `export default { kind: "prose", label: "rem:${b}", title: "T", chapter: "c" };\n`,
+    );
+    writeFileSync(join(root, `${b}.md`), `Body of ${b}.\n`);
+  }
+  for (const s of sidecars) {
+    writeFileSync(
+      join(root, `${s}.qa.json`),
+      JSON.stringify({ $schema: "block-qa/v1", label: `rem:${s}`, criteria: {} }),
+    );
+  }
+  return root;
+}
+
+function orphanIssues(issues: Array<{ message: string }>) {
+  return issues.filter((i) => i.message.includes("orphan QA sidecar"));
+}
+
+describe("no-orphan-sidecar", () => {
+  test("flags a .qa.json whose .ts is gone", async () => {
+    const dir = chapter(["alpha"], ["ghost"]);
+    const { issues } = await validateObjects(dir);
+    const found = orphanIssues(issues);
+    expect(found.length).toBe(1);
+    expect(found[0].message).toContain("ghost.qa.json");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("does not flag a sidecar that has its manifest", async () => {
+    const dir = chapter(["alpha"], ["alpha"]);
+    const { issues } = await validateObjects(dir);
+    expect(orphanIssues(issues).length).toBe(0);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("clean chapter with no sidecars at all is fine", async () => {
+    const dir = chapter(["alpha", "beta"]);
+    const { issues } = await validateObjects(dir);
+    expect(orphanIssues(issues).length).toBe(0);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("reports every orphan, not just the first", async () => {
+    const dir = chapter(["alpha"], ["ghost-one", "ghost-two"]);
+    const { issues } = await validateObjects(dir);
+    expect(orphanIssues(issues).length).toBe(2);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("is an error, not a warning", async () => {
+    // An audit report for a block that does not exist is not a style nit — it
+    // can never be refreshed and it corrupts corpus counts.
+    const dir = chapter(["alpha"], ["ghost"]);
+    const { issues } = await validateObjects(dir);
+    expect(orphanIssues(issues)[0]).toMatchObject({ level: "error" });
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe("no-orphan-sidecar in chapter mode", () => {
+  /**
+   * Chapter mode passes an explicit `blockNames` list; flat mode passes null.
+   * The first version of this check was gated on `blockNames === null`, which
+   * made it a silent no-op for every real paper — the unit tests above all
+   * exercise flat mode and passed regardless. This fixture pins the real path.
+   */
+  function chapterMode(blocks: string[], sidecars: string[]): string {
+    const root = mkdtempSync(join(tmpdir(), "orphan-ch-"));
+    const name = basename(root);
+    for (const b of blocks) {
+      writeFileSync(
+        join(root, `${b}.ts`),
+        `export default { kind: "prose", label: "rem:${b}", title: "T", chapter: "${name}" };\n`,
+      );
+      writeFileSync(join(root, `${b}.md`), `Body of ${b}.\n`);
+    }
+    for (const s of sidecars) {
+      writeFileSync(
+        join(root, `${s}.qa.json`),
+        JSON.stringify({ $schema: "block-qa/v1", label: `rem:${s}`, criteria: {} }),
+      );
+    }
+    // `<dirname>.ts` exporting a Chapter makes validateObjects take the
+    // chapter branch, which supplies blockNames from the section manifest.
+    writeFileSync(
+      join(root, `${name}.ts`),
+      `export default { title: "T", sections: [{ title: "S", blocks: ${JSON.stringify(blocks)} }] };\n`,
+    );
+    return root;
+  }
+
+  test("still flags an orphan when blockNames is supplied", async () => {
+    const dir = chapterMode(["alpha"], ["ghost"]);
+    const { issues } = await validateObjects(dir);
+    const found = orphanIssues(issues);
+    expect(found.length).toBe(1);
+    expect(found[0].message).toContain("ghost.qa.json");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("a sidecar whose manifest exists but was not requested is not an orphan", async () => {
+    // Orphanhood is about the .ts existing ON DISK, not about being in the
+    // caller's subset.
+    const dir = chapterMode(["alpha"], []);
+    writeFileSync(
+      join(dir, "beta.ts"),
+      `export default { kind: "prose", label: "rem:beta", title: "T", chapter: "c" };\n`,
+    );
+    writeFileSync(join(dir, "beta.qa.json"), JSON.stringify({ criteria: {} }));
+    const { issues } = await validateObjects(dir);
+    expect(orphanIssues(issues).length).toBe(0);
+    rmSync(dir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
A `<block>.qa.json` whose `.ts` is gone is an audit report about a block that doesn't exist. Nothing enforced that.

The consequences are quiet rather than loud, which is why they accumulated:

- it **can never be refreshed** — no sweep will ever visit it
- it **silently inflates every corpus census** taken over `**/*.qa.json`, which is how QA state is normally counted. It distorted every count I took across qou this session.

Same principle as `no-orphan-lean` — a `.lean` file is never standalone, and neither is a QA report. Level `error`, matching that constraint.

## Found live in qou: 18 orphans

- **13** whose block name exists nowhere in the corpus
- **5** stranded by a block **moving chapters** — the block picked up a fresh sidecar at its new path while the old file stayed behind, holding verdicts computed against content that has since changed

## It was a no-op in its first form — caught before landing

I gated the check on `blockNames === null`. That's only true in **legacy flat mode**; every real paper goes through **chapter mode** with an explicit block list, so the check never ran on any of them.

All five unit tests exercised flat mode and passed regardless. Running it against the real corpus is what exposed it — validate came back clean when it should have found five known orphans.

The gate was also wrong on its own terms: orphanhood asks whether `<base>.ts` exists **on disk**, not whether the caller requested that block. A sidecar whose manifest exists but wasn't in `blockNames` still finds its `.ts` and isn't flagged, so no gate is needed at all.

Two **chapter-mode** tests now pin the real path — including that manifest-exists-but-not-requested is *not* an orphan.

## Verification

Against qou, `run-validate`:

| | before | after |
|---|---|---|
| result | ✓ Valid — 5 issues | ✗ **Invalid — 10 issues** |

The 5 new ones are exactly the 5 known stranded sidecars, each named with its missing manifest:

```
✗ [p3-blowup-yekutieli]: orphan QA sidecar: p3-blowup-yekutieli.qa.json has no
  sibling p3-blowup-yekutieli.ts. The block was deleted or moved; delete the
  sidecar (git history keeps it) or restore the manifest.
```

- `bun test` — **576 pass, 46 skip, 0 fail** (7 new)
- `tsc --noEmit` — clean
- `eslint .` — clean

## Sequencing

This makes qou's `main` red until its 5 orphans are deleted — that PR follows immediately, and the deletion is verified *by* this constraint.

---
_Generated by [Claude Code](https://claude.ai/code/session_016hQePZH4xA7gxL5eLTP5av)_