### PR TITLE
AGENTS.md: say which bean you are on, at the start and end of every turn

### DIFF
--- a/.beans/folio-assistant-rpt1--report-beans-at-the-top-and-bottom-of-every-turn.md
+++ b/.beans/folio-assistant-rpt1--report-beans-at-the-top-and-bottom-of-every-turn.md
@@ -1,0 +1,31 @@
+---
+# folio-assistant-rpt1
+title: Report beans at the top and bottom of every turn
+status: in-progress
+type: task
+created_at: 2026-08-10T02:00:00Z
+updated_at: 2026-08-10T02:00:00Z
+---
+
+Branch `claude/bean-reporting-directive-2026-08-10`.
+
+`.beans/` is the committed work-plan, but nothing made an agent *say* what it was
+working on. In practice that meant durable work happened without a bean at all —
+a manifest-parser bug (`mcp1`) was found, fixed, tested and merged before anyone
+noticed it had never been claimed, which is precisely what "claim before you
+work" exists to prevent.
+
+Two announcements, both required, because they answer different questions:
+
+- **On starting** — the first line of the turn where work on a bean begins:
+  which bean, and what is being attempted. This is what a sibling session needs
+  in order not to collide, and it is the moment the claim is cheap.
+- **At the end of every turn** — which beans were worked and what is next, each
+  with enough context to be actionable without opening the file.
+
+The synopsis budget is 50 words, not a headline. A bean name plus five words
+tells a reader nothing they could act on; the useful part is *why* it is next
+and what would change if it were not.
+
+Goes in `AGENTS.md` (agent-generic, read natively by every tool) rather than a
+skill, since it applies to every turn regardless of what is being worked on.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,38 @@ beans <id> --status in-progress          # claim an item (durable, visible to si
 - **Move wiring and script together:** when relocating a hook-backed script or a
   queue, repoint every reference (docs, hooks, readers) in the same change.
 
+### Say which bean you are on — every turn
+
+Claiming a bean records the work; **reporting** it is what lets a human steer and
+a sibling session avoid you. Both are required.
+
+**When you begin work on a bean**, open that turn by naming it and what you are
+attempting — before the first tool call, not after the work lands:
+
+> **Starting `fwr7`** — retargeting the seven edges the forward-ref arc left
+> alone, because the edge is wrong rather than the block's position.
+
+**End every turn** with the beans you touched and what is next. One line each,
+**up to 50 words** — enough that a reader can act without opening the file:
+
+> **Beans**
+> - **worked** `fwr8` — Re-baselined both endpoints with the fixed parser: the
+>   arc is 274 → 195, not 274 → 192. Corrected my own claim that the start was
+>   understated; only post-mid-arc figures are short by 3.
+> - **next** `fwr7` — Retarget seven mis-aimed edges. Two are now confirmed
+>   detangler findings rather than reader reports, which raises their priority.
+
+Rules that make the report worth reading:
+
+- **A name and five words is not a synopsis.** Say what changed, or why the next
+  item is next. "Retarget seven edges" is a title; "two are now confirmed
+  findings, which raises their priority" is a reason.
+- **"Next" is your judgement, not a fact.** Beans carry no priority order beyond
+  what an agent asserts — so say why, and expect to be overruled.
+- **Prefix across repos** (`qou/fwr7`, `fa/fsl7`) when a turn spans both.
+- **Report unclaimed work as unclaimed.** If you did durable work without a bean,
+  say so and open one; that omission is the failure this exists to catch.
+
 Full discipline: `.claude/skills/local/todo-manager.md` and
 `.claude/skills/local/bean-coordination.md`.
 


### PR DESCRIPTION
The work-plan already required **claiming** a bean before durable work. Nothing required an agent to **say** so — and the gap showed. A manifest-parser bug (`mcp1`) was found, fixed, tested and merged before anyone noticed it had never been claimed at all. That's exactly what "claim before you work" exists to prevent, and it failed silently.

## Two announcements, because they answer different questions

**On starting** — the first line of the turn where work on a bean begins, before the first tool call:

> **Starting `fwr7`** — retargeting the seven edges the forward-ref arc left alone, because the edge is wrong rather than the block's position.

That's what a sibling session needs in order not to collide, and it's the moment the claim is cheap.

**At the end of every turn** — beans worked and what's next, one line each, **up to 50 words**:

> - **worked** `fwr8` — Re-baselined both endpoints with the fixed parser: the arc is 274 → 195, not 274 → 192. Corrected my own claim that the start was understated; only post-mid-arc figures are short by 3.
> - **next** `fwr7` — Retarget seven mis-aimed edges. Two are now confirmed detangler findings rather than reader reports, which raises their priority.

## Why 50 words and not a headline

A name plus five words is a *title*, not something anyone can act on. The useful content is what changed, or why the next item is next.

Three further rules keep it honest:

- **"Next" is a judgement, not a fact.** Beans carry no priority order beyond what an agent asserts, so say why and expect to be overruled.
- **Prefix across repos** (`qou/fwr7`, `fa/fsl7`) when a turn spans both.
- **Report unclaimed work as unclaimed.** That omission is the failure this exists to catch, so concealing it defeats the point.

Lives in `AGENTS.md` rather than a skill because it applies to every turn regardless of what's being worked on. The qou-side mirror is on the matching branch there.

## Checks

640 tests pass, lint clean, generated docs in sync.

---
_Generated by [Claude Code](https://claude.ai/code/session_016hQePZH4xA7gxL5eLTP5av)_