### PR TITLE
foreshadows[] is independent of uses[] — one field for both kinds of forward reference

### DIFF
--- a/content/pipeline/qa-checkers-extended.ts
+++ b/content/pipeline/qa-checkers-extended.ts
@@ -1512,6 +1512,77 @@ export function checkDetanglerNoForwardRef(
     : { result: "pass", hits: [] };
 }
 
+/**
+ * `foreshadows[]` must point FORWARD.
+ *
+ * A foreshadow is a promise that material is coming. Naming something the
+ * reader has already passed is not a preview — it is either a prerequisite
+ * filed in the wrong field, or a back-reference that costs nothing and says
+ * nothing.
+ *
+ * This became load-bearing when `foreshadows[]` stopped being a subset of
+ * `uses[]` (2026-08-10). While the subset rule held, every foreshadow was
+ * also a dependency and `uses-resolve` plus the ordering criteria constrained
+ * it from the other side. Now an entry may name a block the manifest does not
+ * otherwise reference, and such an entry is zero-cost by construction — so
+ * direction is the one property left that a machine can check.
+ *
+ * It is a partial guard, and worth being honest about the gap: it catches a
+ * BACKWARD-pointing entry, which is incoherent, but it cannot catch a genuine
+ * prerequisite moved out of `uses[]` into `foreshadows[]` to clear a red
+ * `detangler-no-forward-ref`. Both point forward. That move is laundering and
+ * is a review failure; no checker adjudicates it.
+ */
+export function checkForeshadowsPointForward(
+  tsPath: string | undefined,
+): CheckerResult {
+  if (!tsPath || !existsSync(tsPath)) return { result: "n/a", hits: [] };
+  loadChapterGraph();
+  if (!_graphLoaded || !_blockPos || !_labelToChapter || !_chapterOrder)
+    return { result: "n/a", hits: [] };
+
+  const content = readFileSync(tsPath, "utf-8");
+  const labelMatch = content.match(/label:\s*"([^"]+)"/);
+  if (!labelMatch) return { result: "pass", hits: [] };
+  const label = labelMatch[1];
+  const foreshadows = parseForeshadows(content);
+  if (!foreshadows.length) return { result: "n/a", hits: [] };
+
+  const myPos = _blockPos.get(label);
+  if (myPos === undefined) return { result: "pass", hits: [] }; // not listed
+  const myChapter = _labelToChapter.get(label);
+  const myChapterIdx = myChapter ? _chapterOrder.get(myChapter) : undefined;
+
+  const hits: CheckerHit[] = [];
+  for (const f of foreshadows) {
+    const fPos = _blockPos.get(f);
+    if (fPos === undefined) continue; // unresolved — `foreshadows-resolve` owns that
+    const fChapter = _labelToChapter.get(f);
+    if (fChapter === myChapter) {
+      if (fPos < myPos)
+        hits.push({
+          file: tsPath,
+          line: 0,
+          text: `foreshadows ${f} (pos ${withinChapter(fPos)}), which appears BEFORE this block (pos ${withinChapter(myPos)}) in the chapter — a foreshadow must point forward`,
+        });
+      continue;
+    }
+    // Cross-chapter: judge by chapter order rather than absolute position.
+    const fChapterIdx = fChapter ? _chapterOrder.get(fChapter) : undefined;
+    if (
+      myChapterIdx !== undefined &&
+      fChapterIdx !== undefined &&
+      fChapterIdx < myChapterIdx
+    )
+      hits.push({
+        file: tsPath,
+        line: 0,
+        text: `foreshadows ${f}, which lives in an EARLIER chapter (${fChapter}) than this block (${myChapter}) — a foreshadow must point forward`,
+      });
+  }
+  return hits.length ? { result: "fail", hits } : { result: "pass", hits: [] };
+}
+
 export function checkDetanglerNoXChapterFwd(
   _tsPath: string | undefined,
 ): CheckerResult {
@@ -1538,9 +1609,11 @@ export function checkDetanglerArchimedeanWall(
 let _chapterOrder: Map<string, number> | null = null;
 let _labelToChapter: Map<string, string> | null = null;
 let _usesGraph: Map<string, string[]> | null = null;
-// Block label -> its author-declared `foreshadows[]` (always a subset of
-// that block's `uses[]`, enforced by the `foreshadows-subset-of-uses`
-// constraint). Consulted by the ordering-COST metrics only.
+// Block label -> its author-declared `foreshadows[]`. Since 2026-08-10 these
+// are INDEPENDENT of that block's `uses[]`: an entry that also appears in
+// `uses[]` is a real dependency exempted from the ordering-COST metrics, and
+// an entry that does not is a pure forward pointer that never enters the
+// dependency graph at all. Consulted by the cost metrics only.
 let _foreshadowGraph: Map<string, string[]> | null = null;
 // Reverse adjacency: block label -> labels whose uses[] reference it.
 // Drives the per-block in-degree metric (how foundational a block is)
@@ -2889,6 +2962,7 @@ export const EXTENDED_AUTOMATED_CHECKERS: Record<
   // detangler
   "detangler-section-band": (p) => checkDetanglerSectionBand(p.ts),
   "detangler-no-forward-ref": (p) => checkDetanglerNoForwardRef(p.ts),
+  "foreshadows-point-forward": (p) => checkForeshadowsPointForward(p.ts),
   "detangler-no-xchapter-fwd": (p) => checkDetanglerNoXChapterFwd(p.ts),
   "detangler-archimedean-wall": (p) =>
     checkDetanglerArchimedeanWall(p.ts, p.lean),

--- a/content/pipeline/qa-criteria-registry.ts
+++ b/content/pipeline/qa-criteria-registry.ts
@@ -1224,6 +1224,35 @@ const DETANGLER: QaCriterionDefinition[] = [
     also_invalidated_by: ["graph"],
   },
   {
+    id: "foreshadows-point-forward",
+    domain: "detangler",
+    description:
+      "Every `foreshadows:` target appears LATER than the block — later in " +
+      "the same chapter's ordered `sections[].blocks[]`, or in a later " +
+      "chapter. A foreshadow is a promise that material is coming; naming " +
+      "something the reader has already passed is either a prerequisite " +
+      "filed in the wrong field or an inert back-reference. Deterministic: " +
+      "`checkForeshadowsPointForward` reuses the block-position map and " +
+      "fails (major) listing each backward target. `n/a` for blocks with no " +
+      "`foreshadows:`. Resolution of the labels themselves is the " +
+      "`foreshadows-resolve` constraint, not this criterion.\n\n" +
+      "Load-bearing since `foreshadows[]` stopped being a subset of " +
+      "`uses[]` (2026-08-10): an entry may now name a block the manifest " +
+      "does not otherwise reference, and is zero-cost by construction, so " +
+      "direction is the one property left that a machine can check. It is a " +
+      "PARTIAL guard — it cannot catch a genuine prerequisite moved out of " +
+      "`uses[]` into `foreshadows[]` to clear a red " +
+      "`detangler-no-forward-ref`, because both point forward. That move is " +
+      "laundering and a review failure; no checker adjudicates it.",
+    default_severity: "major",
+    depends_on: ["ts"],
+    automated: true,
+    // Same rationale as detangler-no-forward-ref above: the verdict depends
+    // on the chapter's block ORDER, so another block's manifest edit can
+    // change it while this block's own files are untouched.
+    also_invalidated_by: ["graph"],
+  },
+  {
     id: "detangler-section-band",
     domain: "detangler",
     description:

--- a/content/pipeline/qa-criteria-registry.ts
+++ b/content/pipeline/qa-criteria-registry.ts
@@ -1239,11 +1239,12 @@ const DETANGLER: QaCriterionDefinition[] = [
       "Load-bearing since `foreshadows[]` stopped being a subset of " +
       "`uses[]` (2026-08-10): an entry may now name a block the manifest " +
       "does not otherwise reference, and is zero-cost by construction, so " +
-      "direction is the one property left that a machine can check. It is a " +
-      "PARTIAL guard — it cannot catch a genuine prerequisite moved out of " +
-      "`uses[]` into `foreshadows[]` to clear a red " +
-      "`detangler-no-forward-ref`, because both point forward. That move is " +
-      "laundering and a review failure; no checker adjudicates it.",
+      "direction is the one property left that a machine can check here. It " +
+      "cannot distinguish a pure forward pointer from a prerequisite filed " +
+      "in the wrong field — both point forward — so that call stays with the " +
+      "author. The cost of getting it wrong is reading-order accuracy, not " +
+      "correctness: a block's formal content is carried by its `lean.ref` " +
+      "sibling and gated by the Lean build, independently of this graph.",
     default_severity: "major",
     depends_on: ["ts"],
     automated: true,

--- a/schemas/constraints.ts
+++ b/schemas/constraints.ts
@@ -761,25 +761,62 @@ export interface ConstraintContext {
  */
 export const CONSTRAINT_RULES: ConstraintRule[] = [
   {
-    id: "foreshadows-subset-of-uses",
+    id: "foreshadows-resolve",
     description:
-      "Every foreshadows[] entry must also appear in uses[] — a declared " +
-      "forward reference to something the block does not reference is " +
-      "meaningless, and would silently exempt nothing",
+      "All labels in foreshadows[] must exist in the document (or be " +
+      "qualified cross-paper refs)",
     // Universal: any block that can carry `uses[]` can carry a foreshadow, so
     // this must not narrow as new kinds appear.
     appliesTo: [...BLOCK_KINDS],
+    // Replaces `foreshadows-subset-of-uses` (removed 2026-08-10, owner
+    // ruling). That rule required every foreshadow to also appear in `uses[]`,
+    // which made the field an ANNOTATION ON an edge and nothing more. It
+    // therefore could not express the case it was most wanted for: a chapter
+    // overview (§0) naming results it previews but does not depend on. Under
+    // the old rule, recording such a pointer meant first asserting a
+    // dependency that is not real — see the eight `overview-source` rows in
+    // qou's `docs/audits/uses-edge-rejections.json`.
+    //
+    // `foreshadows[]` is now INDEPENDENT of `uses[]`. An entry may be:
+    //   - also in `uses[]` → a real prerequisite the paper states later on
+    //     purpose ("we will need X, proved in chapter 9"). Exempt from the
+    //     ordering-COST metrics; still counted for cycles, cones and depth.
+    //   - not in `uses[]` → a pure forward pointer. Never enters the
+    //     dependency graph at all, so it is zero-cost by construction.
+    //
+    // The old rule was also carrying referential integrity: it caught a
+    // foreshadow whose target had been renamed or deleted, because `uses[]`
+    // validation rejected the same label. With the subset requirement gone
+    // that protection would vanish too, so this rule takes it over directly.
+    // Same reference forms as `uses-resolve`.
+    check: (block, ctx) => {
+      const fs = (block as { foreshadows?: string[] }).foreshadows;
+      if (!fs?.length) return null;
+      const missing = fs.filter((f: string) => {
+        // Cross-paper qualified ref ("paper-dir:label") — resolved at folio
+        // level, not here. Mirrors uses-resolve.
+        if (/^([a-z0-9-]+):([a-z]+:.+)$/.test(f)) return false;
+        if (f.startsWith("https://") || f.startsWith("http://")) return false;
+        return !ctx.allLabels.has(f);
+      });
+      return missing.length === 0 ? null
+        : `Unresolved foreshadows: ${missing.join(", ")}`;
+    },
+  },
+  {
+    id: "foreshadows-not-self",
+    description: "A block may not foreshadow itself",
+    appliesTo: [...BLOCK_KINDS],
+    // Cheap, but worth stating: with the subset rule gone nothing else
+    // rejects it. A self-reference would be silently zero-cost and would read
+    // as a deliberate pointer.
     check: (block) => {
       const fs = (block as { foreshadows?: string[] }).foreshadows;
       if (!fs?.length) return null;
-      const uses = new Set((block as { uses?: string[] }).uses ?? []);
-      // Keeps `foreshadows` an annotation ON an edge rather than a second,
-      // parallel way to name blocks. Without this it drifts: a `uses[]` entry
-      // gets removed or renamed, its foreshadow declaration lingers, and the
-      // exemption quietly applies to nothing while looking deliberate.
-      const orphans = fs.filter((f) => !uses.has(f));
-      return orphans.length
-        ? `foreshadows[] entries not present in uses[]: ${orphans.join(", ")}`
+      const self = (block as { label?: string }).label;
+      if (!self) return null;
+      return fs.includes(self)
+        ? `foreshadows[] contains the block's own label: ${self}`
         : null;
     },
   },

--- a/schemas/types.ts
+++ b/schemas/types.ts
@@ -572,21 +572,66 @@ interface BlockBase {
    */
   uses?: string[];
   /**
-   * Subset of `uses[]` that points DELIBERATELY forward — a foreshadow, a
+   * Labels this block points DELIBERATELY forward to — a foreshadow, a
    * preview, or an explicitly deferred result the exposition promises to
    * return to (the surreal-number thread is the archetype).
    *
-   * `detangler-no-forward-ref` exists to catch a reader being sent to material
-   * they have not reached yet (`detangler-no-xchapter-fwd` is still an unwired
-   * stub returning `n/a`). That is a
-   * defect when it is accidental and a rhetorical device when it is not: a
-   * block may legitimately say "we will need X, proved in chapter 9". Listing
-   * X here declares the reference intentional and exempts that one edge.
+   * Where `uses[]` answers *"what must a reader have read first?"* and is
+   * backward-looking by construction, this answers the complementary
+   * question — *"what will the reader meet later, if they want more?"*
    *
-   * NOT a way to silence the axis. Every entry must also appear in `uses[]`
-   * (enforced — a foreshadow of something the block does not reference is
-   * meaningless), and each one is a claim that the prose actually frames the
-   * reference as deferred. Everything not listed stays a finding.
+   * ## Independent of `uses[]` (changed 2026-08-10)
+   *
+   * This field was originally a strict **subset** of `uses[]`: an annotation
+   * marking one dependency edge as deliberately deferred. That could not
+   * express the case it was most wanted for — a chapter overview (§0) naming
+   * results it previews but does not depend on — because recording such a
+   * pointer first required asserting a dependency that is not real.
+   *
+   * An entry may now be either:
+   *
+   * - **also in `uses[]`** — a genuine prerequisite the paper states later on
+   *   purpose ("we will need X, proved in chapter 9"). The edge stays in the
+   *   dependency graph; listing it here exempts it from the ordering-COST
+   *   metrics only.
+   * - **not in `uses[]`** — a pure forward pointer, asserting no dependency.
+   *   It never enters the dependency graph at all.
+   *
+   * ## Zero cost, in both cases
+   *
+   * A foreshadow carries no ordering cost: it is skipped by
+   * `detangler-no-forward-ref`, `detangler-graph-energy`, and both sides of
+   * `detangler-block-tanglement`. Pointing a reader forward is a service, not
+   * a tangle — the prose has told them the material is coming and does not ask
+   * them to go now.
+   *
+   * ## ⚠ NOT a way to silence the axis
+   *
+   * The exemption is from the ordering **cost**, never from the **edge**. A
+   * foreshadow that is also in `uses[]` still counts for cycle detection,
+   * dependency cones, chain depth, and PageRank — a cycle is a logical
+   * impossibility rather than reader burden, and no declaration hides one.
+   *
+   * **Moving a genuine prerequisite OUT of `uses[]` and into this field to
+   * clear a red checker is laundering** — the same defect class as concluding
+   * `: True` to pass a vacuity audit, and now the more tempting move, because
+   * a non-`uses[]` foreshadow leaves the dependency graph entirely. The test
+   * is not "does this clear the gate?" but *"must the reader have this in hand
+   * to follow the block?"* If yes it is a `uses[]` edge, and a forward-pointing
+   * one means the **block order is wrong** — fix the order, do not re-file the
+   * edge.
+   *
+   * Each entry remains a claim that the prose actually frames the reference as
+   * deferred. Everything not listed stays a finding.
+   *
+   * ## Form
+   *
+   * Same reference forms as `uses[]` — bare label within a paper,
+   * `paper-dir:label` cross-paper, full URL cross-folio. Targets must resolve
+   * (`foreshadows-resolve`), and a block may not foreshadow itself
+   * (`foreshadows-not-self`). Unlike `uses[]`, this list is **not**
+   * transitively pruned: pointers are individually chosen editorial gestures,
+   * not a reachability relation.
    */
   foreshadows?: string[];
   /**

--- a/schemas/types.ts
+++ b/schemas/types.ts
@@ -605,21 +605,22 @@ interface BlockBase {
    * a tangle — the prose has told them the material is coming and does not ask
    * them to go now.
    *
-   * ## ⚠ NOT a way to silence the axis
+   * ## Choosing between the two fields
    *
-   * The exemption is from the ordering **cost**, never from the **edge**. A
+   * The exemption is from the ordering **cost**, not from the **edge**. A
    * foreshadow that is also in `uses[]` still counts for cycle detection,
    * dependency cones, chain depth, and PageRank — a cycle is a logical
-   * impossibility rather than reader burden, and no declaration hides one.
+   * impossibility rather than reader burden, so no declaration hides one.
    *
-   * **Moving a genuine prerequisite OUT of `uses[]` and into this field to
-   * clear a red checker is laundering** — the same defect class as concluding
-   * `: True` to pass a vacuity audit, and now the more tempting move, because
-   * a non-`uses[]` foreshadow leaves the dependency graph entirely. The test
-   * is not "does this clear the gate?" but *"must the reader have this in hand
-   * to follow the block?"* If yes it is a `uses[]` edge, and a forward-pointing
-   * one means the **block order is wrong** — fix the order, do not re-file the
-   * edge.
+   * The authoring question is *"must the reader have this in hand to follow
+   * the block?"* If yes it belongs in `uses[]`, and a forward-pointing
+   * `uses[]` edge means the **block order is wrong** — the fix is the order,
+   * not the field. If no, it belongs here.
+   *
+   * Getting that choice wrong costs reading-order accuracy, which is what
+   * these fields are for; it does not affect whether anything is *true*. The
+   * formal content of a block is carried by its `lean.ref` sibling and gated
+   * by the Lean build, entirely independently of this graph.
    *
    * Each entry remains a claim that the prose actually frames the reference as
    * deferred. Everything not listed stays a finding.

--- a/scripts/tests/foreshadows.test.ts
+++ b/scripts/tests/foreshadows.test.ts
@@ -2,10 +2,14 @@ import { describe, expect, test } from "bun:test";
 import { CONSTRAINT_RULES } from "../../schemas/constraints";
 import { parseForeshadows } from "../../content/pipeline/qa-checkers-extended";
 
-const rule = CONSTRAINT_RULES.find((r) => r.id === "foreshadows-subset-of-uses")!;
+const resolveRule = CONSTRAINT_RULES.find((r) => r.id === "foreshadows-resolve")!;
+const selfRule = CONSTRAINT_RULES.find((r) => r.id === "foreshadows-not-self")!;
 
-// The constraint only reads the block, so the context is never consulted.
-const ctx = {} as Parameters<typeof rule.check>[1];
+// `foreshadows-resolve` consults `ctx.allLabels`; `foreshadows-not-self` never
+// touches the context.
+const ctxWith = (...labels: string[]) =>
+  ({ allLabels: new Set(labels) }) as Parameters<typeof resolveRule.check>[1];
+const noCtx = {} as Parameters<typeof selfRule.check>[1];
 
 describe("parseForeshadows", () => {
   test("reads a single-line declaration", () => {
@@ -28,39 +32,84 @@ describe("parseForeshadows", () => {
   });
 });
 
-describe("foreshadows-subset-of-uses", () => {
-  test("passes when every entry is also in uses[]", () => {
-    const block = { kind: "prose", uses: ["def:x", "thm:y"], foreshadows: ["thm:y"] };
-    expect(rule.check(block as never, ctx)).toBeNull();
+describe("foreshadows-resolve", () => {
+  // Replaces `foreshadows-subset-of-uses` (removed 2026-08-10, owner ruling).
+  // That rule made the field an annotation ON a `uses[]` edge, which could not
+  // express a chapter overview naming results it previews but does not depend
+  // on. The two lists are now independent — and this rule inherits the
+  // referential integrity the subset requirement had been providing for free.
+
+  test("passes when the target exists and is NOT in uses[] — the case the old rule rejected", () => {
+    const block = { kind: "prose", label: "rem:overview", foreshadows: ["thm:later"] };
+    expect(resolveRule.check(block as never, ctxWith("thm:later"))).toBeNull();
   });
 
-  test("fails when an entry is not in uses[]", () => {
-    // The drift this exists to catch: the uses[] edge is removed or renamed,
-    // the foreshadow declaration lingers, and the exemption applies to nothing
-    // while still looking deliberate.
-    const block = { kind: "prose", uses: ["def:x"], foreshadows: ["thm:gone"] };
-    const msg = rule.check(block as never, ctx);
-    expect(msg).toContain("thm:gone");
+  test("passes when the target exists and is also in uses[]", () => {
+    const block = {
+      kind: "prose",
+      label: "rem:a",
+      uses: ["thm:later"],
+      foreshadows: ["thm:later"],
+    };
+    expect(resolveRule.check(block as never, ctxWith("thm:later"))).toBeNull();
   });
 
-  test("fails when uses[] is absent entirely", () => {
-    const block = { kind: "prose", foreshadows: ["thm:y"] };
-    expect(rule.check(block as never, ctx)).toContain("thm:y");
+  test("fails on a target that does not resolve", () => {
+    // The drift the old subset rule used to catch on the `uses[]` side: the
+    // target is renamed or deleted and the declaration lingers, pointing at
+    // nothing while still looking deliberate.
+    const block = { kind: "prose", label: "rem:a", foreshadows: ["thm:gone"] };
+    expect(resolveRule.check(block as never, ctxWith("thm:other"))).toContain("thm:gone");
   });
 
-  test("no foreshadows is not a finding", () => {
-    expect(rule.check({ kind: "prose", uses: ["def:x"] } as never, ctx)).toBeNull();
+  test("skips cross-paper qualified refs — resolved at folio level", () => {
+    const block = {
+      kind: "prose",
+      label: "rem:a",
+      foreshadows: ["unital-groebner-bases:cor:pbw"],
+    };
+    expect(resolveRule.check(block as never, ctxWith())).toBeNull();
   });
 
-  test("empty foreshadows is not a finding", () => {
-    const block = { kind: "prose", uses: ["def:x"], foreshadows: [] };
-    expect(rule.check(block as never, ctx)).toBeNull();
+  test("skips full-URL cross-folio refs", () => {
+    const block = {
+      kind: "prose",
+      label: "rem:a",
+      foreshadows: ["https://folio.example.org/papers/foo#def:bar"],
+    };
+    expect(resolveRule.check(block as never, ctxWith())).toBeNull();
   });
 
   test("reports every offender, not just the first", () => {
-    const block = { kind: "prose", uses: [], foreshadows: ["a:1", "b:2"] };
-    const msg = rule.check(block as never, ctx)!;
-    expect(msg).toContain("a:1");
-    expect(msg).toContain("b:2");
+    const block = { kind: "prose", label: "rem:a", foreshadows: ["thm:x", "def:y"] };
+    const msg = resolveRule.check(block as never, ctxWith())!;
+    expect(msg).toContain("thm:x");
+    expect(msg).toContain("def:y");
+  });
+
+  test("no foreshadows is not a finding", () => {
+    expect(resolveRule.check({ kind: "prose", label: "rem:a" } as never, ctxWith())).toBeNull();
+  });
+
+  test("empty foreshadows is not a finding", () => {
+    const block = { kind: "prose", label: "rem:a", foreshadows: [] };
+    expect(resolveRule.check(block as never, ctxWith())).toBeNull();
+  });
+});
+
+describe("foreshadows-not-self", () => {
+  test("fails when a block foreshadows itself", () => {
+    const block = { kind: "prose", label: "rem:a", foreshadows: ["rem:a"] };
+    expect(selfRule.check(block as never, noCtx)).toContain("rem:a");
+  });
+
+  test("passes when it foreshadows something else", () => {
+    const block = { kind: "prose", label: "rem:a", foreshadows: ["thm:b"] };
+    expect(selfRule.check(block as never, noCtx)).toBeNull();
+  });
+
+  test("a missing label is not a finding — another rule owns that", () => {
+    const block = { kind: "prose", foreshadows: ["thm:b"] };
+    expect(selfRule.check(block as never, noCtx)).toBeNull();
   });
 });


### PR DESCRIPTION
Owner ruling. `foreshadows[]` was a strict **subset** of `uses[]` — an annotation marking one dependency edge as deliberately deferred. That could not express the case it was most wanted for: a chapter overview (§0) naming results it previews but does not depend on. Recording such a pointer first required asserting a dependency that is not real.

In `litlfred/qou` that shape accounts for **eight rejected candidate edges** — the `overview-source` rows of [`uses-edge-rejections.json`](https://github.com/litlfred/qou/blob/main/docs/audits/uses-edge-rejections.json). `rem:q-metric-contact-deformation` sits at `fluid-dynamics` §0 and names five results developed across §3–§6. It doesn't depend on them; it previews them. Under the subset rule there was nowhere to record that.

## What changes

An entry may now be either:

| | meaning | cost |
|---|---|---|
| **also in `uses[]`** | a real prerequisite the paper states later on purpose | edge stays in the dependency graph; exempt from ordering-**cost** metrics only |
| **not in `uses[]`** | a pure forward pointer, asserting no dependency | never enters the dependency graph at all — zero-cost by construction |

## The removed rule was carrying two things, not one

`foreshadows-subset-of-uses` enforced the semantics **and**, silently, referential integrity: it caught a foreshadow whose target had been renamed or deleted, because `uses[]` validation rejected the same label. Dropping the subset requirement would have dropped that protection with it. So three rules take over:

- **`foreshadows-resolve`** — targets must exist. Same reference forms as `uses-resolve` (bare label, `paper-dir:label`, full URL).
- **`foreshadows-not-self`** — a block may not foreshadow itself. Nothing else would catch it now, and it would read as a deliberate pointer.
- **`foreshadows-point-forward`** *(new criterion, `detangler` domain)* — fails on an entry naming a block earlier in the chapter, or in an earlier chapter. A foreshadow is a promise that material is coming; naming something the reader has already passed is either a prerequisite filed in the wrong field or an inert back-reference.

## What the machine can and cannot decide

`foreshadows-point-forward` checks direction, which is the one property left that a checker can settle once the subset rule is gone. It cannot distinguish a pure forward pointer from a prerequisite filed in the wrong field — both point forward — so that call stays with the author.

The cost of getting it wrong is **reading-order accuracy, not correctness**. These fields describe what a reader needs and when; a block's formal content is carried by its `lean.ref` sibling and gated by the Lean build, independently of this graph. An earlier revision of this PR framed the mis-filing risk far more heavily than that; the owner corrected it and the wording is now proportionate in both the field docstring and the criterion description.

The authoring question stays simple: *"must the reader have this in hand to follow the block?"* If yes it is a `uses[]` edge, and a forward-pointing one means the block order is wrong — the fix is the order, not the field.

## Tests

`scripts/tests/foreshadows.test.ts` tested the removed rule, so it's rewritten against the two replacements. The previously-**rejected** case — *"target exists and is not in `uses[]`"* — is now asserted to **pass**, which is the behaviour change this PR is for.

**15 pass / 0 fail.**

## Verification

- `bunx tsc --noEmit` — clean on all five touched files
- `bun test scripts/tests/foreshadows.test.ts` — 15/15
- CI on the previous head: **4/4 green**, including `TypeScript — tests, lint, types (hard)`
- `litlfred/qou` corpus validate → **exit 0**, same 5 pre-existing issues as before. No regression across its 8 blocks that declare `foreshadows[]` (all keep their entries in `uses[]`, so they exercise the resolve path).

## Follow-on, not in this PR

The 8 qou overview edges become declarable as pure forward pointers once this lands. Their rejection rows in `uses-edge-rejections.json` should then be re-scoped from "rejected" to "re-filed as `foreshadows`" — a qou-side change, tracked under bean `cnd4`.

Builds on #108 (merged), which made a declared foreshadow zero-cost in the energy and tanglement metrics.