### PR TITLE
detangler: a ] inside a manifest comment hid 45 blocks from the checker

### DIFF
--- a/.beans/folio-assistant-mcp1--manifest-comment-parse-bug-hid-45-blocks.md
+++ b/.beans/folio-assistant-mcp1--manifest-comment-parse-bug-hid-45-blocks.md
@@ -1,0 +1,37 @@
+---
+# folio-assistant-mcp1
+title: A ] inside a manifest comment hid 45 blocks from the detangler
+status: completed
+type: bug
+created_at: 2026-08-10T01:30:00Z
+updated_at: 2026-08-10T01:40:00Z
+---
+
+Branch `claude/manifest-comment-parse-bug-2026-08-10`, PR #99.
+
+`loadChapterGraph` read chapter manifests with a non-greedy
+`blocks: \[([\s\S]*?)\]`, which stops at the first `]` — including one inside a
+comment. In the qou paper a note reading "…and it has `uses: []` today" sat
+mid-array and every block below it vanished from `blockPos`: **45 of 3498
+blocks, across 7 of 19 chapters**.
+
+Not a miscount — a silent exemption. `checkDetanglerNoForwardRef` returns `pass`
+when a block has no position (`myPos === undefined` reads as "not listed"), and
+edges pointing at an unpositioned block are skipped too. The criterion reported
+clean on material it had never looked at.
+
+The reverse direction is worse: a slug quoted inside a comment counted as a real
+entry, inventing a block *and* advancing `within`, shifting every later position
+in the chapter by one.
+
+Fixed by stripping `//` comments before matching, quote-aware so a `"https://…"`
+in a title survives. 8 tests.
+
+**This is an instance of `fsl7`** ("repoint remaining hand-rolled block scanners
+at the module loader — still scanning source text"). The general fix is to stop
+regex-scanning manifests and import them; this bug is what the source-text scan
+costs in practice, and is worth citing there as motivation.
+
+**Consequence for the qou forward-reference work:** every ordering figure in
+#4889 / #4890 was measured with the broken parser and is understated. The paper
+reads 192 old / **195** fixed. Re-baseline once this lands — one re-run.

--- a/content/pipeline/qa-checkers-extended.ts
+++ b/content/pipeline/qa-checkers-extended.ts
@@ -1586,6 +1586,57 @@ let _graphLoaded = false;
 const CHAPTER_POS_STRIDE = 1_000_000;
 const withinChapter = (pos: number): number => pos % CHAPTER_POS_STRIDE;
 
+/**
+ * Drop `//` line comments from a manifest before its `blocks: [...]` arrays
+ * are matched.
+ *
+ * The arrays are read with a non-greedy `\[([\s\S]*?)\]`, which stops at the
+ * first `]` — including one inside a comment. In a real paper a comment
+ * reading "…and it has `uses: []` …" truncated its section's array, and every
+ * block listed after it vanished from `blockPos`: 45 of 3498 blocks corpus-wide,
+ * across 7 chapters. A block with no position is silently exempt from
+ * `detangler-no-forward-ref` (`myPos === undefined` returns `pass`), and edges
+ * *pointing at* it are skipped too, so the checker reported clean on material it
+ * had never looked at.
+ *
+ * The reverse also bit: a slug quoted inside a comment was counted as a real
+ * entry, which both invented a block and advanced `within`, shifting every
+ * later position in the chapter by one and corrupting every distance measured
+ * from it.
+ *
+ * Quote-aware rather than a blunt `//.*$`, so a `"https://…"` inside a title
+ * survives.
+ */
+export function stripLineComments(src: string): string {
+  let out = "";
+  let quote: string | null = null;
+  for (let i = 0; i < src.length; i++) {
+    const c = src[i];
+    if (quote) {
+      out += c;
+      if (c === "\\") {
+        out += src[++i] ?? "";
+        continue;
+      }
+      if (c === quote) quote = null;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === "`") {
+      quote = c;
+      out += c;
+      continue;
+    }
+    if (c === "/" && src[i + 1] === "/") {
+      // Keep the newline so line-oriented structure is unchanged.
+      while (i < src.length && src[i] !== "\n") i++;
+      out += "\n";
+      continue;
+    }
+    out += c;
+  }
+  return out;
+}
+
 function loadChapterGraph(): void {
   if (_graphLoaded) return;
 
@@ -1666,7 +1717,7 @@ function loadChapterGraph(): void {
       const ci = firstIdx + i;
       const manifestPath = join(base, dir, `${dir}.ts`);
       if (!existsSync(manifestPath)) return;
-      const mc = readFileSync(manifestPath, "utf-8");
+      const mc = stripLineComments(readFileSync(manifestPath, "utf-8"));
       let within = 0;
       let sectionIdx = 0;
       for (const bm of mc.matchAll(/blocks\s*:\s*\[([\s\S]*?)\]/g)) {

--- a/scripts/tests/manifest-comment-parse.test.ts
+++ b/scripts/tests/manifest-comment-parse.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import { stripLineComments } from "../../content/pipeline/qa-checkers-extended";
+
+/**
+ * Chapter manifests are read with a non-greedy `blocks: \[([\s\S]*?)\]`, so a
+ * `]` anywhere inside a comment ends the array early and every block after it
+ * disappears from the position map. A block with no position is silently exempt
+ * from `detangler-no-forward-ref`, and edges pointing at it are skipped — the
+ * checker reports clean on material it never looked at.
+ *
+ * These pin the stripping that has to happen first.
+ */
+const blocksOf = (src: string) =>
+  [...stripLineComments(src).matchAll(/blocks\s*:\s*\[([\s\S]*?)\]/g)].flatMap((m) =>
+    [...m[1].matchAll(/"([^"]+)"/g)].map((x) => x[1]),
+  );
+
+describe("stripLineComments", () => {
+  test("a ] inside a comment no longer truncates the array", () => {
+    // The real case: a note mentioning `uses: []` sat mid-array in mass-theory
+    // and hid every block below it.
+    const src = `blocks: [
+      "alpha",
+      // four consumers are the EW blocks there, and it has \`uses: []\` today
+      "beta",
+      "gamma",
+    ],`;
+    expect(blocksOf(src)).toEqual(["alpha", "beta", "gamma"]);
+  });
+
+  test("a slug quoted inside a comment is not counted as a block", () => {
+    // This one is worse than a miscount: the phantom entry also advanced the
+    // position counter, shifting every later block in the chapter by one.
+    const src = `blocks: [
+      "alpha",
+      // "ghost" was relocated to another chapter in July
+      "beta",
+    ],`;
+    expect(blocksOf(src)).toEqual(["alpha", "beta"]);
+  });
+
+  test("a // inside a string is left alone", () => {
+    const src = `title: "See https://example.com/docs", blocks: ["alpha"],`;
+    expect(stripLineComments(src)).toContain("https://example.com/docs");
+    expect(blocksOf(src)).toEqual(["alpha"]);
+  });
+
+  test("handles all three quote characters", () => {
+    const src = `a: 'http://x/y', b: \`http://z/w\`, c: "http://p/q",`;
+    expect(stripLineComments(src)).toBe(src);
+  });
+
+  test("an escaped quote does not end the string early", () => {
+    const src = `title: "a \\" b // not a comment", blocks: ["alpha"],`;
+    expect(stripLineComments(src)).toContain("// not a comment");
+    expect(blocksOf(src)).toEqual(["alpha"]);
+  });
+
+  test("line structure is preserved so line-oriented parses still line up", () => {
+    const src = `one\n// two\nthree\n`;
+    expect(stripLineComments(src).split("\n").length).toBe(src.split("\n").length);
+  });
+
+  test("a comment at end of file without a trailing newline is dropped", () => {
+    expect(stripLineComments(`"alpha", // trailing`).trim()).toBe(`"alpha",`);
+  });
+
+  test("source with no comments is returned unchanged", () => {
+    const src = `blocks: [\n  "alpha",\n  "beta",\n],\n`;
+    expect(stripLineComments(src)).toBe(src);
+  });
+});


### PR DESCRIPTION
Chapter manifests are read with a non-greedy `blocks: \[([\s\S]*?)\]`, which stops at the **first `]` — including one inside a comment**.

In the qou paper a note reading ``…and it has `uses: []` today`` sits mid-array, and every block listed below it vanished from `blockPos`. **45 of 3498 blocks, across 7 of 19 chapters.**

## Why this is a silent exemption, not a miscount

`checkDetanglerNoForwardRef` returns `pass` when a block has no position — `myPos === undefined` reads as "not listed in the manifest" — and edges *pointing at* an unpositioned block are skipped too. So the criterion reported clean on material it had never looked at, and nothing downstream could distinguish "checked and fine" from "never checked".

**The reverse direction is worse.** A slug quoted inside a comment — `// "ghost" was relocated in July` — was counted as a real entry. That both invents a block *and* advances `within`, shifting every later position in the chapter by one. Distances measured from it are wrong even where nothing is missing.

## The fix

Strip `//` comments before the arrays are matched. The stripper is **quote-aware** rather than a blunt `//.*$`, because a manifest title may legitimately contain `"https://…"` — the corpus has none today, but a regex that would eat one is a trap for whoever adds the first.

## Impact, measured

Forward references on qou read **192 with the old parser and 195 with this one** — three real findings were hidden behind the truncation.

Every ordering number computed before this fix is understated by an unknown few, including the ones in the recent forward-reference work (#4889, #4890). The direction and magnitude of that work stand; the absolute figures want re-baselining once this lands, which is a single re-run.

## Checks

8 new tests pin the behaviour, including both shapes actually found in the corpus (a `]` in a comment; a slug in a comment) and the URL case that motivates quote-awareness. **640 tests pass, 0 fail. Lint clean.**

---
_Generated by [Claude Code](https://claude.ai/code/session_016hQePZH4xA7gxL5eLTP5av)_