### PR TITLE
prepare-merge: stop naming a Lean CI workflow that no longer exists

### DIFF
--- a/.beans/folio-assistant-pmci--prepare-merge-named-a-workflow-that-does-not-exist.md
+++ b/.beans/folio-assistant-pmci--prepare-merge-named-a-workflow-that-does-not-exist.md
@@ -1,0 +1,40 @@
+---
+# folio-assistant-pmci
+title: prepare-merge named a Lean CI workflow that no longer exists
+status: completed
+type: bug
+created_at: 2026-08-10T03:55:00Z
+updated_at: 2026-08-10T03:55:00Z
+---
+
+Branch `claude/prepare-merge-stale-lean-ci-2026-08-10`.
+
+The `prepare-merge` gate told agents to dispatch qou's `lean_ci.yml`. That file
+was deleted in qou's workflows migration ("Finalize GitHub workflows migration
+and Phase 4 cleanup"), so the gate named a workflow that does not exist.
+
+**Found by following it.** Running prepare-merge this session, I looked for
+`lean_ci.yml`, found nothing by that name, guessed `build.yml`, and dispatched
+that — it is a *publish* workflow, not a Lean build. Guessing a workflow name is
+how this gate gets skipped while appearing to have run.
+
+Two facts the gate should have carried and did not:
+
+- **Every workflow in qou is `workflow_dispatch`-only**, by an owner directive
+  of 2026-06-30 over Actions billing. Nothing runs on push or PR, so "CI is
+  green" is never true by default — only ever true because someone dispatched
+  it. The gate's own cautionary tale (Lean CI last ran 2026-04-25, 37 modules
+  silently stopped compiling) is the *expected* state of a dispatch-only repo,
+  not a freak occurrence.
+- **Several workflows document a local equivalent in their own header** —
+  `bun run content/pipeline/lean-orphan-audit.ts --diff <changed .lean>`,
+  `python3 scripts/probe-float64-guard.py --diff <changed .py>`. An agent that
+  cannot dispatch (403 without `actions: write`, which is what I hit) can still
+  run the check.
+
+Fixed in both `.claude/skills/local/prepare-merge.md` and
+`.claude/commands/prepare-merge.md`: find the workflow by reading
+`.github/workflows/`, never by name; the real names as of today; the
+dispatch-only fact; and the local equivalents.
+
+Names in a skill rot silently, and this one rotted into an instruction to guess.

--- a/.claude/commands/prepare-merge.md
+++ b/.claude/commands/prepare-merge.md
@@ -70,10 +70,25 @@ Prefer the MCP tools (structured findings) when connected; otherwise the scripts
   If dispatch is refused (no `actions: write`), say so in the PR with the
   command a maintainer should run, rather than leaving it unmentioned.
 
-  *Why this is a gate and not a nicety:* qou's `lean_ci.yml` last ran
-  2026-04-25 and failed. Nothing dispatched it for ~4 months, and 37 modules
-  silently stopped compiling — including files with plain parse errors that
-  had never compiled at all. A workflow nobody runs is not a safety net.
+  **Find the workflow by reading `.github/workflows/`, not by name.** The
+  example this gate used to name — qou's `lean_ci.yml` — was deleted in that
+  repo's workflows migration. An agent following the old text went looking,
+  found nothing, and guessed `build.yml`, which is a *publish* workflow.
+  Guessing is how this gate gets skipped while appearing to run.
+
+  In qou today the Lean-adjacent gates are `lean-orphan-gate.yml`,
+  `lean-content-siblings.yml` and `probe-float64-gate.yml` — and **every
+  workflow in that repo is `workflow_dispatch`-only**, by an owner directive
+  of 2026-06-30 over Actions billing. Nothing runs on push or PR, so "CI is
+  green" is never true by default. Several of those files document a **local
+  equivalent in their own header** (`lean-orphan-audit.ts --diff`,
+  `probe-float64-guard.py --diff`); run those — same check, no dispatch.
+
+  *Why this is a gate and not a nicety:* qou's Lean CI last ran 2026-04-25 and
+  failed. Nothing dispatched it for ~4 months, and 37 modules silently stopped
+  compiling — including files with plain parse errors that had never compiled
+  at all. A workflow nobody runs is not a safety net, and in a dispatch-only
+  repo that is the default state rather than the exception.
 
 **`contentType: who-smart-dak` (L2):**
 - BPMN/DMN well-formedness; data-dictionary + value-set validation

--- a/.claude/skills/local/prepare-merge.md
+++ b/.claude/skills/local/prepare-merge.md
@@ -84,13 +84,34 @@ the one recipe.
    skip it: state in the PR that CI was not run, and give the exact command a
    maintainer should run.
 
-   *Why this is a step and not advice:* qou's `lean_ci.yml` last ran
-   2026-04-25 and failed on `main`. Nothing dispatched it for four months,
-   and 37 modules silently stopped compiling — several with plain parse
-   errors, i.e. files that had never compiled at all. The regression was
-   invisible precisely because a workflow existed and no one ran it. Check
-   when CI last ran (`actions_list` → `list_workflow_runs`) as part of this
-   step; "there is a workflow" is not evidence anything is being checked.
+   **Find the workflow by reading `.github/workflows/`, not by name.** The
+   example this step used to give — qou's `lean_ci.yml` — was deleted in that
+   repo's workflows migration, and an agent following the old text went
+   looking for it, found nothing, and guessed `build.yml`, which is a
+   *publish* workflow. Guessing a workflow name is how this gate gets skipped
+   while appearing to run.
+
+   In qou today the Lean-adjacent gates are `lean-orphan-gate.yml`,
+   `lean-content-siblings.yml` and `probe-float64-gate.yml`. **All of them,
+   and every other workflow in that repo, are `workflow_dispatch`-only** — an
+   owner directive of 2026-06-30 disabled auto-triggers over Actions billing.
+   So nothing runs on push or PR, and "CI is green" is never true by default;
+   it is only ever true because someone dispatched it.
+
+   Several of those files document a **local equivalent in their own header**
+   — e.g. `bun run content/pipeline/lean-orphan-audit.ts --diff <changed .lean>`
+   and `python3 scripts/probe-float64-guard.py --diff <changed .py>`. Run
+   those; they are the same check without the dispatch. Read the workflow
+   before assuming there is no local path.
+
+   *Why this is a step and not advice:* qou's Lean CI last ran 2026-04-25 and
+   failed on `main`. Nothing dispatched it for four months, and 37 modules
+   silently stopped compiling — several with plain parse errors, i.e. files
+   that had never compiled at all. The regression was invisible precisely
+   because a workflow existed and no one ran it. Check when CI last ran
+   (`actions_list` → `list_workflow_runs`) as part of this step; "there is a
+   workflow" is not evidence anything is being checked, and in a
+   dispatch-only repo it is evidence of the opposite.
 8. **Stop here** unless a PR / merge was explicitly requested. If a PR *was*
    requested, see below.
 


### PR DESCRIPTION
The `prepare-merge` gate told agents to dispatch qou's **`lean_ci.yml`**. That file was deleted in qou's workflows migration — the gate named a workflow that isn't there.

## Found by following it

Running prepare-merge this session I looked for `lean_ci.yml`, found nothing by that name, guessed `build.yml` and dispatched that. It's a **publish** workflow, not a Lean build.

Guessing a workflow name is how this gate gets skipped *while appearing to have run* — the exact failure it exists to prevent.

## Two facts it should have carried

**Every workflow in qou is `workflow_dispatch`-only**, by an owner directive of 2026-06-30 over Actions billing. Nothing runs on push or PR, so "CI is green" is never true by default — it's only ever true because someone dispatched it.

That reframes the gate's own cautionary tale. "Lean CI last ran 2026-04-25, 37 modules silently stopped compiling" reads as a freak lapse; in a dispatch-only repo it's the **expected** state, and an agent should read it that way.

**Several workflows document a local equivalent in their own header** — `bun run content/pipeline/lean-orphan-audit.ts --diff <changed .lean>`, `python3 scripts/probe-float64-guard.py --diff <changed .py>`. An agent that can't dispatch (403 without `actions: write`, which is what I hit) can still run the check instead of recording the gate as unrun.

## The change

Both `.claude/skills/local/prepare-merge.md` and `.claude/commands/prepare-merge.md` now say: **find the workflow by reading `.github/workflows/`, never by name**; the real names as of today (`lean-orphan-gate.yml`, `lean-content-siblings.yml`, `probe-float64-gate.yml`); the dispatch-only fact; and the local equivalents.

Names in a skill rot silently, and this one had rotted into an instruction to guess.

## Checks

640 tests pass, lint clean, generated docs in sync.

---
_Generated by [Claude Code](https://claude.ai/code/session_016hQePZH4xA7gxL5eLTP5av)_