### PR TITLE
uses-editorial-review: sibling parity stops being evidence after a bulk edit

### DIFF
--- a/.beans/folio-assistant-sib1--sibling-parity-is-not-evidence-after-a-bulk-edit.md
+++ b/.beans/folio-assistant-sib1--sibling-parity-is-not-evidence-after-a-bulk-edit.md
@@ -1,0 +1,32 @@
+---
+# folio-assistant-sib1
+title: sibling parity is not evidence after a bulk edit touched the family
+status: completed
+type: task
+created_at: 2026-08-10T04:45:00Z
+updated_at: 2026-08-10T04:45:00Z
+---
+
+Branch `claude/sibling-parity-caveat-2026-08-10`. Follow-up to `uer2`, from
+`qou/prn1`.
+
+Two independent readers judged a five-member family of millennium-problem bound
+remarks *deliberately* empty, on the grounds that every member names the same
+six blocks in prose and every member declares nothing. Declaring in one would be
+the anomaly. The inference is sound and the conclusion was wrong.
+
+Every member lost 8-10 `uses[]` edges to a single bulk "transitive-prune" commit
+whose rule (*if A→B and B→C, drop A→C*) fired in cases where B→C was being
+dropped in the same pass. Corpus-wide that commit and one other destroyed
+reachability for 856 edges, 785 of which are still unreachable today across 335
+blocks.
+
+The parity was real. It was uniform **damage**, not uniform intent — and a bulk
+operation produces parity by construction, so the heuristic cannot tell the two
+apart.
+
+Now in the skill: check the family's *history* before resting on parity. A
+convention shows up as blocks authored empty; damage shows up as one commit
+emptying all of them on the same day. Generalised at the end, because the same
+trap applies to any argument from "what the corpus does" — a corpus that has been
+swept records the sweep as much as the authors.

--- a/docs/reference/skill-instructions/uses-editorial-review.md
+++ b/docs/reference/skill-instructions/uses-editorial-review.md
@@ -144,6 +144,33 @@ Searching for the target's *words* also misses a lean on the target's *object*
 — a source writing "the canonical $\tilde w_\lambda$" depends on whatever
 defines the undeformed $w_\lambda$, whether or not it ever says so.
 
+## Sibling parity is evidence only until a bulk edit touched the family
+
+"All five siblings declare nothing, so declaring it here would be the anomaly"
+is a good argument, and it is exactly the argument to distrust when a bulk
+operation has run over the corpus.
+
+Two independent readers used it to judge a five-member family of millennium-
+problem bounds *deliberately* empty — each names the same six blocks in prose
+and each declares nothing. The uniformity was real. It was also **uniform
+damage**: every member lost 8-10 edges to a single "transitive-prune" commit
+whose rule (*if A→B and B→C, drop A→C*) fired where B→C was being dropped in the
+same pass. A bulk edit produces parity **by construction**, so parity cannot
+distinguish a shared convention from a shared wound.
+
+Before resting on it, check the **family's history**, not just the block's:
+
+```sh
+git log --oneline -- <chapter>/<sibling>.ts   # for two or three siblings
+```
+
+A convention shows up as blocks that were *authored* empty. Damage shows up as
+one commit emptying all of them on the same day. If the emptiness has a single
+commit behind it, parity tells you nothing about intent.
+
+The same caution applies to any evidence drawn from what "the corpus does":
+a corpus that has been swept is a record of the sweep as much as of the authors.
+
 ## One reading is not the standard
 
 Adjudicating `uses[]` is not a task where a careful pass suffices, and the

--- a/skills/folio-core/uses-editorial-review.md
+++ b/skills/folio-core/uses-editorial-review.md
@@ -145,6 +145,33 @@ Searching for the target's *words* also misses a lean on the target's *object*
 — a source writing "the canonical $\tilde w_\lambda$" depends on whatever
 defines the undeformed $w_\lambda$, whether or not it ever says so.
 
+## Sibling parity is evidence only until a bulk edit touched the family
+
+"All five siblings declare nothing, so declaring it here would be the anomaly"
+is a good argument, and it is exactly the argument to distrust when a bulk
+operation has run over the corpus.
+
+Two independent readers used it to judge a five-member family of millennium-
+problem bounds *deliberately* empty — each names the same six blocks in prose
+and each declares nothing. The uniformity was real. It was also **uniform
+damage**: every member lost 8-10 edges to a single "transitive-prune" commit
+whose rule (*if A→B and B→C, drop A→C*) fired where B→C was being dropped in the
+same pass. A bulk edit produces parity **by construction**, so parity cannot
+distinguish a shared convention from a shared wound.
+
+Before resting on it, check the **family's history**, not just the block's:
+
+```sh
+git log --oneline -- <chapter>/<sibling>.ts   # for two or three siblings
+```
+
+A convention shows up as blocks that were *authored* empty. Damage shows up as
+one commit emptying all of them on the same day. If the emptiness has a single
+commit behind it, parity tells you nothing about intent.
+
+The same caution applies to any evidence drawn from what "the corpus does":
+a corpus that has been swept is a record of the sweep as much as of the authors.
+
 ## One reading is not the standard
 
 Adjudicating `uses[]` is not a task where a careful pass suffices, and the


### PR DESCRIPTION
*"All five siblings declare nothing, so declaring it here would be the anomaly"* is a good argument — and exactly the argument to distrust once a bulk operation has run over the corpus.

## What happened

Two **independent** readers used it to judge a five-member family of millennium-problem bound remarks *deliberately* empty. Each names the same six blocks in prose; each declares nothing. Declaring in one would be the odd one out.

The uniformity was real. It was also **uniform damage**: every member lost 8–10 `uses[]` edges to a single "transitive-prune" commit, whose rule (*if A→B and B→C, drop A→C*) fired in cases where B→C was being dropped in the same pass.

Corpus-wide, that commit and one other destroyed reachability for **856 edges — 785 still unreachable today across 335 blocks** (litlfred/qou#4910).

## Why the heuristic can't survive it

A bulk edit produces parity **by construction**. It cannot distinguish a shared convention from a shared wound, because it created the sharing.

The skill now says to check the **family's history** before resting on it, with the command:

```sh
git log --oneline -- <chapter>/<sibling>.ts
```

A convention shows up as blocks that were *authored* empty. Damage shows up as one commit emptying all of them on the same day. If the emptiness has a single commit behind it, parity tells you nothing about intent.

## Generalised deliberately

The last line widens it, because the trap isn't specific to parity: **any** argument from "what the corpus does" inherits it. A corpus that has been swept is a record of the sweep as much as of the authors — and this project has swept it more than once.

## Checks

640 tests pass, lint clean, generated instruction docs in sync.

---
_Generated by [Claude Code](https://claude.ai/code/session_016hQePZH4xA7gxL5eLTP5av)_