### PR TITLE
schema: `foreshadows[]` — declare a forward reference as deliberate

### DIFF
--- a/content/pipeline/qa-checkers-extended.ts
+++ b/content/pipeline/qa-checkers-extended.ts
@@ -1456,6 +1456,19 @@ export function checkDetanglerSectionBand(
 // this commit, with explicit `n/a` returns so the sweep doesn't
 // flag them as missing. A follow-up commit will wire them.
 
+/**
+ * Parse a block manifest's `foreshadows: [...]` — the subset of `uses[]` the
+ * author has declared as a deliberate forward reference.
+ *
+ * Text-level like the sibling `label:` parse in this file, so the checker
+ * stays free of a module import of the manifest.
+ */
+export function parseForeshadows(tsSrc: string): string[] {
+  const m = tsSrc.match(/\bforeshadows:\s*\[([\s\S]*?)\]/);
+  if (!m) return [];
+  return [...m[1].matchAll(/["']([^"']+)["']/g)].map((x) => x[1]);
+}
+
 export function checkDetanglerNoForwardRef(
   tsPath: string | undefined,
 ): CheckerResult {
@@ -1472,11 +1485,19 @@ export function checkDetanglerNoForwardRef(
   if (myPos === undefined) return { result: "pass", hits: [] }; // not listed
   const myChapter = _labelToChapter.get(label);
 
+  // Deliberate forward references — a foreshadow, a preview, or an explicitly
+  // deferred result the exposition promises to return to. Declared on the
+  // block, so the intent lives in the authored manifest next to `uses[]`
+  // rather than in a QA sidecar. Only these edges are exempt; every other
+  // forward ref is still a finding.
+  const foreshadowed = new Set(parseForeshadows(content));
+
   const hits: CheckerHit[] = [];
   for (const u of _usesGraph.get(label) ?? []) {
     // Only SAME-chapter forward refs here; cross-chapter is the
     // separate `detangler-no-xchapter-fwd` criterion.
     if (_labelToChapter.get(u) !== myChapter) continue;
+    if (foreshadowed.has(u)) continue;
     const uPos = _blockPos.get(u);
     if (uPos !== undefined && uPos > myPos) {
       hits.push({

--- a/schemas/constraints.ts
+++ b/schemas/constraints.ts
@@ -398,6 +398,7 @@ export const AuthorNoteSchema = z.object({
 const BlockBaseSchema = z.object({
   title: z.string().optional(),
   uses: z.array(z.string()).optional(),
+  foreshadows: z.array(z.string()).optional(),
   cites: z.array(z.string()).optional(),
   tags: z.array(z.string()).optional(),
   companions: CompanionsSchema.optional(),
@@ -564,6 +565,7 @@ export const ProseSchema = z.object({
   cites: z.array(z.string()).optional(),
   tags: z.array(z.string()).optional(),
   uses: z.array(z.string()).optional(),
+  foreshadows: z.array(z.string()).optional(),
   companions: CompanionsSchema.optional(),
   rendered: z.array(RenderedAssetSchema).optional(),
   meta: z.record(z.string(), z.unknown()).optional(),
@@ -577,6 +579,7 @@ export const EquationSchema = z.object({
   tex: z.string().optional(),
   tags: z.array(z.string()).optional(),
   uses: z.array(z.string()).optional(),
+  foreshadows: z.array(z.string()).optional(),
   companions: CompanionsSchema.optional(),
   rendered: z.array(RenderedAssetSchema).optional(),
   meta: z.record(z.string(), z.unknown()).optional(),
@@ -591,6 +594,7 @@ export const DiagramSchema = z.object({
   caption: z.string().optional(),
   tags: z.array(z.string()).optional(),
   uses: z.array(z.string()).optional(),
+  foreshadows: z.array(z.string()).optional(),
   companions: CompanionsSchema.optional(),
   rendered: z.array(RenderedAssetSchema).optional(),
   meta: z.record(z.string(), z.unknown()).optional(),
@@ -605,6 +609,7 @@ export const TableSchema = z.object({
   title: z.string().optional(),
   tags: z.array(z.string()).optional(),
   uses: z.array(z.string()).optional(),
+  foreshadows: z.array(z.string()).optional(),
   computation: ComputationSchema.optional(),
   companions: CompanionsSchema.optional(),
   rendered: z.array(RenderedAssetSchema).optional(),
@@ -755,6 +760,29 @@ export interface ConstraintContext {
  * Add custom rules by appending to this array.
  */
 export const CONSTRAINT_RULES: ConstraintRule[] = [
+  {
+    id: "foreshadows-subset-of-uses",
+    description:
+      "Every foreshadows[] entry must also appear in uses[] — a declared " +
+      "forward reference to something the block does not reference is " +
+      "meaningless, and would silently exempt nothing",
+    // Universal: any block that can carry `uses[]` can carry a foreshadow, so
+    // this must not narrow as new kinds appear.
+    appliesTo: [...BLOCK_KINDS],
+    check: (block) => {
+      const fs = (block as { foreshadows?: string[] }).foreshadows;
+      if (!fs?.length) return null;
+      const uses = new Set((block as { uses?: string[] }).uses ?? []);
+      // Keeps `foreshadows` an annotation ON an edge rather than a second,
+      // parallel way to name blocks. Without this it drifts: a `uses[]` entry
+      // gets removed or renamed, its foreshadow declaration lingers, and the
+      // exemption quietly applies to nothing while looking deliberate.
+      const orphans = fs.filter((f) => !uses.has(f));
+      return orphans.length
+        ? `foreshadows[] entries not present in uses[]: ${orphans.join(", ")}`
+        : null;
+    },
+  },
   {
     id: "md-exists",
     description: "Every block must have a companion .md file",

--- a/schemas/types.ts
+++ b/schemas/types.ts
@@ -572,6 +572,24 @@ interface BlockBase {
    */
   uses?: string[];
   /**
+   * Subset of `uses[]` that points DELIBERATELY forward — a foreshadow, a
+   * preview, or an explicitly deferred result the exposition promises to
+   * return to (the surreal-number thread is the archetype).
+   *
+   * `detangler-no-forward-ref` exists to catch a reader being sent to material
+   * they have not reached yet (`detangler-no-xchapter-fwd` is still an unwired
+   * stub returning `n/a`). That is a
+   * defect when it is accidental and a rhetorical device when it is not: a
+   * block may legitimately say "we will need X, proved in chapter 9". Listing
+   * X here declares the reference intentional and exempts that one edge.
+   *
+   * NOT a way to silence the axis. Every entry must also appear in `uses[]`
+   * (enforced — a foreshadow of something the block does not reference is
+   * meaningless), and each one is a claim that the prose actually frames the
+   * reference as deferred. Everything not listed stays a finding.
+   */
+  foreshadows?: string[];
+  /**
    * Bibliography keys cited by this block (e.g. ["kock2004", "atiyah1988"]).
    *
    * These are reference ids from content/schema/references.ts.
@@ -882,6 +900,8 @@ export interface ProseBlock {
   title?: string;
   /** Labels of content blocks this prose depends on (for the dependency graph). */
   uses?: string[];
+  /** Subset of `uses[]` that points deliberately forward — see `BlockBase.foreshadows`. */
+  foreshadows?: string[];
   /** Bibliography keys cited by this block. */
   cites?: string[];
   tags?: string[];
@@ -908,6 +928,8 @@ export interface EquationBlock {
    *  all declare it. `tags` was likewise present in the Zod schema and absent
    *  here. */
   uses?: string[];
+  /** Subset of `uses[]` that points deliberately forward — see `BlockBase.foreshadows`. */
+  foreshadows?: string[];
   /** Inline TeX for the equation (short enough to live in .ts). */
   tex?: string;
   companions?: Companions;
@@ -933,6 +955,8 @@ export interface DiagramBlock {
   tags?: string[];
   /** Labels of content blocks this diagram depends on (for the dependency graph). */
   uses?: string[];
+  /** Subset of `uses[]` that points deliberately forward — see `BlockBase.foreshadows`. */
+  foreshadows?: string[];
   companions?: Companions;
   /** Pre-rendered diagram (e.g. SVG from tikzcd server-side render). */
   rendered?: RenderedAsset[];
@@ -959,6 +983,8 @@ export interface TableBlock {
   tags?: string[];
   /** Blocks that this table summarises data from. */
   uses?: string[];
+  /** Subset of `uses[]` that points deliberately forward — see `BlockBase.foreshadows`. */
+  foreshadows?: string[];
   /** Witness/script the table values are derived from (mirrors RemarkBlock).
    *  Lets tables that cite `:val[…]` literals declare the upstream witness
    *  dep, same as remark/proof/definition blocks. */

--- a/scripts/tests/foreshadows.test.ts
+++ b/scripts/tests/foreshadows.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { CONSTRAINT_RULES } from "../../schemas/constraints";
+import { parseForeshadows } from "../../content/pipeline/qa-checkers-extended";
+
+const rule = CONSTRAINT_RULES.find((r) => r.id === "foreshadows-subset-of-uses")!;
+
+// The constraint only reads the block, so the context is never consulted.
+const ctx = {} as Parameters<typeof rule.check>[1];
+
+describe("parseForeshadows", () => {
+  test("reads a single-line declaration", () => {
+    expect(
+      parseForeshadows(`export default prose({ foreshadows: ["def:x"] });`),
+    ).toEqual(["def:x"]);
+  });
+
+  test("reads a multi-line declaration", () => {
+    const src = `export default prose({\n  foreshadows: [\n    "def:x",\n    "thm:y",\n  ],\n});\n`;
+    expect(parseForeshadows(src)).toEqual(["def:x", "thm:y"]);
+  });
+
+  test("absent field yields nothing", () => {
+    expect(parseForeshadows(`export default prose({ uses: ["def:x"] });`)).toEqual([]);
+  });
+
+  test("empty array yields nothing", () => {
+    expect(parseForeshadows(`export default prose({ foreshadows: [] });`)).toEqual([]);
+  });
+});
+
+describe("foreshadows-subset-of-uses", () => {
+  test("passes when every entry is also in uses[]", () => {
+    const block = { kind: "prose", uses: ["def:x", "thm:y"], foreshadows: ["thm:y"] };
+    expect(rule.check(block as never, ctx)).toBeNull();
+  });
+
+  test("fails when an entry is not in uses[]", () => {
+    // The drift this exists to catch: the uses[] edge is removed or renamed,
+    // the foreshadow declaration lingers, and the exemption applies to nothing
+    // while still looking deliberate.
+    const block = { kind: "prose", uses: ["def:x"], foreshadows: ["thm:gone"] };
+    const msg = rule.check(block as never, ctx);
+    expect(msg).toContain("thm:gone");
+  });
+
+  test("fails when uses[] is absent entirely", () => {
+    const block = { kind: "prose", foreshadows: ["thm:y"] };
+    expect(rule.check(block as never, ctx)).toContain("thm:y");
+  });
+
+  test("no foreshadows is not a finding", () => {
+    expect(rule.check({ kind: "prose", uses: ["def:x"] } as never, ctx)).toBeNull();
+  });
+
+  test("empty foreshadows is not a finding", () => {
+    const block = { kind: "prose", uses: ["def:x"], foreshadows: [] };
+    expect(rule.check(block as never, ctx)).toBeNull();
+  });
+
+  test("reports every offender, not just the first", () => {
+    const block = { kind: "prose", uses: [], foreshadows: ["a:1", "b:2"] };
+    const msg = rule.check(block as never, ctx)!;
+    expect(msg).toContain("a:1");
+    expect(msg).toContain("b:2");
+  });
+});


### PR DESCRIPTION
Implements the ruling that **a forward reference is legitimate when it's a foreshadow, a preview, or an explicitly deferred result** the exposition promises to return to (the surreal thread being the archetype).

`detangler-no-forward-ref` had no way to express that — it flagged every same-chapter forward `uses[]` edge unconditionally. **246 blocks** report a finding with no way to say *"this one is the rhetorical device, not the defect."*

## The field

`BlockBase.foreshadows?: string[]` names the subset of `uses[]` that points forward on purpose. The checker skips exactly those edges.

**Declared on the block, not in a QA sidecar.** Foreshadowing is an editorial fact about the prose, so it belongs in the authored manifest beside `uses[]` — the relation it annotates — rather than as an acknowledgement in the QA layer. It also survives sweeps and sits where an author is already working.

## Not a silencer

New universal constraint **`foreshadows-subset-of-uses`** requires every entry to appear in `uses[]`. Without it the field drifts: a `uses[]` edge gets renamed or dropped, the declaration lingers, and the exemption applies to nothing while still looking deliberate. Everything not listed remains a finding.

## Verified end-to-end on real data, not just fixtures

`braids-and-knots/coxeter-parabolic-transversal`, which uses `def:hecke-normal-form` at manifest pos 46 from pos 32:

| | result |
|---|---|
| before | **fail** — `forward ref: uses def:hecke-normal-form (manifest pos 46)…` |
| after, with `foreshadows: ["def:hecke-normal-form"]` | **pass**, 0 hits |

And **inert without it** — the corpus still reports 246 failing blocks, since nothing declares a foreshadow yet. Opt-in by construction; no accidental mass-suppression.

## Two repo drift-guards caught real mistakes before this landed

Both were right to fail:

- **schema-parity** — `prose`, `equation`, `diagram` and `table` declare their fields **inline** rather than inheriting `BlockBase`, so adding the Zod field alone broke the TS/Zod pairing for those four kinds.
- **appliesTo-coverage** — my constraint listed 11 kinds and silently skipped `algorithm`, `proof`, `diagram`, `table`. Now `[...BLOCK_KINDS]`.

I'd have shipped both without those tests.

## Note

`detangler-no-xchapter-fwd` is untouched — it's still an **unwired stub returning `n/a`**, contrary to what its presence in the criteria list suggests.

- `bun test` — **586 pass, 46 skip, 0 fail** (10 new)
- `tsc --noEmit`, `eslint .` — clean
- qou `run-validate` — exit 0, unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_016hQePZH4xA7gxL5eLTP5av)_