### PR TITLE
beans: guard `beans create` on exact title; gitignore baseline for new folios

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,15 @@ content/audit-tex-source.json
 # directories staged for the next `git add -A`.
 __pycache__/
 *.py[cod]
+
+# Agent scratch state — transient tooling state, never repository content.
+# Same class as .claude/worktrees/ above. A sandbox accumulates these as
+# untracked directories and a `git add -A` sweeps them into an unrelated
+# commit; in the qou folio that mechanism committed 46,155 files under a
+# one-file Lean subject line. Prophylactic here — folio-assistant has none
+# of these today, and should not acquire them.
+.agents/
+amalgamated_done/
+amalgamated_input/
+_deprecated/
+scratch/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,18 @@ beans create "<title>"                   # open a work-plan item
 beans <id> --status in-progress          # claim an item (durable, visible to siblings)
 ```
 
+> **Check before you create (STRICT).** `beans create` is **not** idempotent —
+> it mints a fresh ID on every call and dedupes on nothing, so re-entering a
+> work-plan step duplicates the plan instead of no-op'ing. Before **every**
+> `beans create`, including the session milestone, run the exact-title
+> existence check in [`skills/folio-core/todo-manager.md` §Check before you
+> create](skills/folio-core/todo-manager.md); on a match, claim the existing
+> bean with `beans update <id> --status in-progress` instead. History: in the
+> `qou` folio an unguarded re-run of that step ~980 times on 2026-08-04
+> produced **14,688** duplicate beans — 92 % of every open bean in the repo —
+> which starved the idle-backlog policy of signal, collided with the IDs of 15
+> real beans, and corrupted a later agent's own corpus-grep.
+
 - **Session todos:** track anything you want to persist as beans, not in your
   agent's ephemeral in-memory todo list — `.beans/` is committed, so the plan
   survives a resume in a fresh container.

--- a/docs/guides/writing-a-paper.md
+++ b/docs/guides/writing-a-paper.md
@@ -86,6 +86,41 @@ beans <id> --status in-progress
 The agent creates the block files and a `main.tex`, then confirms with
 `content_list`.
 
+### Required `.gitignore` baseline
+
+Every new folio repository starts with these entries. They are not optional
+polish — agent sandboxes accumulate scratch directories as untracked state, and
+a single `git add -A` then commits all of it under a message describing
+something else. In the `qou` folio that mechanism produced one commit adding
+**46,155 files / 11.4 M insertions** under a one-file Lean subject line,
+including 14,688 duplicate beans.
+
+```gitignore
+# Agent scratch state — transient tooling state, never repository content.
+.agents/
+amalgamated_done/
+amalgamated_input/
+_deprecated/
+scratch/
+.claude/worktrees/
+
+# Python bytecode
+__pycache__/
+*.py[cod]
+```
+
+Two deliberate exclusions:
+
+- **`.beans/` stays tracked.** It is the durable, cross-session work plan; a
+  sibling agent has to be able to read it. Bean *duplication* is prevented by
+  the create-guard in
+  [`skills/folio-core/todo-manager.md`](../../skills/folio-core/todo-manager.md),
+  not by ignoring the directory.
+- **Any directory your folio documents as a real pipeline stays tracked** — in
+  `qou`, `uploads/` is the document-intake stage and belongs in git. Check your
+  own `AGENTS.md` §Project structure before adding a path to this list: if it is
+  documented there, it is content, not scratch.
+
 > **Assistant:** *(creates blocks, calls `content_list`)* Scaffolded 5 blocks
 > under `content/harmonic-series/`. Current artifacts:
 >

--- a/docs/reference/skill-instructions/session-intent.md
+++ b/docs/reference/skill-instructions/session-intent.md
@@ -72,6 +72,14 @@ Three places, all required:
 ```
 
 **b. Beans CLI** — Create a parent session bean and child tasks.
+
+> **Check before you create (STRICT).** `beans create` is not idempotent — it
+> mints a fresh ID every call and dedupes on nothing, so re-entering this step
+> duplicates the whole plan rather than no-op'ing. Run the existence check in
+> [`todo-manager.md` §Check before you create](todo-manager.md) before **every**
+> `beans create` below, the session milestone included. An unguarded re-run of
+> exactly this step produced 14,688 duplicate beans in one folio on 2026-08-04.
+
 - Create a session-level milestone/epic: `beans create "Session: <Branch/Goal>" --type milestone`
 - For each task you pick up, create a child task and link it to the session bean:
   `beans create "<Task>" --type task`

--- a/docs/reference/skill-instructions/todo-manager.md
+++ b/docs/reference/skill-instructions/todo-manager.md
@@ -45,6 +45,47 @@ Note: the npm package named `beans` is an unrelated abandoned tool — do **not*
    `beans create "<Task Title>" --type task`
    `beans update <child-id> --parent <session-id>`
 3. **No manual `.md` checklists:** Never use `session-beans.md` or raw Markdown `- [ ]` checklists to track global tasks. Always use the `beans` CLI to prevent namespace pollution and maintain the official project tracking.
+4. **Check before you create:** `beans create` is **not** idempotent. Run the existence check below before every `beans create` — no exceptions, including the session milestone.
+
+## Check before you create — `beans create` is not idempotent (STRICT)
+
+`beans create` mints a **fresh random ID on every call** and dedupes on
+nothing. Re-running a work-plan step is therefore *not* a no-op — it creates a
+second bean. **Before every `beans create`, check whether the bean exists:**
+
+```bash
+T="Prove Foo.bar"
+beans list --json --search "title:\"$T\"" | python3 -c '
+import json, sys
+t = sys.argv[1]
+m = [b for b in json.load(sys.stdin) if b["title"] == t]
+print(f"{len(m)} exact match(es)")
+[print(" ", b["id"], b["status"]) for b in m]' "$T"
+```
+
+- **≥ 1 match** → do **not** create. Claim the existing bean instead:
+  `beans update <id> --status in-progress --body-append "Claimed by <branch>"`
+- **0 matches** → `beans create "$T" --type task`
+
+`--search` is a fuzzy Bleve query, so the exact-title comparison inside the
+pipe is load-bearing — do not drop it and trust `--search` alone.
+
+**Why this is STRICT.** In the `qou` folio on 2026-08-04, one agent context
+re-ran its 15-bean session work-plan ~980 times back-to-back (median 19 s per
+cycle, ~16 h wall). Because `create` is unconditional, that produced **14,688
+duplicate beans** — 92 % of every open bean in that repo. The damage was not
+just clutter:
+
+- the session-start sweep and the idle-backlog policy were reading mostly noise;
+- ~980 copies of an already-proved item sat at `todo`;
+- the duplicates **collided with the IDs of 15 real beans**, making
+  `beans update <id>` ambiguous for those;
+- they corrupted a later agent's own corpus-grep — 4,928 `.beans` files matched
+  one search term across just 36 titles, inflating 14 real source files into an
+  apparent 54 and nearly landing a false correction in a PR body.
+
+The runaway loop is not something a doc can prevent; an unguarded `create` is.
+This rule is platform-level so every folio inherits it.
 
 ## Working with Beans
 

--- a/skills/folio-core/session-intent.md
+++ b/skills/folio-core/session-intent.md
@@ -69,6 +69,14 @@ Three places, all required:
 ```
 
 **b. Beans CLI** — Create a parent session bean and child tasks.
+
+> **Check before you create (STRICT).** `beans create` is not idempotent — it
+> mints a fresh ID every call and dedupes on nothing, so re-entering this step
+> duplicates the whole plan rather than no-op'ing. Run the existence check in
+> [`todo-manager.md` §Check before you create](todo-manager.md) before **every**
+> `beans create` below, the session milestone included. An unguarded re-run of
+> exactly this step produced 14,688 duplicate beans in one folio on 2026-08-04.
+
 - Create a session-level milestone/epic: `beans create "Session: <Branch/Goal>" --type milestone`
 - For each task you pick up, create a child task and link it to the session bean:
   `beans create "<Task>" --type task`

--- a/skills/folio-core/todo-manager.md
+++ b/skills/folio-core/todo-manager.md
@@ -45,6 +45,47 @@ Note: the npm package named `beans` is an unrelated abandoned tool — do **not*
    `beans create "<Task Title>" --type task`
    `beans update <child-id> --parent <session-id>`
 3. **No manual `.md` checklists:** Never use `session-beans.md` or raw Markdown `- [ ]` checklists to track global tasks. Always use the `beans` CLI to prevent namespace pollution and maintain the official project tracking.
+4. **Check before you create:** `beans create` is **not** idempotent. Run the existence check below before every `beans create` — no exceptions, including the session milestone.
+
+## Check before you create — `beans create` is not idempotent (STRICT)
+
+`beans create` mints a **fresh random ID on every call** and dedupes on
+nothing. Re-running a work-plan step is therefore *not* a no-op — it creates a
+second bean. **Before every `beans create`, check whether the bean exists:**
+
+```bash
+T="Prove Foo.bar"
+beans list --json --search "title:\"$T\"" | python3 -c '
+import json, sys
+t = sys.argv[1]
+m = [b for b in json.load(sys.stdin) if b["title"] == t]
+print(f"{len(m)} exact match(es)")
+[print(" ", b["id"], b["status"]) for b in m]' "$T"
+```
+
+- **≥ 1 match** → do **not** create. Claim the existing bean instead:
+  `beans update <id> --status in-progress --body-append "Claimed by <branch>"`
+- **0 matches** → `beans create "$T" --type task`
+
+`--search` is a fuzzy Bleve query, so the exact-title comparison inside the
+pipe is load-bearing — do not drop it and trust `--search` alone.
+
+**Why this is STRICT.** In the `qou` folio on 2026-08-04, one agent context
+re-ran its 15-bean session work-plan ~980 times back-to-back (median 19 s per
+cycle, ~16 h wall). Because `create` is unconditional, that produced **14,688
+duplicate beans** — 92 % of every open bean in that repo. The damage was not
+just clutter:
+
+- the session-start sweep and the idle-backlog policy were reading mostly noise;
+- ~980 copies of an already-proved item sat at `todo`;
+- the duplicates **collided with the IDs of 15 real beans**, making
+  `beans update <id>` ambiguous for those;
+- they corrupted a later agent's own corpus-grep — 4,928 `.beans` files matched
+  one search term across just 36 titles, inflating 14 real source files into an
+  apparent 54 and nearly landing a false correction in a PR body.
+
+The runaway loop is not something a doc can prevent; an unguarded `create` is.
+This rule is platform-level so every folio inherits it.
 
 ## Working with Beans
 


### PR DESCRIPTION
Platform-level half of a fix for a failure that hit the `qou` folio, so every folio inherits it. Companion: litlfred/qou#4914 (which also carries the cleanup).

## The failure

`beans create` mints a fresh random ID on every call and dedupes on nothing, and no instruction in `AGENTS.md`, `skills/folio-core/todo-manager.md`, or `session-intent.md` told an agent to look before creating.

On 2026-08-04 one agent context in `qou` re-ran its 15-bean session work-plan **~980 times back-to-back** — a strict 15-title cycle in fixed order, ~1.3 s per bean (Go-binary startup), median 19 s per cycle, ~6 h active over a 16 h span. Result: **14,688 duplicate beans**, 92 % of every open bean in that repo.

The loop was the trigger. The unguarded `create` is the cause, and it is the part a doc can fix.

Damage beyond clutter, all measured in `qou`:

- the session-start sweep and the idle-backlog policy were reading almost pure noise;
- ~980 copies of an already-proved item sat at `todo`;
- the duplicates **collided with the IDs of 15 real beans**, making `beans update <id>` ambiguous for those;
- they corrupted a later agent's own corpus-grep — 4,928 `.beans` files matched one search term across just 36 titles, inflating 14 real source files into an apparent 54, and nearly landing a false correction in a PR body.

## What changed

**The create-guard (STRICT)** — an exact-title existence check before every `beans create`, session milestone included, added to:

- [`AGENTS.md`](../blob/claude/bean-create-guard-2026-08-10/AGENTS.md) §"Work-plan & todos"
- [`skills/folio-core/todo-manager.md`](../blob/claude/bean-create-guard-2026-08-10/skills/folio-core/todo-manager.md) — canonical form + the incident record
- [`skills/folio-core/session-intent.md`](../blob/claude/bean-create-guard-2026-08-10/skills/folio-core/session-intent.md) — at the step that actually creates them

`beans list --search` is a fuzzy Bleve query, so the exact-title comparison in the pipe is load-bearing; the docs say so rather than leaving a reader to trust `--search` alone.

**The `.gitignore` baseline** — the duplicates reached git because `git add -A` in a sandbox swept its untracked scratch state into a commit whose subject described a one-file Lean change (46,155 files / 11.4 M insertions). Added to [`.gitignore`](../blob/claude/bean-create-guard-2026-08-10/.gitignore) prophylactically — folio-assistant has none of these dirs today and should not acquire them — and documented as a required step of [`docs/guides/writing-a-paper.md` §"Step 2 — Scaffold the repository"](../blob/claude/bean-create-guard-2026-08-10/docs/guides/writing-a-paper.md), which is the answer to *"make sure it persists on new folios"*: a new folio now starts with the baseline instead of acquiring the problem and fixing it later.

Two deliberate non-ignores, both stated in the guide:

- **`.beans/` stays tracked** — it is the durable cross-session work plan a sibling agent has to read. Duplication is the guard's job, not the ignore file's.
- **Any path a folio's own `AGENTS.md` documents as a pipeline stays tracked** — in `qou` that is `uploads/` (document intake). The guide tells the reader to check their own §Project structure before adding a path, which is exactly the check that kept `uploads/` out of the list.

## Verification

Docs and `.gitignore` only — no `src/`, `schemas/`, or adapter code touched, so no build or test surface changes.

- Guard command tested against a live `.beans/` (3,073 beans): exact-title hit returns the one bean and its status; a nonexistent title returns 0.
- `beans check` on that repo: 13 issues before the cleanup, 13 after — no regression.
- Ignore rules confirmed to bite for new paths via `git check-ignore -v`.

---
_Generated by [Claude Code](https://claude.ai/code/session_014EXphXvdtvwX2QHxWy6mr5)_