### PR TITLE
uses-editorial-review: a block's uses[] may be carrying the whole family

### DIFF
--- a/.beans/folio-assistant-uer2--uses-review-family-edges-and-the-two-reader-standard.md
+++ b/.beans/folio-assistant-uer2--uses-review-family-edges-and-the-two-reader-standard.md
@@ -1,0 +1,41 @@
+---
+# folio-assistant-uer2
+title: uses-editorial-review — family-carried edges and the two-reader standard
+status: completed
+type: task
+created_at: 2026-08-10T04:05:00Z
+updated_at: 2026-08-10T04:05:00Z
+---
+
+Branch `claude/uses-review-family-edges-2026-08-10`.
+
+The skill already warned to read a block's extracted `tbl:…-data` children
+before calling an edge spurious. A later pass showed that rule was too narrow in
+one direction and missing a second rule entirely.
+
+**Too narrow: proof children carry edges too, and may be the only carrier.** In
+`qou/fwr7`, `prop:gram-determinant-plancherel-ratio`'s own prose genuinely never
+names `rem:gram-matrix-spectral-connection` — I checked, and reported it as a
+clean deletion. Its **proof child** cites the target by label for the exact
+identity the parent's boxed formula is built from, and that proof declares no
+`uses[]` of its own. The parent's entry was the sole record of the dependency.
+Deleting it would have erased the edge, not tidied it.
+
+So the rule generalises: a block is the head of a family, and the *declaration*
+sits on the parent while the *lean* may sit in any child. Check whether a child
+leans on the target, and whether that child declares anything itself.
+
+**Missing: the standard of evidence.** The skill said nothing about how many
+readings an edge edit needs, and the project's own numbers are stark:
+
+- 274-edge pass, destructive verdicts re-reviewed: 3 of 35 deletions and **17 of
+  23** foreshadows overturned.
+- 8-edge slice, 6 single-reader reports and 2 self-verified: two independent
+  readers returned **keep on all eight**, agreeing row for row, every refutation
+  on positive evidence rather than the tie-break.
+
+Now stated: two readers who cannot see each other's verdicts, for anything that
+edits the graph; agreement is the signal; disagreement or doubt means leave the
+edge. Plus the retarget rule — it asserts two things at once and needs evidence
+for each half, since one retarget in that slice had a true second half and a
+false first, making it an addition rather than a swap.

--- a/docs/reference/skill-instructions/uses-editorial-review.md
+++ b/docs/reference/skill-instructions/uses-editorial-review.md
@@ -119,13 +119,55 @@ declaring:
   block than the edge under review. A deferral pointed elsewhere cannot
   exempt this one.
 
-Before calling a forward edge spurious, read the block's extracted
-`tbl:…-data` children. Pointer-style blocks ("See Table 3") keep their
-substance there, and a name-and-notation search of the `.md` alone will
-report absence that is not real. Searching for the target's *words* also
-misses a lean on the target's *object* — a source writing
-"the canonical $\tilde w_\lambda$" depends on whatever defines the
-undeformed $w_\lambda$, whether or not it ever says so.
+## A block's `uses[]` may be carrying the whole family
+
+**Never judge an entry from the block's own `.md` alone.** A block is the head
+of a family — `X-proof`, `X-interpretation`, `X-tableN-data` — and the
+dependency you are looking for is often in a child while the *declaration* sits
+on the parent.
+
+- **Table children.** Pointer-style blocks ("See Table 3") keep their substance
+  in `tbl:…-data`. A name-and-notation search of the parent's `.md` reports an
+  absence that is not real.
+- **Proof children.** A proof cites what the statement assumes. In one case the
+  parent's prose genuinely never named the target, its **proof child cited the
+  target by label** for the exact identity the parent's boxed formula is built
+  from — and that proof declared no `uses[]` of its own. The parent's entry was
+  the **sole record** of the dependency, so deleting it as "unsupported by the
+  prose" would have erased the edge entirely.
+
+So before removing an entry, check whether any child leans on the target, and
+whether that child declares anything itself. An entry that looks like dead
+weight on the parent may be the family's only declaration.
+
+Searching for the target's *words* also misses a lean on the target's *object*
+— a source writing "the canonical $\tilde w_\lambda$" depends on whatever
+defines the undeformed $w_\lambda$, whether or not it ever says so.
+
+## One reading is not the standard
+
+Adjudicating `uses[]` is not a task where a careful pass suffices, and the
+numbers say so rather than intuition:
+
+- A pass over 274 forward edges had its **destructive verdicts re-reviewed**:
+  3 of 35 deletions and **17 of 23** foreshadow declarations were overturned.
+- A later slice of 8 edges — 6 of them reported by a single earlier reader, 2
+  of those "verified directly against the text" — went to **two independent
+  readers**. Both returned *keep* on **all eight**, agreeing row for row. Every
+  refutation rested on positive evidence, not on a tie-break. Both "verified"
+  ones had been checked by keyword search over the `.md` alone.
+
+Use **two readers who cannot see each other's verdicts** for anything that
+edits the graph, and treat agreement as the signal. Where they disagree, or
+where either is unsure, leave the edge alone: a wrongly deleted editorial edge
+silently corrupts every ordering metric computed from the graph, and nothing
+downstream catches it.
+
+**A retarget carries both burdens.** It asserts this edge is wrong *and* that
+one is right, so it needs evidence for each half separately. In the slice above
+one retarget's second half was true — the proposed target really was leaned on
+and really was missing — while its first half was false. Split, it was not a
+swap but an **addition**, and both edges survived.
 
 ## Reading the mechanical findings first
 

--- a/skills/folio-core/uses-editorial-review.md
+++ b/skills/folio-core/uses-editorial-review.md
@@ -120,13 +120,55 @@ declaring:
   block than the edge under review. A deferral pointed elsewhere cannot
   exempt this one.
 
-Before calling a forward edge spurious, read the block's extracted
-`tbl:…-data` children. Pointer-style blocks ("See Table 3") keep their
-substance there, and a name-and-notation search of the `.md` alone will
-report absence that is not real. Searching for the target's *words* also
-misses a lean on the target's *object* — a source writing
-"the canonical $\tilde w_\lambda$" depends on whatever defines the
-undeformed $w_\lambda$, whether or not it ever says so.
+## A block's `uses[]` may be carrying the whole family
+
+**Never judge an entry from the block's own `.md` alone.** A block is the head
+of a family — `X-proof`, `X-interpretation`, `X-tableN-data` — and the
+dependency you are looking for is often in a child while the *declaration* sits
+on the parent.
+
+- **Table children.** Pointer-style blocks ("See Table 3") keep their substance
+  in `tbl:…-data`. A name-and-notation search of the parent's `.md` reports an
+  absence that is not real.
+- **Proof children.** A proof cites what the statement assumes. In one case the
+  parent's prose genuinely never named the target, its **proof child cited the
+  target by label** for the exact identity the parent's boxed formula is built
+  from — and that proof declared no `uses[]` of its own. The parent's entry was
+  the **sole record** of the dependency, so deleting it as "unsupported by the
+  prose" would have erased the edge entirely.
+
+So before removing an entry, check whether any child leans on the target, and
+whether that child declares anything itself. An entry that looks like dead
+weight on the parent may be the family's only declaration.
+
+Searching for the target's *words* also misses a lean on the target's *object*
+— a source writing "the canonical $\tilde w_\lambda$" depends on whatever
+defines the undeformed $w_\lambda$, whether or not it ever says so.
+
+## One reading is not the standard
+
+Adjudicating `uses[]` is not a task where a careful pass suffices, and the
+numbers say so rather than intuition:
+
+- A pass over 274 forward edges had its **destructive verdicts re-reviewed**:
+  3 of 35 deletions and **17 of 23** foreshadow declarations were overturned.
+- A later slice of 8 edges — 6 of them reported by a single earlier reader, 2
+  of those "verified directly against the text" — went to **two independent
+  readers**. Both returned *keep* on **all eight**, agreeing row for row. Every
+  refutation rested on positive evidence, not on a tie-break. Both "verified"
+  ones had been checked by keyword search over the `.md` alone.
+
+Use **two readers who cannot see each other's verdicts** for anything that
+edits the graph, and treat agreement as the signal. Where they disagree, or
+where either is unsure, leave the edge alone: a wrongly deleted editorial edge
+silently corrupts every ordering metric computed from the graph, and nothing
+downstream catches it.
+
+**A retarget carries both burdens.** It asserts this edge is wrong *and* that
+one is right, so it needs evidence for each half separately. In the slice above
+one retarget's second half was true — the proposed target really was leaned on
+and really was missing — while its first half was false. Split, it was not a
+swap but an **addition**, and both edges survived.
 
 ## Reading the mechanical findings first
 


### PR DESCRIPTION
The skill warned to read a block's extracted `tbl:…-data` children before calling an edge spurious. That rule was **too narrow**, and it was **missing a second rule entirely**.

## Too narrow: proof children carry edges too, and may be the only carrier

`prop:gram-determinant-plancherel-ratio`'s own prose genuinely never names `rem:gram-matrix-spectral-connection`. I checked, and reported it as a clean deletion.

Its **proof child cites the target by label** for the exact identity the parent's boxed formula is built from — and that proof declares **no `uses[]` of its own**. The parent's entry was the *sole record* of the dependency. Deleting it as "unsupported by the prose" would have erased the edge, not tidied it.

So the rule generalises: a block heads a family, the **declaration** sits on the parent, and the **lean** may sit in any child. Before removing an entry, check whether a child leans on the target and whether that child declares anything itself. An entry that looks like dead weight on the parent may be the family's only declaration.

## Missing: the standard of evidence

The skill said nothing about how many readings an edge edit needs. The project's own numbers are stark:

- Over **274 forward edges**, re-reviewing the destructive verdicts overturned **3 of 35 deletions** and **17 of 23 foreshadow declarations**.
- A later slice of **8 edges** — six from a single earlier reader's report, two of them verified by me against the text — went to **two independent readers**. Both returned *keep* on **all eight**, agreeing row for row, every refutation resting on positive evidence rather than the tie-break. Both of the "verified" ones had been checked by keyword search over the `.md` alone.

Now stated: **two readers who cannot see each other's verdicts** for anything that edits the graph; agreement is the signal; disagreement or doubt means leave the edge alone.

## And the retarget rule

A retarget asserts two things at once — this edge is wrong *and* that one is right — so it needs evidence for **each half separately**. One retarget in that slice had a true second half (the proposed target really was leaned on, and really was missing) and a false first. Split, it wasn't a swap but an **addition**, and both edges survived.

## Checks

640 tests pass, lint clean, generated instruction docs regenerated and in sync.

---
_Generated by [Claude Code](https://claude.ai/code/session_016hQePZH4xA7gxL5eLTP5av)_