### PR TITLE
validate: report manifest fields the schema silently strips

### DIFF
--- a/.beans/folio-assistant-unk1--unknown-manifest-fields-were-stripped-in-silence.md
+++ b/.beans/folio-assistant-unk1--unknown-manifest-fields-were-stripped-in-silence.md
@@ -1,0 +1,41 @@
+---
+# folio-assistant-unk1
+title: unknown manifest fields were stripped in silence
+status: completed
+type: bug
+created_at: 2026-08-10T05:00:00Z
+updated_at: 2026-08-10T05:00:00Z
+---
+
+Branch `claude/unknown-manifest-fields-2026-08-10`.
+
+The Zod block schemas are non-strict, so a key nothing declares is **stripped
+without an error**. A misspelt field name vanishes and the data it carried never
+reaches the graph — no warning, no diff, nothing to notice.
+
+Found via `qou/fwr10`: two proof blocks declare their parent as `proofOf` where
+the canonical field is `of`, so those parent links are **absent from the
+dependency graph entirely**. Two independent readers hit it in different
+tranches.
+
+The class had bitten this schema before. `ProofSchema` carries a comment
+recording that `of` was declared on the TS `ProofBlock` and missing from the Zod
+object, "so it was silently stripped".
+
+**Detected without changing what validates.** Zod strips, so comparing the raw
+object's keys against the parsed result's is exactly the signal. No schema
+change, no strict mode, no source-text scanning — the last of which is its own
+known hazard here (`fsl7`, `mcp1`).
+
+Reported at **warning**, not error: the field is inert rather than malformed, so
+the block is still valid content and failing a build over it is
+disproportionate. Saying nothing is what let two sit in a real paper.
+
+**Corpus impact: 35 warnings across qou**, and the number is instructive. A first
+survey found 6 unknown keys by collecting schema identifiers globally; that
+undercounted, because a field can be declared on the paper or chapter schema and
+still be unknown *on a block*. `chapter:` is the case — 11 blocks set it and it
+is dropped every time. Only the parse itself knows what a given kind accepts.
+
+`run-validate` on qou goes 5 issues to 40, all warnings, still ✓ Valid. The
+content fixes are qou-side and not done here.

--- a/content/pipeline/validate.ts
+++ b/content/pipeline/validate.ts
@@ -155,6 +155,29 @@ async function loadBlocksFromDir(
         continue;
       }
 
+      // A key the schema does not declare is SILENTLY STRIPPED — the Zod
+      // block schemas are non-strict, so a misspelt field name produces no
+      // error and the data it carried never reaches the graph. Comparing the
+      // raw object's keys against the parsed result's is exactly that signal,
+      // without changing what validates.
+      //
+      // Real cases: two proof blocks declare their parent as `proofOf`, where
+      // the canonical field is `of`, so those parent links are absent from the
+      // dependency graph entirely. Three more carry `is_mathematics`. The same
+      // class bit this schema once before — `of` itself was declared on the TS
+      // type and missing from the Zod object, and was stripped until noticed.
+      for (const key of Object.keys(block as Record<string, unknown>)) {
+        if (key in (result.data as Record<string, unknown>)) continue;
+        issues.push({
+          level: "warning",
+          block: name,
+          message:
+            `Unknown field "${key}" — no schema declares it, so it was silently ` +
+            `dropped and carries no meaning. Check for a misspelling of a real field.`,
+          file: `${name}.ts`,
+        });
+      }
+
       blocks.set(name, block);
 
       // Math-link detection: scan the sibling .md (if any) for

--- a/scripts/tests/validate-unknown-field.test.ts
+++ b/scripts/tests/validate-unknown-field.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { validateObjects } from "../../content/pipeline/validate";
+
+/**
+ * The Zod block schemas are non-strict, so a key nothing declares is stripped
+ * without an error and the data it carried never reaches the graph. Two proof
+ * blocks in a real paper declare their parent as `proofOf` where the canonical
+ * field is `of` — the parent link is simply absent from the dependency graph,
+ * and nothing said so.
+ */
+function chapter(body: string, name = "alpha"): string {
+  const root = mkdtempSync(join(tmpdir(), "unknown-field-"));
+  writeFileSync(join(root, `${name}.ts`), body);
+  writeFileSync(join(root, `${name}.md`), `Body of ${name}.\n`);
+  return root;
+}
+
+const unknownIssues = (issues: Array<{ message: string }>) =>
+  issues.filter((i) => i.message.includes("Unknown field"));
+
+describe("unknown manifest fields", () => {
+  test("a key no schema declares is reported", async () => {
+    const dir = chapter(
+      `export default { kind: "prose", label: "rem:alpha", title: "T", proofOf: "prop:x" };\n`,
+    );
+    const { issues } = await validateObjects(dir);
+    const found = unknownIssues(issues);
+    expect(found.length).toBe(1);
+    expect(found[0].message).toContain("proofOf");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("it is a warning, not an error", async () => {
+    // The field is inert, not malformed — the block is still valid content, so
+    // failing the build over it would be disproportionate. Saying nothing is
+    // what let two of these sit in a real paper.
+    const dir = chapter(
+      `export default { kind: "prose", label: "rem:alpha", title: "T", is_mathematics: true };\n`,
+    );
+    const { issues } = await validateObjects(dir);
+    expect(unknownIssues(issues)[0]).toMatchObject({ level: "warning" });
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("every unknown key is reported, not just the first", async () => {
+    const dir = chapter(
+      `export default { kind: "prose", label: "rem:alpha", title: "T", probe: 1, consumers: [] };\n`,
+    );
+    const { issues } = await validateObjects(dir);
+    expect(unknownIssues(issues).length).toBe(2);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("a clean block reports nothing", async () => {
+    const dir = chapter(
+      `export default { kind: "prose", label: "rem:alpha", title: "T", tags: ["a"] };\n`,
+    );
+    const { issues } = await validateObjects(dir);
+    expect(unknownIssues(issues).length).toBe(0);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("the canonical spelling of a stripped field is not reported", async () => {
+    // `of` is the real field `proofOf` was reaching for; it must stay silent.
+    const dir = chapter(
+      `export default { kind: "proof", label: "prf:alpha", title: "T", of: "prop:x" };\n`,
+    );
+    const { issues } = await validateObjects(dir);
+    expect(unknownIssues(issues).length).toBe(0);
+    rmSync(dir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
The Zod block schemas are non-strict, so a key nothing declares is **dropped without an error**. A misspelt field name vanishes and the data it carried never reaches the graph — no warning, no diff, nothing to notice.

## How it surfaced

Two proof blocks in qou declare their parent as **`proofOf`** where the canonical field is **`of`**, so those parent links are absent from the dependency graph entirely. Two independent readers hit it in *different tranches* of a completeness review.

The class had bitten this schema before — `ProofSchema` still carries a comment recording that `of` was declared on the TS type and missing from the Zod object, *"so it was silently stripped."*

## Detected without changing what validates

Zod strips unknown keys, so comparing the **raw object's keys against the parsed result's** is exactly the signal. No schema change, no strict mode, and no scanning of `.ts` source text — which is its own known hazard in this file's history (`fsl7`, `mcp1`).

Reported at **warning**, not error: the field is inert rather than malformed, so the block is still valid content and failing a build over it would be disproportionate. Saying nothing is what let two of these sit in a real paper.

## The corpus number is itself the lesson

**35 warnings across qou** — not the 6 my first survey found.

That survey collected schema identifiers *globally* and undercounted, because a field can be declared on the paper or chapter schema and still be unknown **on a block**. `chapter:` is exactly that case: 11 blocks set it, and it's dropped every time. Only the parse knows what a given kind accepts, which is why the check asks the parse instead of a list.

`run-validate` on qou goes 5 issues → 40, all warnings, still **✓ Valid**. The content fixes are qou-side and not in this change.

## Checks

678 tests pass, lint clean, generated docs in sync. `origin/main` merged in (10 commits, no conflicts).

---
_Generated by [Claude Code](https://claude.ai/code/session_016hQePZH4xA7gxL5eLTP5av)_