### PR TITLE
Manifest parsing: read the array, not the text that looks like one

### DIFF
--- a/content/pipeline/build-foreshadows.ts
+++ b/content/pipeline/build-foreshadows.ts
@@ -42,7 +42,11 @@
  */
 import { readFileSync, writeFileSync, existsSync, readdirSync } from "node:fs";
 import { join } from "node:path";
-import { parseForeshadows, parseMdBlockRefs } from "./qa-checkers-extended";
+import {
+  parseForeshadows,
+  parseMdBlockRefs,
+  parseManifestStringArray,
+} from "./qa-checkers-extended";
 import { findContentRepoRoot } from "./repo-root";
 
 // The CONTENT repo's content/, not folio-assistant's. An import-relative path
@@ -89,11 +93,7 @@ export function buildForeshadows(paper: string): {
       if (!m) continue;
       const label = m[1];
       slugToLabel.set(f.slice(0, -3), label);
-      const um = src.match(/uses\s*:\s*\[([\s\S]*?)\]/);
-      uses.set(
-        label,
-        new Set(um ? [...um[1].matchAll(/"([^"]+)"/g)].map((x) => x[1]) : []),
-      );
+      uses.set(label, new Set(parseManifestStringArray(src, "uses")));
       declared.set(label, parseForeshadows(src));
       const md = join(chDir, `${f.slice(0, -3)}.md`);
       if (existsSync(md)) mdRefs.set(label, parseMdBlockRefs(readFileSync(md, "utf-8")));

--- a/content/pipeline/qa-checkers-extended.ts
+++ b/content/pipeline/qa-checkers-extended.ts
@@ -1469,10 +1469,126 @@ export function checkDetanglerSectionBand(
  * applies to the `uses:` parse in `loadChapterGraph`. Do not write a closing
  * bracket in a comment inside one of these arrays.
  */
-export function parseForeshadows(tsSrc: string): string[] {
-  const m = tsSrc.match(/\bforeshadows:\s*\[([\s\S]*?)\]/);
+/**
+ * Blank out string-literal CONTENTS and comment bodies, preserving every
+ * index so offsets into the result are valid offsets into the original.
+ *
+ * Used to locate manifest array fields without being fooled by text that
+ * merely looks like one. Handles `"`, `'` and backtick literals (with
+ * escapes), plus `//` and block comments.
+ */
+export function maskStringsAndComments(src: string): string {
+  const out = src.split("");
+  let i = 0;
+  const n = src.length;
+  const blank = (from: number, to: number) => {
+    for (let k = from; k < to && k < n; k++) if (out[k] !== "\n") out[k] = " ";
+  };
+  while (i < n) {
+    const c = src[i];
+    const d = src[i + 1];
+    if (c === "/" && d === "/") {
+      const end = src.indexOf("\n", i);
+      blank(i, end === -1 ? n : end);
+      i = end === -1 ? n : end;
+      continue;
+    }
+    if (c === "/" && d === "*") {
+      const end = src.indexOf("*/", i + 2);
+      blank(i, end === -1 ? n : end + 2);
+      i = end === -1 ? n : end + 2;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === "`") {
+      let j = i + 1;
+      while (j < n) {
+        if (src[j] === "\\") { j += 2; continue; }
+        if (src[j] === c) break;
+        j++;
+      }
+      blank(i + 1, j); // keep the quotes, blank the contents
+      i = j + 1;
+      continue;
+    }
+    i++;
+  }
+  return out.join("");
+}
+
+/**
+ * Extract a manifest array field's string entries.
+ *
+ * Replaces three regex-shaped bugs that made the checkers read different
+ * data from the content pipeline — which imports the manifest and sees the
+ * real array — while `validate` stayed green:
+ *
+ *  1. **Phantom entries.** A quoted string in a comment inside the array was
+ *     extracted as an entry. Live in the corpus: `p3-blowup-yekutieli.ts`
+ *     read 4 `uses[]` entries where the truth is 3, the extra being the
+ *     phrase `NS blowup ⟺ obstruction level n*` from an explanatory comment.
+ *  2. **Wrong array entirely.** The old match was unanchored and took the
+ *     first hit in the file, so a quoted `uses: [...]` in an `authorNotes`
+ *     body won over the block's real field. Live in
+ *     `hecke-log-decomposition-table-data.ts`, whose note documents an
+ *     earlier fabricated-edge incident and thereby fabricated another.
+ *  3. **Silent truncation.** `[\s\S]*?\]` stops at the first `]`, so a
+ *     comment containing one — `// moved out of uses[]` — dropped every
+ *     entry after it. The worst of the three: a truncated array is
+ *     indistinguishable from a shorter one, so nothing downstream can
+ *     detect it.
+ *
+ * Masking fixes all three at once: comments and string CONTENTS are blanked
+ * (indices preserved), so the field is located only at a real property
+ * position and the closing bracket is found by depth-scanning text that can
+ * no longer contain a decorative one. Entries are then read from the
+ * ORIGINAL source over that range.
+ *
+ * Note the masking must be index-preserving rather than a strip: naive
+ * comment removal corrupts `https://…` inside string literals.
+ */
+export function parseManifestStringArray(tsSrc: string, field: string): string[] {
+  const masked = maskStringsAndComments(tsSrc);
+  const re = new RegExp(`(^|[{,\\s])${field}\\s*:\\s*\\[`, "g");
+  const m = re.exec(masked);
   if (!m) return [];
-  return [...m[1].matchAll(/["']([^"']+)["']/g)].map((x) => x[1]);
+  const open = masked.indexOf("[", m.index);
+  let depth = 0;
+  let close = -1;
+  for (let k = open; k < masked.length; k++) {
+    if (masked[k] === "[") depth++;
+    else if (masked[k] === "]") {
+      depth--;
+      if (depth === 0) { close = k; break; }
+    }
+  }
+  if (close === -1) return [];
+  // Read entries from the ORIGINAL text, but only at positions the mask
+  // agrees are string literals — so a bracket or quote inside a comment
+  // cannot contribute an entry.
+  const region = tsSrc.slice(open + 1, close);
+  const maskRegion = masked.slice(open + 1, close);
+  const out: string[] = [];
+  const entry = /["']/g;
+  let mm: RegExpExecArray | null;
+  while ((mm = entry.exec(maskRegion))) {
+    const q = mm.index;
+    const quote = maskRegion[q];
+    const end = maskRegion.indexOf(quote, q + 1);
+    if (end === -1) break;
+    out.push(region.slice(q + 1, end));
+    entry.lastIndex = end + 1;
+  }
+  return out;
+}
+
+/**
+ * Parse a block manifest's DECLARED `foreshadows: [...]`.
+ *
+ * Comment- and string-safe via `parseManifestStringArray`; see that
+ * function for the three failure modes this replaced.
+ */
+export function parseForeshadows(tsSrc: string): string[] {
+  return parseManifestStringArray(tsSrc, "foreshadows");
 }
 
 /**
@@ -1846,13 +1962,12 @@ function loadChapterGraph(): void {
             // Record the block's `uses:[...]` dependency edges (only the
             // uses array — NOT cites/interprets/own-label) for cycle
             // detection.
-            const usesM = content.match(/uses\s*:\s*\[([\s\S]*?)\]/);
             // De-duplicate: a block listing the same `uses:` label twice
             // must not inflate out-degree / in-degree / cone size — count
             // unique dependency edges only.
-            const useLabels = usesM
-              ? [...new Set([...usesM[1].matchAll(/"([^"]+)"/g)].map((x) => x[1]))]
-              : [];
+            const useLabels = [
+              ...new Set(parseManifestStringArray(content, "uses")),
+            ];
             usesGraph.set(m[1], useLabels);
             foreshadowGraph.set(m[1], parseForeshadows(content));
             // Collect the narrative's raw block references now; the

--- a/scripts/tests/manifest-parse.test.ts
+++ b/scripts/tests/manifest-parse.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+import {
+  maskStringsAndComments,
+  parseManifestStringArray,
+  parseForeshadows,
+} from "../../content/pipeline/qa-checkers-extended";
+
+describe("maskStringsAndComments", () => {
+  test("preserves length and newlines so indices stay valid", () => {
+    const src = 'const a = "hi"; // note\nconst b = 1;\n';
+    const out = maskStringsAndComments(src);
+    expect(out.length).toBe(src.length);
+    expect(out.split("\n").length).toBe(src.split("\n").length);
+  });
+
+  test("blanks string contents but keeps the quotes", () => {
+    expect(maskStringsAndComments('x = "abc"')).toBe('x = "   "');
+  });
+
+  test("does NOT corrupt a URL inside a string — the reason this masks rather than strips", () => {
+    // A naive comment-strip would cut at the `//` in https:// and silently
+    // truncate the literal.
+    const src = 'uses: ["https://folio.example.org/p#def:x"]';
+    expect(parseManifestStringArray(src, "uses")).toEqual([
+      "https://folio.example.org/p#def:x",
+    ]);
+  });
+
+  test("blanks line and block comments", () => {
+    expect(maskStringsAndComments("a // c\nb")).toBe("a     \nb");
+    expect(maskStringsAndComments("a /* c */ b")).toBe("a         b");
+  });
+});
+
+describe("parseManifestStringArray", () => {
+  test("reads a plain array", () => {
+    const src = `uses: ["def:a", "thm:b"],`;
+    expect(parseManifestStringArray(src, "uses")).toEqual(["def:a", "thm:b"]);
+  });
+
+  test("mode 1 — a quoted string in a comment is NOT an entry", () => {
+    // Live in the corpus: p3-blowup-yekutieli.ts read 4 entries where the
+    // truth is 3, the extra being a phrase from this kind of comment.
+    const src = [
+      "  uses: [",
+      "    // conj:regularity-breakdown removed: this prop is the",
+      '    // unconditional reformulation "NS blowup ⟺ obstruction level n*",',
+      '    "prop:descent-condition",',
+      '    "def:local-cohomology-group",',
+      "  ],",
+    ].join("\n");
+    expect(parseManifestStringArray(src, "uses")).toEqual([
+      "prop:descent-condition",
+      "def:local-cohomology-group",
+    ]);
+  });
+
+  test("mode 2 — a quoted `uses: [...]` earlier in the file does not win", () => {
+    // Live in hecke-log-decomposition-table-data.ts, whose authorNote quotes
+    // a manifest snippet as prose — and appears before the real field.
+    const src = [
+      "export default remark({",
+      "  authorNotes: [",
+      "    {",
+      '      body: "the block declared `uses: [\\"prop:ghost\\"]`, which does not exist",',
+      "    },",
+      "  ],",
+      '  uses: ["prop:real"],',
+      "});",
+    ].join("\n");
+    expect(parseManifestStringArray(src, "uses")).toEqual(["prop:real"]);
+  });
+
+  test("mode 3 — a closing bracket in a comment does NOT truncate", () => {
+    // The worst mode: a truncated array is indistinguishable from a shorter
+    // one, so no checker can detect it.
+    const src = [
+      "  foreshadows: [",
+      '    "def:a",',
+      "    // moved out of uses[] because the reader does not need it first",
+      '    "thm:b",',
+      '    "rem:c",',
+      "  ],",
+    ].join("\n");
+    expect(parseForeshadows(src)).toEqual(["def:a", "thm:b", "rem:c"]);
+  });
+
+  test("does not match a field whose name merely ends with the target", () => {
+    const src = `notuses: ["def:wrong"], uses: ["def:right"],`;
+    expect(parseManifestStringArray(src, "uses")).toEqual(["def:right"]);
+  });
+
+  test("handles a nested array without stopping at its inner bracket", () => {
+    const src = `uses: ["a:b", ["c:d"], "e:f"],`;
+    expect(parseManifestStringArray(src, "uses")).toEqual(["a:b", "c:d", "e:f"]);
+  });
+
+  test("absent field yields nothing", () => {
+    expect(parseManifestStringArray('tags: ["x"]', "uses")).toEqual([]);
+  });
+
+  test("empty array yields nothing", () => {
+    expect(parseManifestStringArray("uses: [],", "uses")).toEqual([]);
+  });
+
+  test("an unterminated array yields nothing rather than running away", () => {
+    expect(parseManifestStringArray('uses: ["a:b",', "uses")).toEqual([]);
+  });
+
+  test("single quotes are accepted, matching the old behaviour", () => {
+    expect(parseManifestStringArray("uses: ['def:a'],", "uses")).toEqual(["def:a"]);
+  });
+});


### PR DESCRIPTION
The checkers located `uses[]` and `foreshadows[]` by regexing the manifest **text** and pulling every quoted string out of the captured region. The content pipeline *imports* the manifest and reads the real array. Where the two disagreed, every ordering metric was computed on wrong data **while `validate` stayed green**.

Three failure modes, all observed, two live in the qou corpus.

## 1. Phantom entries

A quoted string in a comment inside the array became an entry.

```ts
uses: [
  // conj:regularity-breakdown removed (§3b): this prop is the
  // unconditional reformulation "NS blowup ⟺ obstruction level n*", not a
  // result that assumes blow-up occurs; ...
  "prop:descent-condition",
```

`p3-blowup-yekutieli.ts` read **4** entries where the truth is 3 — the extra being that phrase, lifted out of the comment. It resolves to no block, inflating out-degree and cone size.

## 2. Wrong array entirely

The match was unanchored and took the **first** hit in the file, so a quoted `uses: [...]` inside an `authorNotes` body won over the block's real field. Live in `hecke-log-decomposition-table-data.ts`.

That note is documenting an *earlier* fabricated-edge incident. In documenting it, it fabricated another.

## 3. Silent truncation

`[\s\S]*?\]` stops at the first `]`, so a comment containing one — `// moved out of uses[]` — dropped every entry after it.

The worst of the three: **a truncated array is indistinguishable from a shorter one**, so nothing downstream can detect it and `uses-resolve` has nothing unresolvable to flag.

## The fix

Index-preserving **masking** rather than stripping. `maskStringsAndComments` blanks comment bodies and string *contents* while keeping every offset valid, so the field is found only at a real property position and the closing bracket is located by depth-scan over text that can no longer hold a decorative one. Entries are then read from the **original** source over that range.

Masking rather than stripping matters: a naive comment-strip cuts at the `//` in an `https://` URL inside a string literal and truncates it. There's a test for exactly that.

## Blast radius — measured, not estimated

Across **3484 blocks**, 4 fields change. All four are corrections that remove a phantom; none loses a real edge.

| file | field | before → after |
|---|---|---|
| `hecke-log-decomposition-table-data.ts` | `uses` | 1 → **0** |
| `climax-volume-mass.ts` | `uses` | 1 → **0** |
| `p3-blowup-yekutieli.ts` | `uses` | 4 → **3** |
| `q-beta-form-a-n1-symbolic-table-data.ts` | `uses` | 1 → **0** |

The three `1 → 0` cases are blocks with no real `uses[]` at all — the old parser was inventing one out of quoted prose.

## It corrects a live artifact

qou's committed `foreshadows.json` carried two phantom entries under `rem:q-metric-contact-deformation` — fragments of the comment I wrote *warning about mode 3*, with quotes paired across it by the old parser. Regenerating drops them: **880 → 878** effective.

The qou-side regeneration ships separately and depends on this landing.

## Verification

- **14 new tests** — one per failure mode, plus the URL case, nested arrays, an unterminated array, and a field whose name merely ends with the target
- Suite **617 → 631 pass**
- The **7 failures are pre-existing**: Lean tactic-ladder tests that fail identically on clean `main`, verified by checking out `main` and running the suite there
- `bunx tsc --noEmit` clean on both touched files
- Both live corpus cases verified corrected, with an unchanged control block

---
_Generated by [Claude Code](https://claude.ai/code/session_01AS8WGCDJPU2qE36oS9GxjP)_