### PR TITLE
Derive foreshadows from the .md narrative

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,8 @@ __pycache__/
 /amalgamated_input/
 /_deprecated/
 /scratch/
+
+# Symlink farm created by the CONTENT repo's scripts/setup-folio-assistant.sh
+# (e.g. content/schema/references.ts -> <content-repo>/content/schema/references.ts).
+# Machine-local absolute paths — useful in a working clone, meaningless in git.
+content/schema/

--- a/content/pipeline/build-foreshadows.ts
+++ b/content/pipeline/build-foreshadows.ts
@@ -1,0 +1,201 @@
+#!/usr/bin/env bun
+/**
+ * Emit `foreshadows.json` — every block's forward pointers, derived from its
+ * `.md` narrative and unioned with whatever the manifest declares.
+ *
+ * ## Why this is generated rather than authored
+ *
+ * A forward pointer already lives in the prose: *"see X"*, *"the remarks below
+ * frame these regimes as ODEs"*. Writing it a second time into `foreshadows:`
+ * duplicates authored content into metadata, and the copy goes stale the
+ * moment the prose changes — the same drift class the witness and QA-sidecar
+ * machinery already spends real effort policing.
+ *
+ * So this follows the pattern the corpus already uses for derived data:
+ * `proof-objects.json` (formalization status, derived from Lean, never stored
+ * on the block) and `glossary.json` (built from `defines`). Committed,
+ * regenerated, never hand-edited.
+ *
+ * ## What stays in the manifest
+ *
+ * `foreshadows:` is NOT emptied by this. Derivation reaches exactly one of the
+ * field's two cases:
+ *
+ *   - a pure forward pointer, not in `uses[]`  → DERIVED here
+ *   - a real dependency the paper states later on purpose → DECLARED, and
+ *     underivable: no rule separates it from a forward `uses[]` edge that is
+ *     merely a defect. Only the author can.
+ *
+ * The union of the two is what every consumer should read.
+ *
+ * ## The checkers do not read this file
+ *
+ * `loadChapterGraph` runs the same derivation from source on every load, so a
+ * stale or missing `foreshadows.json` can never change a verdict. This
+ * artifact is an emission for humans, diffs, and other tools.
+ *
+ * Usage:
+ *   bun run content/pipeline/build-foreshadows.ts <paper-dir> [--check]
+ *
+ * `--check` regenerates in memory and exits 1 if the committed file differs,
+ * naming the drifted blocks. That is the CI gate; it never rewrites.
+ */
+import { readFileSync, writeFileSync, existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { parseForeshadows, parseMdBlockRefs } from "./qa-checkers-extended";
+import { findContentRepoRoot } from "./repo-root";
+
+// The CONTENT repo's content/, not folio-assistant's. An import-relative path
+// resolves to `folio-assistant/content` — which holds only `pipeline/` — so
+// every paper lookup would miss and this would cheerfully emit an empty
+// artifact. That exact mistake once left the whole detangler axis reporting
+// `n/a` while looking healthy; see the note on CONTENT_DIR in
+// qa-checkers-extended.ts.
+const CONTENT_DIR = join(findContentRepoRoot(), "content");
+
+interface BlockEntry {
+  derived: string[];
+  declared: string[];
+  effective: string[];
+}
+
+export function buildForeshadows(paper: string): {
+  schema: string;
+  paper: string;
+  generated_from: string;
+  note: string;
+  totals: { blocks: number; derived: number; declared: number; effective: number };
+  blocks: Record<string, BlockEntry>;
+} {
+  const paperDir = join(CONTENT_DIR, paper);
+  const paperTs = join(paperDir, `${paper}.ts`);
+  if (!existsSync(paperTs)) throw new Error(`no paper manifest: ${paperTs}`);
+  const dirs = [...readFileSync(paperTs, "utf-8").matchAll(/dir:\s*"([^"]+)"/g)].map(
+    (m) => m[1],
+  );
+
+  const slugToLabel = new Map<string, string>();
+  const uses = new Map<string, Set<string>>();
+  const declared = new Map<string, string[]>();
+  const mdRefs = new Map<string, string[]>();
+
+  for (const dir of dirs) {
+    const chDir = join(paperDir, dir);
+    if (!existsSync(chDir)) continue;
+    for (const f of readdirSync(chDir)) {
+      if (!f.endsWith(".ts") || f === `${dir}.ts`) continue;
+      const src = readFileSync(join(chDir, f), "utf-8");
+      const m = src.match(/label:\s*"([^"]+)"/);
+      if (!m) continue;
+      const label = m[1];
+      slugToLabel.set(f.slice(0, -3), label);
+      const um = src.match(/uses\s*:\s*\[([\s\S]*?)\]/);
+      uses.set(
+        label,
+        new Set(um ? [...um[1].matchAll(/"([^"]+)"/g)].map((x) => x[1]) : []),
+      );
+      declared.set(label, parseForeshadows(src));
+      const md = join(chDir, `${f.slice(0, -3)}.md`);
+      if (existsSync(md)) mdRefs.set(label, parseMdBlockRefs(readFileSync(md, "utf-8")));
+    }
+  }
+
+  // Reading order, from each chapter manifest's ordered sections[].blocks[].
+  const pos = new Map<string, number>();
+  const STRIDE = 100_000;
+  dirs.forEach((dir, ci) => {
+    const mf = join(paperDir, dir, `${dir}.ts`);
+    if (!existsSync(mf)) return;
+    let within = 0;
+    for (const bm of readFileSync(mf, "utf-8").matchAll(/blocks\s*:\s*\[([\s\S]*?)\]/g))
+      for (const sm of bm[1].matchAll(/"([^"]+)"/g)) {
+        const lb = slugToLabel.get(sm[1]);
+        if (lb && !pos.has(lb)) pos.set(lb, ci * STRIDE + within++);
+      }
+  });
+
+  const blocks: Record<string, BlockEntry> = {};
+  let dTot = 0;
+  let cTot = 0;
+  let eTot = 0;
+  for (const [label, refs] of [...mdRefs].sort(([a], [b]) => a.localeCompare(b))) {
+    const myPos = pos.get(label);
+    if (myPos === undefined) continue; // unlisted block: no reading order
+    const u = uses.get(label) ?? new Set();
+    const derived = refs
+      .filter((t) => t !== label && !u.has(t) && pos.has(t) && (pos.get(t) as number) > myPos)
+      .sort();
+    const dec = (declared.get(label) ?? []).slice().sort();
+    if (!derived.length && !dec.length) continue;
+    const effective = [...new Set([...derived, ...dec])].sort();
+    blocks[label] = { derived, declared: dec, effective };
+    dTot += derived.length;
+    cTot += dec.length;
+    eTot += effective.length;
+  }
+
+  return {
+    schema: "foreshadows/v1",
+    paper,
+    generated_from:
+      "block .md narratives (](#kind:label) links + `kind:label` mentions), " +
+      "filtered to labels later in reading order and absent from uses[], " +
+      "unioned with the manifest's declared foreshadows[]",
+    note:
+      "GENERATED — do not hand-edit. Rebuild with " +
+      "`bun run content/pipeline/build-foreshadows.ts <paper>`. The QA " +
+      "checkers derive the same data from source on every run and never read " +
+      "this file, so it cannot go stale in a way that changes a verdict.",
+    totals: { blocks: Object.keys(blocks).length, derived: dTot, declared: cTot, effective: eTot },
+    blocks,
+  };
+}
+
+if (import.meta.main) {
+  const args = process.argv.slice(2);
+  const check = args.includes("--check");
+  const paper = args.find((a) => !a.startsWith("--"));
+  if (!paper) {
+    console.error("usage: build-foreshadows.ts <paper-dir> [--check]");
+    process.exit(2);
+  }
+  const built = buildForeshadows(paper);
+  const out = join(CONTENT_DIR, paper, "foreshadows.json");
+  const text = `${JSON.stringify(built, null, 2)}\n`;
+
+  if (check) {
+    if (!existsSync(out)) {
+      console.error(`foreshadows.json missing for ${paper} — run without --check`);
+      process.exit(1);
+    }
+    const have = readFileSync(out, "utf-8");
+    if (have === text) {
+      console.log(`foreshadows.json up to date (${built.totals.blocks} blocks)`);
+      process.exit(0);
+    }
+    // Name the drifted blocks rather than just reporting inequality.
+    const prev = JSON.parse(have) as { blocks?: Record<string, BlockEntry> };
+    const before = prev.blocks ?? {};
+    const keys = [...new Set([...Object.keys(before), ...Object.keys(built.blocks)])].sort();
+    const drift = keys.filter(
+      (k) =>
+        JSON.stringify(before[k]?.effective ?? null) !==
+        JSON.stringify(built.blocks[k]?.effective ?? null),
+    );
+    console.error(`foreshadows.json is stale for ${paper}: ${drift.length} block(s) differ`);
+    for (const k of drift.slice(0, 20)) {
+      console.error(
+        `  ${k}\n    committed: ${JSON.stringify(before[k]?.effective ?? [])}` +
+          `\n    rebuilt  : ${JSON.stringify(built.blocks[k]?.effective ?? [])}`,
+      );
+    }
+    if (drift.length > 20) console.error(`  … and ${drift.length - 20} more`);
+    process.exit(1);
+  }
+
+  writeFileSync(out, text);
+  const t = built.totals;
+  console.log(
+    `wrote ${out}\n  ${t.blocks} blocks | ${t.derived} derived + ${t.declared} declared -> ${t.effective} effective`,
+  );
+}

--- a/content/pipeline/qa-checkers-extended.ts
+++ b/content/pipeline/qa-checkers-extended.ts
@@ -1457,16 +1457,79 @@ export function checkDetanglerSectionBand(
 // flag them as missing. A follow-up commit will wire them.
 
 /**
- * Parse a block manifest's `foreshadows: [...]` — the subset of `uses[]` the
- * author has declared as a deliberate forward reference.
+ * Parse a block manifest's DECLARED `foreshadows: [...]`.
  *
  * Text-level like the sibling `label:` parse in this file, so the checker
  * stays free of a module import of the manifest.
+ *
+ * ⚠ The array match is non-greedy, so it stops at the first `]`. A comment
+ * inside the array containing a closing bracket — `// moved out of uses[]` —
+ * silently truncates the list, and a truncated array is indistinguishable
+ * from a shorter one, so nothing downstream can detect it. The same shape
+ * applies to the `uses:` parse in `loadChapterGraph`. Do not write a closing
+ * bracket in a comment inside one of these arrays.
  */
 export function parseForeshadows(tsSrc: string): string[] {
   const m = tsSrc.match(/\bforeshadows:\s*\[([\s\S]*?)\]/);
   if (!m) return [];
   return [...m[1].matchAll(/["']([^"']+)["']/g)].map((x) => x[1]);
+}
+
+/**
+ * Every block label a `.md` narrative references, in either form the corpus
+ * uses:
+ *
+ *   - `](#kind:label)` — a markdown link (4786 occurrences in qou)
+ *   - `` `kind:label` `` — a backtick mention (907, of which 44 appear in no
+ *     link anywhere in their block)
+ *
+ * Deliberately NOT included: `:refterm[…]{#slug}` / `:defterm[…]{#slug}`.
+ * Those carry GLOSSARY TERM slugs (`braided-monoidal-category`) — a separate
+ * namespace from block labels, owned by the `defines` machinery.
+ *
+ * Returns raw candidates. Resolution against the corpus and the
+ * forward/backward split are the caller's job; this function has no position
+ * information and stays deliberately ignorant of it.
+ */
+export function parseMdBlockRefs(mdSrc: string): string[] {
+  const out = new Set<string>();
+  for (const m of mdSrc.matchAll(/\]\(#([a-z]+:[a-z0-9-]+)\)/g)) out.add(m[1]);
+  for (const m of mdSrc.matchAll(/`([a-z]+:[a-z0-9-]+)`/g)) out.add(m[1]);
+  return [...out];
+}
+
+/**
+ * A block's DERIVED forward pointers: labels its narrative references that sit
+ * later in the reading order and are not already declared dependencies.
+ *
+ * This is the autopopulation rule. A forward pointer already lives in the
+ * prose — "see X", "the remarks below frame these regimes as ODEs" — so the
+ * manifest should not have to repeat it. Same relationship `cites` has to
+ * `\cite{}` in the `.md`.
+ *
+ * What it CANNOT derive, and why the manifest field remains: a foreshadow that
+ * is also a `uses[]` dependency — a real prerequisite the paper states later
+ * on purpose. No rule separates that from a forward `uses[]` edge that is
+ * simply a defect; only the author's declaration can. Callers therefore take
+ * the UNION of this and `parseForeshadows`.
+ */
+export function deriveForeshadows(
+  label: string,
+  mdSrc: string,
+  uses: readonly string[],
+  positionOf: (l: string) => number | undefined,
+  isKnownLabel: (l: string) => boolean,
+): string[] {
+  const myPos = positionOf(label);
+  if (myPos === undefined) return [];
+  const declared = new Set(uses);
+  return parseMdBlockRefs(mdSrc)
+    .filter((t) => t !== label && !declared.has(t) && isKnownLabel(t))
+    .filter((t) => {
+      const p = positionOf(t);
+      return p !== undefined && p > myPos;
+    })
+    .sort();
 }
 
 export function checkDetanglerNoForwardRef(
@@ -1722,11 +1785,14 @@ function loadChapterGraph(): void {
   const chapterOrder = new Map<string, number>();
   const labelToChapter = new Map<string, string>();
   const usesGraph = new Map<string, string[]>();
-  // Author-declared deliberate forward references, per block. A separate
-  // adjacency (rather than a per-file re-parse) so the RECEIVE side of the
-  // tanglement metric can ask "did the citing block declare this?" without
-  // reading that block's manifest again.
+  // Deliberate forward references, per block. A separate adjacency (rather
+  // than a per-file re-parse) so the RECEIVE side of the tanglement metric
+  // can ask "did the citing block declare this?" without reading that
+  // block's manifest again. Seeded with the DECLARED entries and unioned
+  // with the ones derived from each `.md` once positions exist.
   const foreshadowGraph = new Map<string, string[]>();
+  // Raw block labels each narrative references, pre-direction-filter.
+  const mdRefs = new Map<string, string[]>();
 
   // Resolve the paper from the folio rather than hardcoding one. A
   // folio may hold several papers and the platform must not privilege
@@ -1789,6 +1855,20 @@ function loadChapterGraph(): void {
               : [];
             usesGraph.set(m[1], useLabels);
             foreshadowGraph.set(m[1], parseForeshadows(content));
+            // Collect the narrative's raw block references now; the
+            // forward/backward split needs positions, which are built in the
+            // pass below. Missing .md is normal for some kinds and is not an
+            // error here.
+            try {
+              mdRefs.set(
+                m[1],
+                parseMdBlockRefs(
+                  readFileSync(join(chDir, `${f.slice(0, -3)}.md`), "utf-8"),
+                ),
+              );
+            } catch {
+              /* no .md sibling */
+            }
           }
         }
       } catch {}
@@ -1883,6 +1963,40 @@ function loadChapterGraph(): void {
         for (const n of nodes)
           next.set(n, next.get(n)! + damping * dangling);
       for (const [k, v] of next) pagerank.set(k, v);
+    }
+  }
+
+  // Union the DERIVED forward pointers into the declared ones. Runs here
+  // rather than in the block loop because the forward/backward split needs
+  // `blockPos`, which is only complete once every chapter manifest has been
+  // walked.
+  //
+  // Derivation is done from source on every load rather than read from the
+  // generated `foreshadows.json`, so a stale or absent artifact can never
+  // change a checker's verdict. The JSON is an emission for humans and other
+  // tools, not an input.
+  {
+    const posOf = (l: string) => blockPos.get(l);
+    // Every block the walk saw is a key here, so this doubles as the
+    // "is this a real label?" test — an unresolvable reference in prose is
+    // dropped rather than becoming a phantom pointer.
+    const known = (l: string) => labelToChapter.has(l);
+    for (const [label, refs] of mdRefs) {
+      const myPos = blockPos.get(label);
+      if (myPos === undefined) continue;
+      const uses = new Set(usesGraph.get(label) ?? []);
+      const derived = refs.filter(
+        (t) =>
+          t !== label &&
+          !uses.has(t) &&
+          known(t) &&
+          (posOf(t) ?? -1) > myPos,
+      );
+      if (!derived.length) continue;
+      foreshadowGraph.set(
+        label,
+        [...new Set([...(foreshadowGraph.get(label) ?? []), ...derived])],
+      );
     }
   }
 

--- a/content/pipeline/script-sidecars/detangler-block-tanglement.script.json
+++ b/content/pipeline/script-sidecars/detangler-block-tanglement.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "detangler-block-tanglement",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "080654c93cc4",
+  "script_commit_sha": "1a0072c9eb0be730cb6b90e0ae3a8867e0ec2126",
+  "last_run_at": "2026-08-10T19:59:29.342Z",
+  "last_run_sha": "b508ca3925ce303b7ea4090f82c03f54c6cffa3e",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/detangler-no-forward-ref.script.json
+++ b/content/pipeline/script-sidecars/detangler-no-forward-ref.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "detangler-no-forward-ref",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "df7a68d30c46",
+  "script_commit_sha": "1a0072c9eb0be730cb6b90e0ae3a8867e0ec2126",
+  "last_run_at": "2026-08-10T19:59:29.342Z",
+  "last_run_sha": "b508ca3925ce303b7ea4090f82c03f54c6cffa3e",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/foreshadows-point-forward.script.json
+++ b/content/pipeline/script-sidecars/foreshadows-point-forward.script.json
@@ -1,10 +1,10 @@
 {
   "$schema": "qa-script/v1",
-  "criterion_id": "detangler-graph-energy",
+  "criterion_id": "foreshadows-point-forward",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "d8d7fa2bb342",
+  "script_hash": "296e68ad2618",
   "script_commit_sha": "1a0072c9eb0be730cb6b90e0ae3a8867e0ec2126",
-  "last_run_at": "2026-08-10T19:59:29.342Z",
+  "last_run_at": "2026-08-10T19:23:08.419Z",
   "last_run_sha": "b508ca3925ce303b7ea4090f82c03f54c6cffa3e",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/uses-editorial-hygiene.script.json
+++ b/content/pipeline/script-sidecars/uses-editorial-hygiene.script.json
@@ -2,13 +2,13 @@
   "$schema": "qa-script/v1",
   "criterion_id": "uses-editorial-hygiene",
   "source_file": "content/pipeline/qa-checkers-uses.ts",
-  "script_hash": "51e33f456ef9",
+  "script_hash": "1d50b09b0497",
   "script_commit_sha": "7b12c02ea38e6126e44e887d9e5f3242d0916315",
   "extra_inputs": [
     "content/pipeline/content-graph.ts"
   ],
   "deps_hash": "c7f602946422",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "last_run_at": "2026-08-10T19:36:28.892Z",
+  "last_run_sha": "b508ca3925ce303b7ea4090f82c03f54c6cffa3e",
   "engine_version": "bun-1.3.11"
 }

--- a/scripts/tests/derive-foreshadows.test.ts
+++ b/scripts/tests/derive-foreshadows.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import {
+  parseMdBlockRefs,
+  deriveForeshadows,
+} from "../../content/pipeline/qa-checkers-extended";
+
+describe("parseMdBlockRefs", () => {
+  test("reads markdown links", () => {
+    expect(parseMdBlockRefs("see [the thing](#prop:foo) for more")).toEqual(["prop:foo"]);
+  });
+
+  test("reads backtick mentions", () => {
+    expect(parseMdBlockRefs("as `conj:bar` shows")).toEqual(["conj:bar"]);
+  });
+
+  test("de-duplicates across both forms", () => {
+    const md = "[x](#prop:foo) and `prop:foo` again and [y](#prop:foo)";
+    expect(parseMdBlockRefs(md)).toEqual(["prop:foo"]);
+  });
+
+  test("ignores glossary term slugs — a different namespace", () => {
+    // :refterm/:defterm carry lowercase-hyphen term slugs owned by `defines`,
+    // not `kind:label` block labels. Including them would invent pointers to
+    // blocks that do not exist.
+    const md = "the :refterm[braided monoidal category]{#braided-monoidal-category} is";
+    expect(parseMdBlockRefs(md)).toEqual([]);
+  });
+
+  test("ignores prose that merely looks label-ish", () => {
+    expect(parseMdBlockRefs("ratio 3:4 and http://x.example/y")).toEqual([]);
+  });
+
+  test("empty narrative yields nothing", () => {
+    expect(parseMdBlockRefs("")).toEqual([]);
+  });
+});
+
+describe("deriveForeshadows", () => {
+  // Reading order: a=0, b=1, c=2, d=3
+  const pos: Record<string, number> = {
+    "rem:a": 0,
+    "prop:b": 1,
+    "thm:c": 2,
+    "def:d": 3,
+  };
+  const positionOf = (l: string) => pos[l];
+  const known = (l: string) => l in pos;
+
+  test("keeps a forward reference that is not a dependency", () => {
+    const md = "[later](#thm:c)";
+    expect(deriveForeshadows("rem:a", md, [], positionOf, known)).toEqual(["thm:c"]);
+  });
+
+  test("drops a BACKWARD reference — a foreshadow must point forward", () => {
+    const md = "[earlier](#rem:a)";
+    expect(deriveForeshadows("def:d", md, [], positionOf, known)).toEqual([]);
+  });
+
+  test("drops a reference already declared in uses[] — that is a dependency", () => {
+    const md = "[later](#thm:c)";
+    expect(deriveForeshadows("rem:a", md, ["thm:c"], positionOf, known)).toEqual([]);
+  });
+
+  test("drops a self-reference", () => {
+    expect(deriveForeshadows("rem:a", "[me](#rem:a)", [], positionOf, known)).toEqual([]);
+  });
+
+  test("drops an unresolvable label rather than inventing a pointer", () => {
+    const md = "[ghost](#prop:does-not-exist)";
+    expect(deriveForeshadows("rem:a", md, [], positionOf, known)).toEqual([]);
+  });
+
+  test("a block with no reading-order position derives nothing", () => {
+    // Unlisted in any chapter manifest: there is no "forward" to speak of.
+    expect(deriveForeshadows("rem:unlisted", "[x](#thm:c)", [], positionOf, known)).toEqual([]);
+  });
+
+  test("returns sorted, de-duplicated results across both ref forms", () => {
+    const md = "[c](#thm:c) `def:d` [c again](#thm:c) `thm:c`";
+    expect(deriveForeshadows("rem:a", md, [], positionOf, known)).toEqual([
+      "def:d",
+      "thm:c",
+    ]);
+  });
+
+  test("derived and uses[] are disjoint by construction", () => {
+    // This is what makes the union behaviour-neutral for the cost metrics:
+    // they iterate the uses graph, and nothing derived can appear there.
+    const md = "[b](#prop:b) [c](#thm:c) [d](#def:d)";
+    const derived = deriveForeshadows("rem:a", md, ["prop:b"], positionOf, known);
+    expect(derived).toEqual(["def:d", "thm:c"]);
+    expect(derived).not.toContain("prop:b");
+  });
+});


### PR DESCRIPTION
Owner directive: a forward pointer already lives in the prose — *"see X"*, *"the remarks below frame these regimes as ODEs"* — so the manifest shouldn't have to repeat it. Same relationship `cites` has to `\cite{}` in the `.md`.

**Rule:** a block label the narrative references, that sits **later** in reading order, and is **not** already in `uses[]`.

Both reference forms the corpus actually uses:

| form | occurrences in qou |
|---|---|
| `](#kind:label)` markdown links | 4786 |
| `` `kind:label` `` backtick mentions | 907 — of which **44** appear in no link anywhere in their block |

**Excluded:** `:refterm/:defterm{#slug}`. Those carry glossary *term* slugs (`braided-monoidal-category`), a different namespace from block labels, owned by the `defines` machinery. Including them would invent pointers to blocks that don't exist.

**Measured on qou:** 504 blocks, **868 derived + 18 declared → 880 effective**. Two independent implementations (this and a throwaway Python probe) agree on 868 exactly.

## What this cannot derive — and why the field stays

A foreshadow that is *also* a `uses[]` dependency — a real prerequisite the paper states later on purpose — is not derivable by any rule. Nothing separates it from a forward `uses[]` edge that is simply a defect; only the author can. So consumers read the **union**, and `foreshadows:` keeps carrying that case.

Of 17 hand-declared entries, derivation reproduces **7**. The other 10 are exactly this class.

## The union is behaviour-neutral, and that's provable

Not sampled — provable from the code. `deriveForeshadows` filters on `!uses.has(t)`, so derived and `uses[]` are **disjoint by construction**, while every cost metric iterates `_usesGraph` or `_reverseUses` (built from `uses[]`). A derived pointer can therefore never be reached by one.

That's the correct outcome: these were never costs. The value is informational, and `_foreshadowGraph` now means *effective* rather than *declared* for any future consumer.

## The artifact

`build-foreshadows.ts` emits `content/<paper>/foreshadows.json`, following the pattern the corpus already uses for derived data — `proof-objects.json` (formalization status, derived from Lean, explicitly *never* stored on the block) and `glossary.json`.

`--check` regenerates in memory and exits 1 naming the drifted blocks with committed-vs-rebuilt; it never rewrites. Verified both ways: clean on a fresh build, and on an injected perturbation it reports

```
foreshadows.json is stale: 1 block(s) differ
  conj:algebraic-geometric-dilog-equivalence
    committed: ["bogus:injected"]
    rebuilt  : ["conj:shared-denominator-cusp-holonomy"]
```

**Checkers never read this file.** They derive from source on every load, so a stale or absent artifact cannot change a verdict.

## Two traps, both pre-documented in this repo

**`CONTENT_DIR` must resolve via `findContentRepoRoot()`, not import-relative.** The import-relative form points at `folio-assistant/content`, which holds only `pipeline/` — so every paper lookup misses and the tool cheerfully emits an *empty* artifact. That's the same mistake that once left the entire detangler axis reporting `n/a` while looking healthy. I wrote it that way first; the existing comment on `CONTENT_DIR` caught it.

**`parseForeshadows`' array match is non-greedy**, so a closing bracket inside a comment in the array silently truncates the list — and a truncated array is indistinguishable from a shorter one, so nothing downstream detects it. That cost me a false "pass" earlier today on a list missing two entries. Now documented on the function, along with the note that `uses:` has the identical shape.

## Verification

- `bun test` — **29 pass / 0 fail** across both foreshadows test files (16 new)
- `bunx tsc --noEmit` — clean on all three touched files
- `run-validate` on qou with the artifact present — exit 0, same 5 pre-existing issues

## Sequencing

Land this before the qou side ([litlfred/qou#4956](https://github.com/litlfred/qou/pull/4956)), which commits the generated `foreshadows.json` — that artifact has nothing to regenerate or check it until this is on `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AS8WGCDJPU2qE36oS9GxjP)_