### PR TITLE
fix(gitignore): anchor the agent-scratch patterns, here and in the new-folio baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,16 @@ __pycache__/
 # commit; in the qou folio that mechanism committed 46,155 files under a
 # one-file Lean subject line. Prophylactic here — folio-assistant has none
 # of these today, and should not acquire them.
-.agents/
-amalgamated_done/
-amalgamated_input/
-_deprecated/
-scratch/
+#
+# ANCHORED with a leading slash — root-level only. A gitignore pattern with no
+# internal slash matches at EVERY depth, so the unanchored form these entries
+# originally had reaches into nested directories that share a name. In the qou
+# folio that captured two documented archives — `computations/_deprecated/`
+# (1,449 tracked files, including `script-qa/*.script-qa.json` QA sidecars) and
+# `docs/audits/_deprecated/` (66) — where any NEW file would then be skipped by
+# `git add` with no error. Keep the leading slash on every entry.
+/.agents/
+/amalgamated_done/
+/amalgamated_input/
+/_deprecated/
+/scratch/

--- a/docs/guides/writing-a-paper.md
+++ b/docs/guides/writing-a-paper.md
@@ -97,17 +97,29 @@ including 14,688 duplicate beans.
 
 ```gitignore
 # Agent scratch state — transient tooling state, never repository content.
-.agents/
-amalgamated_done/
-amalgamated_input/
-_deprecated/
-scratch/
+# Leading slash = root-level only. Keep it (see the warning below).
+/.agents/
+/amalgamated_done/
+/amalgamated_input/
+/_deprecated/
+/scratch/
 .claude/worktrees/
 
 # Python bytecode
 __pycache__/
 *.py[cod]
 ```
+
+**Keep the leading slashes.** A gitignore pattern containing no internal slash
+matches at *every* directory depth, not just the root. Written unanchored, the
+`_deprecated/` line above silently captured two documented archives in the `qou`
+folio — `computations/_deprecated/` (1,449 tracked files, including
+`script-qa/*.script-qa.json` QA sidecars) and `docs/audits/_deprecated/` (66) —
+and `scratch/` reached every `content/**/scratch/`. Already-tracked files were
+unaffected, because an ignore rule never untracks; the hazard is that any *new*
+file under such a path is skipped by `git add` with no error and no output. If
+your folio keeps a nested archive or scratch area under one of these names, the
+anchored form is what keeps it committable.
 
 Two deliberate exclusions:
 


### PR DESCRIPTION
Fixes a bug I shipped in #106. Companion: litlfred/qou#4922.

## The defect

A gitignore pattern containing **no internal slash matches at every directory depth**, not just the root. The five entries #106 added in `a43c18d6` were unanchored, so `_deprecated/` and `scratch/` reach into any nested directory sharing those names.

**folio-assistant itself is unaffected** — it has zero tracked files under any of those five names at any depth, which I verified rather than assumed.

The real defect was in the **documented baseline**. `docs/guides/writing-a-paper.md` §"Step 2 — Scaffold the repository" told every new folio to copy the unanchored form. In a folio that keeps a nested archive under one of those names, that silently captures it — and that is not hypothetical. In `qou`:

| path | tracked files | what it is |
|---|---|---|
| `computations/_deprecated/` | **1,449** | documented retirement area with its own `README.md`, witnesses, and `script-qa/*.script-qa.json` QA sidecars |
| `docs/audits/_deprecated/` | **66** | retired audit docs |

Already-tracked files were never at risk, because an ignore rule never untracks. The hazard is forward-looking and silent: any **new** file under such a path is skipped by `git add` with no error and no output — a new QA sidecar would simply never be committed. That is the same silent-loss shape the block was written to prevent, so shipping it as the recommended baseline was the part worth fixing fastest.

## The fix

- `.gitignore` — all five entries anchored to `/...`, with a comment explaining why the slash is load-bearing.
- `docs/guides/writing-a-paper.md` — the baseline now shows the anchored form, plus a **Keep the leading slashes** note giving the mechanism, the concrete `qou` damage, the reason already-tracked files look fine, and when a folio will actually need the anchoring.

## Verification

`git check-ignore --no-index`, both directions:

- **ignored:** `.agents/x`, `_deprecated/x`, `scratch/x`
- **not ignored:** `computations/_deprecated/x.py`, `docs/audits/_deprecated/n.md`, `content/p/scratch/n.md`

`bun run scripts/gen-skill-docs.ts --check` → *generated docs are up to date*. No `skills/**` body changed here, so no regeneration was needed — noting it because a stale generated mirror is exactly what failed CI on #106's first push.

Docs and `.gitignore` only; no `src/`, `schemas/`, or adapter code touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_014EXphXvdtvwX2QHxWy6mr5)_