### PR TITLE
uses/detangler skills: when a forward ref is a foreshadow, and why a reorder is not mechanical

### DIFF
--- a/docs/reference/skill-instructions/detangler-integration-watcher.md
+++ b/docs/reference/skill-instructions/detangler-integration-watcher.md
@@ -27,6 +27,55 @@ The formal relation is a separate edge kind in
 querying it from this watcher. The `uses` QA axis owns whether `uses[]`
 is *well used* — that is `uses-editorial-review`, not this watcher.
 
+## An intra-section swap is not a mechanical fix
+
+Reordering blocks to clear forward references is the obvious discharge
+for a `detangler-no-forward-ref` finding, and it is **not** safe to
+apply unread. Run over a real paper, an unconstrained search cleared 66
+of 236 forward references — and a narrative review of its 53 moves found
+**18 of them made the paper worse**. Reducing the metric and improving
+the reading are different objectives, and they diverge often enough that
+the difference is not a rounding error.
+
+Constrain the search first. Each of these exists because a move broke
+something a reader would hit:
+
+| constraint | what it prevents |
+|---|---|
+| a block never leaves its section | section membership decides which heading a block appears under — that is a rewrite, not a reordering |
+| the section's first unit and any `meta.position: "opening"` block are pinned | a block landing above the framing prose it presupposes |
+| a block may not precede one it `interprets` | splitting a narrative pair; `interprets` pairs blocks whose slugs share no prefix, so no family rule catches it |
+| forward references over prose may not rise — both `[text](#label)` and backticked `kind:slug` | stranding a block from a dependency `uses[]` never declared. Count both forms: a block naming its prerequisite only in code spans is invisible to a link-only scan |
+| families are atomic: `X` with `X-proof`, `X-interpretation`, `X-tableN-data` | a proposition separated from its proof |
+| a unit headed by a descendant of a block in the same section is pinned | an *already-detached* child wandering further from its parent |
+| comments never move; the entry beneath a comment is pinned | a note re-attaching to a block it was not written about. Some of these describe the block below; others describe a block that was moved away and is no longer there. Text alone does not tell them apart |
+
+Prose references are a **guard, not an objective**. Minimising them
+would be authoring `uses[]` by inference, which is the failure mode the
+`uses` axis exists to prevent.
+
+Even fully constrained, the search cannot see authored order, and this
+is what escalation is for. Every one of these was found only by reading:
+
+- a section intro that narrates a sequence — "the analysis proceeds in
+  three stages. **First** … **Second** …", a hand-numbered 1–5 arc,
+  "**Finally**, the classical limit demonstrates…" — which the move
+  falsifies;
+- a block opening on a **bare anaphor** ("**These axioms** carry direct
+  physical meanings…", "they are **its** surrounding vocabulary");
+- a **definite article** pointing at something introduced above ("**the**
+  terminal Skein resolution", "the confinement category") with no
+  `uses[]` edge behind it;
+- the previous block **closing by announcing** the next ("Iterating this
+  categorical jet construction generates the recursive brane tower");
+- a block that self-labels "(forward reference)" — the edge is authored.
+
+So: propose, review, then apply — never apply and then review. Record
+each veto **with its reason, per block**, in a pin list the next run
+reads; the reasons live in the prose, not the manifests, and rediscovering
+them costs a full reading every time. Expect the reviewed yield to be
+roughly a third of what the raw metric promises, and prefer it.
+
 **Setup:** use `NAME=detangler-integration-watcher` everywhere the
 parent's §1 references `${NAME}`. Files at
 `.beans/detangler-integration-watcher-queue.json` and

--- a/docs/reference/skill-instructions/uses-editorial-review.md
+++ b/docs/reference/skill-instructions/uses-editorial-review.md
@@ -80,6 +80,53 @@ When reviewing, do not open the Lean file to decide what belongs in
 | `warn` | A marginal entry, or a missing dependency a reader could shrug off. |
 | `fail` | A missing dependency a reader would stumble over, **or** an entry that is plainly a copied-in formal dependency. |
 
+## Forward references and `foreshadows[]`
+
+A `uses[]` entry pointing at a block that appears *later* in the chapter
+is a `detangler-no-forward-ref` finding. Sometimes that is right — the
+exposition really does defer — and `foreshadows[]` (a subset of `uses[]`,
+enforced by `foreshadows-subset-of-uses`) declares it, permanently
+exempting the edge.
+
+Permanently is the operative word. A wrong declaration does not merely
+mislabel: it hides a genuine ordering defect behind an authored claim
+that the disorder was intended, and nothing downstream re-opens it. The
+contract in `BlockBase.foreshadows` is strict — the prose must **frame
+the reference as deferred** ("we will need X, proved in chapter 9").
+
+The bar is a first-person authorial hand-off that says the treatment
+happens *elsewhere*: "we establish this in X", "we work this out
+separately", "the derivation is recorded in X". In a review of 274
+forward edges, every declaration that survived adversarial re-review had
+that shape, and **17 of 23** first-pass declarations did not and were
+withdrawn.
+
+| Looks like a deferral | Actually |
+|---|---|
+| Bare cross-reference — "See [X] in Chapter 7" | `ordering`. Says nothing about direction. |
+| Organizational pointer — "these tables are projections of this master table" | `ordering`. About structure, not sequence. |
+| Block asserts the target's conclusion as background, then reasons onward from it | `ordering`. Consuming a result is the opposite of deferring it. |
+| Target listed under "## Rigorous results" / "## Consumers / downstream" | `ordering` — and check the direction; these often run target→source. |
+| A forward-looking word ("below", "later", "we must show") | `ordering` unless the sentence is about *this target's placement*. "Below $n^*$" is a numeric comparison; "we must show" is usually about research, not chapter order. |
+
+Two failure modes survive a verbatim quote, so check both before
+declaring:
+
+- **False locator.** "the functor of the *next subsection*" where the
+  target is 21 sections and ~300 blocks away. The prose defers; it does
+  not defer *this far*, and the edge is a real defect.
+- **Mis-aimed deferral.** The quoted sentence hands off to a *different*
+  block than the edge under review. A deferral pointed elsewhere cannot
+  exempt this one.
+
+Before calling a forward edge spurious, read the block's extracted
+`tbl:…-data` children. Pointer-style blocks ("See Table 3") keep their
+substance there, and a name-and-notation search of the `.md` alone will
+report absence that is not real. Searching for the target's *words* also
+misses a lean on the target's *object* — a source writing
+"the canonical $\tilde w_\lambda$" depends on whatever defines the
+undeformed $w_\lambda$, whether or not it ever says so.
+
 ## Reading the mechanical findings first
 
 Run the script half before adjudicating — it is cheap and it changes

--- a/skills/folio-core/detangler-integration-watcher.md
+++ b/skills/folio-core/detangler-integration-watcher.md
@@ -11,9 +11,10 @@ description: >
   the editor's detanglement skill suite (`content-graph`,
   `chapter-complexity-review`, `block-density`, `critical-path-analysis`)
   on every detected change. Queues findings, auto-discharges mechanical
-  fixes (intra-section swap, table extraction), escalates section splits
-  / merges / cross-chapter moves / new sections to the author. Inherits
-  shared mechanics from `local/integration-watcher`.
+  fixes (table extraction), routes block reorderings through narrative
+  review before applying them, and escalates section splits / merges /
+  cross-chapter moves / new sections to the author. Inherits shared
+  mechanics from `local/integration-watcher`.
 allowed-tools: Read Edit Write Bash Grep Glob Agent Monitor Skill
 ---
 
@@ -35,6 +36,55 @@ The formal relation is a separate edge kind in
 `content/pipeline/content-graph.ts`; pass `"editorial"` explicitly when
 querying it from this watcher. The `uses` QA axis owns whether `uses[]`
 is *well used* — that is `uses-editorial-review`, not this watcher.
+
+## An intra-section swap is not a mechanical fix
+
+Reordering blocks to clear forward references is the obvious discharge
+for a `detangler-no-forward-ref` finding, and it is **not** safe to
+apply unread. Run over a real paper, an unconstrained search cleared 66
+of 236 forward references — and a narrative review of its 53 moves found
+**18 of them made the paper worse**. Reducing the metric and improving
+the reading are different objectives, and they diverge often enough that
+the difference is not a rounding error.
+
+Constrain the search first. Each of these exists because a move broke
+something a reader would hit:
+
+| constraint | what it prevents |
+|---|---|
+| a block never leaves its section | section membership decides which heading a block appears under — that is a rewrite, not a reordering |
+| the section's first unit and any `meta.position: "opening"` block are pinned | a block landing above the framing prose it presupposes |
+| a block may not precede one it `interprets` | splitting a narrative pair; `interprets` pairs blocks whose slugs share no prefix, so no family rule catches it |
+| forward references over prose may not rise — both `[text](#label)` and backticked `kind:slug` | stranding a block from a dependency `uses[]` never declared. Count both forms: a block naming its prerequisite only in code spans is invisible to a link-only scan |
+| families are atomic: `X` with `X-proof`, `X-interpretation`, `X-tableN-data` | a proposition separated from its proof |
+| a unit headed by a descendant of a block in the same section is pinned | an *already-detached* child wandering further from its parent |
+| comments never move; the entry beneath a comment is pinned | a note re-attaching to a block it was not written about. Some of these describe the block below; others describe a block that was moved away and is no longer there. Text alone does not tell them apart |
+
+Prose references are a **guard, not an objective**. Minimising them
+would be authoring `uses[]` by inference, which is the failure mode the
+`uses` axis exists to prevent.
+
+Even fully constrained, the search cannot see authored order, and this
+is what escalation is for. Every one of these was found only by reading:
+
+- a section intro that narrates a sequence — "the analysis proceeds in
+  three stages. **First** … **Second** …", a hand-numbered 1–5 arc,
+  "**Finally**, the classical limit demonstrates…" — which the move
+  falsifies;
+- a block opening on a **bare anaphor** ("**These axioms** carry direct
+  physical meanings…", "they are **its** surrounding vocabulary");
+- a **definite article** pointing at something introduced above ("**the**
+  terminal Skein resolution", "the confinement category") with no
+  `uses[]` edge behind it;
+- the previous block **closing by announcing** the next ("Iterating this
+  categorical jet construction generates the recursive brane tower");
+- a block that self-labels "(forward reference)" — the edge is authored.
+
+So: propose, review, then apply — never apply and then review. Record
+each veto **with its reason, per block**, in a pin list the next run
+reads; the reasons live in the prose, not the manifests, and rediscovering
+them costs a full reading every time. Expect the reviewed yield to be
+roughly a third of what the raw metric promises, and prefer it.
 
 **Setup:** use `NAME=detangler-integration-watcher` everywhere the
 parent's §1 references `${NAME}`. Files at

--- a/skills/folio-core/uses-editorial-review.md
+++ b/skills/folio-core/uses-editorial-review.md
@@ -81,6 +81,53 @@ When reviewing, do not open the Lean file to decide what belongs in
 | `warn` | A marginal entry, or a missing dependency a reader could shrug off. |
 | `fail` | A missing dependency a reader would stumble over, **or** an entry that is plainly a copied-in formal dependency. |
 
+## Forward references and `foreshadows[]`
+
+A `uses[]` entry pointing at a block that appears *later* in the chapter
+is a `detangler-no-forward-ref` finding. Sometimes that is right — the
+exposition really does defer — and `foreshadows[]` (a subset of `uses[]`,
+enforced by `foreshadows-subset-of-uses`) declares it, permanently
+exempting the edge.
+
+Permanently is the operative word. A wrong declaration does not merely
+mislabel: it hides a genuine ordering defect behind an authored claim
+that the disorder was intended, and nothing downstream re-opens it. The
+contract in `BlockBase.foreshadows` is strict — the prose must **frame
+the reference as deferred** ("we will need X, proved in chapter 9").
+
+The bar is a first-person authorial hand-off that says the treatment
+happens *elsewhere*: "we establish this in X", "we work this out
+separately", "the derivation is recorded in X". In a review of 274
+forward edges, every declaration that survived adversarial re-review had
+that shape, and **17 of 23** first-pass declarations did not and were
+withdrawn.
+
+| Looks like a deferral | Actually |
+|---|---|
+| Bare cross-reference — "See [X] in Chapter 7" | `ordering`. Says nothing about direction. |
+| Organizational pointer — "these tables are projections of this master table" | `ordering`. About structure, not sequence. |
+| Block asserts the target's conclusion as background, then reasons onward from it | `ordering`. Consuming a result is the opposite of deferring it. |
+| Target listed under "## Rigorous results" / "## Consumers / downstream" | `ordering` — and check the direction; these often run target→source. |
+| A forward-looking word ("below", "later", "we must show") | `ordering` unless the sentence is about *this target's placement*. "Below $n^*$" is a numeric comparison; "we must show" is usually about research, not chapter order. |
+
+Two failure modes survive a verbatim quote, so check both before
+declaring:
+
+- **False locator.** "the functor of the *next subsection*" where the
+  target is 21 sections and ~300 blocks away. The prose defers; it does
+  not defer *this far*, and the edge is a real defect.
+- **Mis-aimed deferral.** The quoted sentence hands off to a *different*
+  block than the edge under review. A deferral pointed elsewhere cannot
+  exempt this one.
+
+Before calling a forward edge spurious, read the block's extracted
+`tbl:…-data` children. Pointer-style blocks ("See Table 3") keep their
+substance there, and a name-and-notation search of the `.md` alone will
+report absence that is not real. Searching for the target's *words* also
+misses a lean on the target's *object* — a source writing
+"the canonical $\tilde w_\lambda$" depends on whatever defines the
+undeformed $w_\lambda$, whether or not it ever says so.
+
 ## Reading the mechanical findings first
 
 Run the script half before adjudicating — it is cheap and it changes


### PR DESCRIPTION
Two skill corrections, both earned by applying the platform to a real paper (274 forward `uses[]` references in `qou`) and measuring where the guidance was wrong.

## 1. `uses-editorial-review` — document when a forward reference is a foreshadow

`foreshadows[]` shipped with a schema contract and no guidance in the skill that governs the relation it exempts. Applying it showed what that costs: 23 first-pass declarations went in and adversarial re-review withdrew **17**.

Every withdrawal came from the same substitution — treating "the block names the later target and cites it" as the bar, where `BlockBase.foreshadows` asks whether the prose *frames the reference as deferred*. In one chapter the citation syntax did not distinguish backward from forward at all: a single sentence cited one target 10 positions back and another 60 forward with identical parentheses. Naming carries no signal about direction there, which is precisely the harm `detangler-no-forward-ref` exists to catch.

The new section states the bar (a first-person hand-off — "we establish this in X", "we work this out separately"), tabulates the five near-misses against it, and names two traps that survive a verbatim quote:

- **false locator** — "the functor of the *next subsection*", 21 sections away
- **mis-aimed deferral** — the quoted sentence hands off to a different block than the edge under review

It also records why a name-and-notation search is not evidence of absence, since that is how the same review nearly deleted live edges: pointer-style blocks keep their substance in extracted `tbl:…-data` children, and searching for a target's *words* misses a lean on the target's *object*.

## 2. `detangler-integration-watcher` — a block reorder is not a mechanical fix

The skill listed **"intra-section swap" among the fixes the watcher may auto-discharge**. Running it says otherwise: an unconstrained search cleared 66 of 236 forward references, and narrative review found **18 of its 53 moves made the paper worse**. Reducing the metric and improving the reading are different objectives, and they diverge far too often for the difference to be a rounding error.

The description now routes reorderings through review instead of discharging them, and a new section gives the constraints to apply first. Each exists because a specific move broke something:

| constraint | prevents |
|---|---|
| section openers + `meta.position: "opening"` pinned | a block above the framing prose it presupposes |
| no block precedes one it `interprets` | splitting a pair whose slugs share no prefix |
| prose forward refs may not rise — links **and** backticked `kind:slug` | stranding a block from a dependency `uses[]` never declared |
| families atomic; already-detached children pinned | a proposition separated from its proof |
| comments never move | a note re-attaching to a block it was not written about |

Prose references are recorded as a **guard, not an objective** — minimising them would be authoring `uses[]` by inference, the failure the `uses` axis exists to prevent.

The section also names what no constraint can see, because it is the reason to escalate rather than a gap to close: intros that narrate a sequence, bare anaphora, definite articles pointing at a definition above, a block closing by announcing the next, and blocks that self-label "(forward reference)". Guidance is **propose, review, then apply** — never apply and then review — and record each veto with its reason per block, since those reasons live in the prose and rediscovering them costs a full reading. Expect the reviewed yield near a third of what the raw metric promises, and prefer it.

## Checks

Generated instruction docs regenerated; `gen-schema-docs --check` and `gen-skill-docs --check` both clean; 586 tests pass, 0 fail; lint clean. `origin/main` merged in.

---
_Generated by [Claude Code](https://claude.ai/code/session_016hQePZH4xA7gxL5eLTP5av)_