### PR TITLE
docs: regenerate the stale reference + a --check gate so it cannot rot again

### DIFF
--- a/.github/workflows/code-quality-gates.yml
+++ b/.github/workflows/code-quality-gates.yml
@@ -167,6 +167,16 @@ jobs:
       - name: tsc --noEmit
         run: bunx tsc --noEmit -p tsconfig.json
 
+      # `docs/reference/**` is generated from skill sources and must not be
+      # hand-edited, but nothing verified it had been REGENERATED after a
+      # source change. document-intake.md sat 35 lines behind its source and
+      # the published docs site served the stale copy. --check writes nothing
+      # and names every file that would change.
+      - name: generated docs are current
+        run: |
+          bun run scripts/gen-schema-docs.ts --check
+          bun run scripts/gen-skill-docs.ts --check
+
   rust-wildcard:
     name: Rust wildcard imports (warn-only)
     runs-on: ubuntu-latest

--- a/docs/reference/skill-instructions/document-intake.md
+++ b/docs/reference/skill-instructions/document-intake.md
@@ -116,17 +116,48 @@ per [`bib-qa.md §Batch intake pipeline`](bib-qa.md#batch-intake-pipeline).
 
 Convert raw format to `extracted-text.md`:
 
+**For PDFs, always start with
+[`scripts/pdf-extract.py`](../../scripts/pdf-extract.py)** — do not reach for a
+Python PDF library directly. It walks a fallback ladder (`pdftotext` → `pypdf` →
+`pdfminer.six` → a zero-dependency content-stream extractor → OCR) and, when it
+cannot read a file, **tells you which rung failed and why** instead of returning
+an empty string:
+
+```bash
+python3 scripts/pdf-extract.py FILE.pdf -o extracted-text.md
+python3 scripts/pdf-extract.py FILE.pdf --diagnose   # structure only
+```
+
+Exit `0` = text; **exit `2` = no text layer (a scan)**; exit `3` = a parser
+problem on a file that does have text.
+
+Two failure modes it exists to prevent, both observed in practice:
+
+* **A silent empty extraction reads exactly like a scan, a broken library, and
+  a malformed PDF.** The script separates them by inspecting the PDF structure
+  (`CCITTFaxDecode` / `JBIG2Decode` / `DCTDecode` counts against `/Font`), so
+  "swap libraries" vs "you need OCR" is decided by evidence rather than guessed.
+* **A broken native extension kills the whole pipeline.** `pypdf` and
+  `pdfminer.six` both fail via pyo3 `PanicException` when `cryptography`'s Rust
+  bindings are broken — and that is a `BaseException`, so an ordinary
+  `except Exception` does **not** catch it. Every rung is guarded accordingly.
+  The zero-dependency rung exists precisely for this case; in the container this
+  was written in it was the only rung that worked.
+
 | Format | Extraction method |
 |--------|-------------------|
-| PDF (text) | `pdftotext` or PDF.js |
-| PDF (scan) | Tesseract OCR / Claude vision |
+| PDF (text) | `scripts/pdf-extract.py` (ladder; `pdftotext` when available) |
+| PDF (scan) | `scripts/pdf-extract.py` → exit 2, then Tesseract OCR / Claude vision |
 | LaTeX | Direct parse (strip preamble) |
 | HTML | Readability + turndown |
 | DOCX | Pandoc → markdown |
 | Images | Claude vision API |
 
-For scanned documents, use Claude's vision capability to extract
-text with structural awareness (headings, lists, tables, boxes).
+For scanned documents the script's OCR rung fires automatically **if**
+`tesseract` and `pdftoppm` are installed (`apt-get install -y tesseract-ocr
+poppler-utils`); it names whichever is missing. Where OCR is unavailable, or
+where layout carries meaning (headings, lists, tables, boxes), fall back to
+Claude's vision capability, which reads structure that OCR flattens.
 
 **Output**: `extracted-text.md` — raw markdown with preserved structure.
 

--- a/scripts/gen-schema-docs.ts
+++ b/scripts/gen-schema-docs.ts
@@ -25,6 +25,44 @@ const REPO_ROOT = resolve(import.meta.dir, "..");
 const SKILLS_DIR = join(REPO_ROOT, "schemas", "skills");
 const OUT_DIR = join(REPO_ROOT, "docs", "reference", "skills");
 
+/**
+ * `--check`: verify the generated tree is current without writing to it.
+ *
+ * These pages are generated from skill sources and the repo forbids editing
+ * them by hand, but nothing verified they had actually been regenerated after
+ * a source change — so `document-intake.md` sat 35 lines behind its source
+ * (the PDF-extraction ladder) and the published docs site served the stale
+ * copy. A generated file with no drift guard is a file that silently rots.
+ *
+ * Collects every path whose content would change, so one run reports all of
+ * them rather than the first.
+ */
+const CHECK_ONLY = process.argv.includes("--check");
+const drifted: string[] = [];
+
+function emit(path: string, content: string): void {
+  if (CHECK_ONLY) {
+    const current = existsSync(path) ? readFileSync(path, "utf-8") : null;
+    if (current !== content) drifted.push(path);
+    return;
+  }
+  writeFileSync(path, content);
+}
+
+function reportDrift(): void {
+  if (!CHECK_ONLY) return;
+  if (drifted.length === 0) {
+    console.log("generated docs are up to date");
+    process.exit(0);
+  }
+  console.error(
+    `generated docs are STALE (${drifted.length} file(s)); re-run without --check:`,
+  );
+  for (const p of drifted) console.error(`  ${p}`);
+  process.exit(1);
+}
+
+
 interface JsonSchema {
   $id?: string;
   title?: string;
@@ -207,7 +245,7 @@ function main(): void {
       continue;
     }
     const page = renderSkillPage(skill, input, output);
-    writeFileSync(join(OUT_DIR, `${skill}.md`), page);
+    emit(join(OUT_DIR, `${skill}.md`), page);
     const title = (input?.title || output?.title || skill).replace(/ (Input|Output)$/i, "");
     const desc = (input?.description || output?.description || "").replace(/\|/g, "\\|");
     indexRows.push(`| [${title}](${skill}.html) | \`${skill}\` | ${desc} |`);
@@ -237,8 +275,9 @@ function main(): void {
   index.push("bodies the LLM loads) and the [TypeScript API reference](../../api/) for the");
   index.push("content-object model (`Block`, `Chapter`, `Paper`, builders, and Zod constraints).");
   index.push("");
-  writeFileSync(join(OUT_DIR, "index.md"), index.join("\n"));
+  emit(join(OUT_DIR, "index.md"), index.join("\n"));
   console.log(`  ✓ index.md (${indexRows.length} skills)`);
+  reportDrift();
   console.log(`\nWrote schema docs to ${OUT_DIR}`);
 }
 

--- a/scripts/gen-skill-docs.ts
+++ b/scripts/gen-skill-docs.ts
@@ -27,6 +27,44 @@ import { join, resolve, basename } from "path";
 
 const REPO_ROOT = resolve(import.meta.dir, "..");
 const OUT_DIR = join(REPO_ROOT, "docs", "reference", "skill-instructions");
+
+/**
+ * `--check`: verify the generated tree is current without writing to it.
+ *
+ * These pages are generated from skill sources and the repo forbids editing
+ * them by hand, but nothing verified they had actually been regenerated after
+ * a source change — so `document-intake.md` sat 35 lines behind its source
+ * (the PDF-extraction ladder) and the published docs site served the stale
+ * copy. A generated file with no drift guard is a file that silently rots.
+ *
+ * Collects every path whose content would change, so one run reports all of
+ * them rather than the first.
+ */
+const CHECK_ONLY = process.argv.includes("--check");
+const drifted: string[] = [];
+
+function emit(path: string, content: string): void {
+  if (CHECK_ONLY) {
+    const current = existsSync(path) ? readFileSync(path, "utf-8") : null;
+    if (current !== content) drifted.push(path);
+    return;
+  }
+  writeFileSync(path, content);
+}
+
+function reportDrift(): void {
+  if (!CHECK_ONLY) return;
+  if (drifted.length === 0) {
+    console.log("generated docs are up to date");
+    process.exit(0);
+  }
+  console.error(
+    `generated docs are STALE (${drifted.length} file(s)); re-run without --check:`,
+  );
+  for (const p of drifted) console.error(`  ${p}`);
+  process.exit(1);
+}
+
 const SCHEMA_DIR = join(REPO_ROOT, "docs", "reference", "skills");
 
 interface Group {
@@ -115,7 +153,7 @@ function main(): void {
       page.push(body.trimEnd());
       page.push("{% endraw %}");
       page.push("");
-      writeFileSync(join(OUT_DIR, `${name}.md`), page.join("\n"));
+      emit(join(OUT_DIR, `${name}.md`), page.join("\n"));
       written.set(name, group.category);
 
       const desc = escapePipes((body.match(/^#\s+.+\n+([^\n#].*)$/m)?.[1] ?? "").slice(0, 100));
@@ -162,9 +200,10 @@ function main(): void {
   idx.push("> skill *definitions* + typed schemas today; their prose instruction bodies");
   idx.push("> will appear here as they are authored.");
   idx.push("");
-  writeFileSync(join(OUT_DIR, "index.md"), idx.join("\n"));
+  emit(join(OUT_DIR, "index.md"), idx.join("\n"));
   const total = Object.values(indexRows).reduce((n, r) => n + r.length, 0);
   console.log(`  ✓ index.md (${total} instruction bodies)`);
+  reportDrift();
   console.log(`\nWrote skill instruction docs to ${OUT_DIR}`);
 }
 


### PR DESCRIPTION
`docs/reference/**` is generated from skill sources, and AGENTS.md forbids hand-editing it. **Nothing verified it had actually been regenerated** after a source change — so it drifted silently.

`docs/reference/skill-instructions/document-intake.md` sat **35 lines behind its source**, missing the whole `scripts/pdf-extract.py` fallback-ladder section, its exit-code contract (`0` = text, `2` = scan, `3` = parser problem), and the two failure modes it exists to prevent. The docs site publishes from `docs/`, so **the stale copy is what readers were served**.

## The fix

Regenerated, and both generators gain `--check`: compare what they would write against what's on disk, **write nothing**, exit 1 naming every stale file. Collects all of them rather than stopping at the first.

Wired into **`TypeScript — tests, lint, types (hard)`** — the job that actually runs on PRs — rather than `docs-site.yml`, which publishes.

Same shape as the `no-orphan-sidecar` constraint from earlier: a generated file with no drift guard is a file that silently rots, so make the invariant checkable instead of relying on someone remembering.

## Verified three ways

| | result |
|---|---|
| `--check` on the regenerated tree | exit 0, *"generated docs are up to date"* |
| `--check` on the stale committed doc | **exit 1**, names `document-intake.md` |
| `--check` side effects | **none** — git reports 0 changes under `docs/` |

## One thing worth recording, since it cost a recovery

Using `git stash` to test the stale case **also stashes the generator patch** — so that run silently used the *original* generators, wrote the files, reported success, and then blocked the pop. Reverting only the generated file is the correct way to exercise it. The first "it passed!" was the test procedure being wrong, not the code being right.

- `bun test` — 632 tests, **0 fail**
- `tsc --noEmit`, `eslint .` — clean
- workflow YAML parses

---
_Generated by [Claude Code](https://claude.ai/code/session_016hQePZH4xA7gxL5eLTP5av)_