### PR TITLE
uses-editorial-review: foreshadows is independent of uses[] now

### DIFF
--- a/.beans/folio-assistant-fsh2--skill-described-a-foreshadows-rule-that-was-removed.md
+++ b/.beans/folio-assistant-fsh2--skill-described-a-foreshadows-rule-that-was-removed.md
@@ -1,0 +1,39 @@
+---
+# folio-assistant-fsh2
+title: uses-editorial-review described a foreshadows rule that was removed
+status: completed
+type: bug
+created_at: 2026-08-15T12:50:00Z
+updated_at: 2026-08-15T12:50:00Z
+---
+
+Branch `claude/foreshadows-skill-after-ruling-2026-08-15`.
+
+An owner ruling on 2026-08-10 made `foreshadows[]` **independent of `uses[]`**
+and removed `foreshadows-subset-of-uses`. The skill agents read before doing this
+work still described the field as "a subset of `uses[]`, enforced by
+`foreshadows-subset-of-uses`" — stale guidance pointing at a rule that no longer
+exists.
+
+**The ruling corrects a real design flaw in the original field**, which I built.
+Requiring every foreshadow to also sit in `uses[]` made it an annotation on an
+edge and nothing more, so it could not express the case it was most wanted for:
+a chapter overview naming results it previews but does not depend on. Recording
+such a pointer meant first asserting a dependency that is not real.
+
+The field now splits, and the split is what the skill needed to say:
+
+- **pure forward pointer**, not in `uses[]` — *derived* from the block's own
+  markdown links, never authored, zero-cost by construction because it never
+  enters the dependency graph;
+- **deferred prerequisite**, in `uses[]` — *declared*, and underivable: no rule
+  separates it from a forward edge that is merely a defect.
+
+Also corrected: the "17 of 23 withdrawn" figure now carries its context. It was
+measured under the subset rule, when every forward pointer had to be declared;
+most of the withdrawn ones were pure pointers, which now derive themselves. Left
+in, because the *bar* it establishes still governs the declared case.
+
+Worth noting the derivation is not the trap the old guidance feared. It reads
+links and backticked labels, never deferral language — the distinction that made
+an earlier attempt classify "Below $n^*$", a numeric comparison, as a deferral.

--- a/docs/reference/skill-instructions/uses-editorial-review.md
+++ b/docs/reference/skill-instructions/uses-editorial-review.md
@@ -84,13 +84,42 @@ When reviewing, do not open the Lean file to decide what belongs in
 
 A `uses[]` entry pointing at a block that appears *later* in the chapter
 is a `detangler-no-forward-ref` finding. Sometimes that is right — the
-exposition really does defer — and `foreshadows[]` (a subset of `uses[]`,
-enforced by `foreshadows-subset-of-uses`) declares it, permanently
-exempting the edge.
+exposition really does defer — and `foreshadows[]` records it.
 
-Permanently is the operative word. A wrong declaration does not merely
-mislabel: it hides a genuine ordering defect behind an authored claim
-that the disorder was intended, and nothing downstream re-opens it. The
+**`foreshadows[]` is independent of `uses[]`** (owner ruling, 2026-08-10;
+the old `foreshadows-subset-of-uses` rule is gone). That independence is
+the whole point, and it splits the field into two cases you must keep
+apart:
+
+| case | in `uses[]`? | who records it | cost |
+|---|---|---|---|
+| **Pure forward pointer** — the prose names something coming later and does not depend on it | no | **derived** from the `.md`, not authored | zero by construction: it never enters the dependency graph |
+| **Deferred prerequisite** — a real dependency the paper states later on purpose | yes | **declared** by the author, and only the author | exempt from ordering *cost*; still counted for cycles, cones and depth |
+
+The earlier subset rule required every foreshadow to sit in `uses[]`,
+which made the field an annotation on an edge and nothing more. It could
+not express the case it was most wanted for — a chapter overview naming
+results it previews but does not depend on — because recording such a
+pointer meant first asserting a dependency that is not real.
+
+**Do not hand-author the first case.** `deriveForeshadows` reads the
+block's own markdown links and backticked labels, keeps those that
+resolve to a real block sitting later in reading order and are not
+already in `uses[]`, and `loadChapterGraph` re-derives on every load.
+Writing them into the manifest duplicates authored content into metadata,
+where it goes stale the moment the prose changes.
+
+Note what the derivation does **not** do: it never reads deferral
+*language*. It matches links and labels. An attempt to detect phrasing
+instead classified "**Below** $n^*$" — a numeric comparison — as a
+deferral, which is why the mechanical half stays mechanical.
+
+## Declaring the second case
+
+Only a deferred prerequisite needs your judgement, and it is the
+expensive one to get wrong: it exempts a real `uses[]` edge from the
+ordering metrics, hiding a genuine defect behind an authored claim that
+the disorder was intended, and nothing downstream re-opens it. The
 contract in `BlockBase.foreshadows` is strict — the prose must **frame
 the reference as deferred** ("we will need X, proved in chapter 9").
 
@@ -99,7 +128,9 @@ happens *elsewhere*: "we establish this in X", "we work this out
 separately", "the derivation is recorded in X". In a review of 274
 forward edges, every declaration that survived adversarial re-review had
 that shape, and **17 of 23** first-pass declarations did not and were
-withdrawn.
+withdrawn. Read that number in context: it was measured under the subset
+rule, when *every* forward pointer had to be declared. Most of the
+withdrawn ones were pure pointers, which now derive themselves.
 
 | Looks like a deferral | Actually |
 |---|---|
@@ -118,6 +149,17 @@ declaring:
 - **Mis-aimed deferral.** The quoted sentence hands off to a *different*
   block than the edge under review. A deferral pointed elsewhere cannot
   exempt this one.
+
+Both are about the *declared* case only. A derived pointer is aimed by
+the link itself, so it cannot be mis-aimed, and it carries no exemption
+to abuse.
+
+Two rules police the field now that the subset requirement is gone:
+`foreshadows-resolve` (every target must exist — the referential
+integrity `uses[]` validation used to provide incidentally) and
+`foreshadows-not-self`. The `foreshadows-point-forward` criterion catches
+a target the reader has already passed, which is either a prerequisite
+filed in the wrong field or an inert back-reference.
 
 ## A block's `uses[]` may be carrying the whole family
 

--- a/skills/folio-core/uses-editorial-review.md
+++ b/skills/folio-core/uses-editorial-review.md
@@ -85,13 +85,42 @@ When reviewing, do not open the Lean file to decide what belongs in
 
 A `uses[]` entry pointing at a block that appears *later* in the chapter
 is a `detangler-no-forward-ref` finding. Sometimes that is right — the
-exposition really does defer — and `foreshadows[]` (a subset of `uses[]`,
-enforced by `foreshadows-subset-of-uses`) declares it, permanently
-exempting the edge.
+exposition really does defer — and `foreshadows[]` records it.
 
-Permanently is the operative word. A wrong declaration does not merely
-mislabel: it hides a genuine ordering defect behind an authored claim
-that the disorder was intended, and nothing downstream re-opens it. The
+**`foreshadows[]` is independent of `uses[]`** (owner ruling, 2026-08-10;
+the old `foreshadows-subset-of-uses` rule is gone). That independence is
+the whole point, and it splits the field into two cases you must keep
+apart:
+
+| case | in `uses[]`? | who records it | cost |
+|---|---|---|---|
+| **Pure forward pointer** — the prose names something coming later and does not depend on it | no | **derived** from the `.md`, not authored | zero by construction: it never enters the dependency graph |
+| **Deferred prerequisite** — a real dependency the paper states later on purpose | yes | **declared** by the author, and only the author | exempt from ordering *cost*; still counted for cycles, cones and depth |
+
+The earlier subset rule required every foreshadow to sit in `uses[]`,
+which made the field an annotation on an edge and nothing more. It could
+not express the case it was most wanted for — a chapter overview naming
+results it previews but does not depend on — because recording such a
+pointer meant first asserting a dependency that is not real.
+
+**Do not hand-author the first case.** `deriveForeshadows` reads the
+block's own markdown links and backticked labels, keeps those that
+resolve to a real block sitting later in reading order and are not
+already in `uses[]`, and `loadChapterGraph` re-derives on every load.
+Writing them into the manifest duplicates authored content into metadata,
+where it goes stale the moment the prose changes.
+
+Note what the derivation does **not** do: it never reads deferral
+*language*. It matches links and labels. An attempt to detect phrasing
+instead classified "**Below** $n^*$" — a numeric comparison — as a
+deferral, which is why the mechanical half stays mechanical.
+
+## Declaring the second case
+
+Only a deferred prerequisite needs your judgement, and it is the
+expensive one to get wrong: it exempts a real `uses[]` edge from the
+ordering metrics, hiding a genuine defect behind an authored claim that
+the disorder was intended, and nothing downstream re-opens it. The
 contract in `BlockBase.foreshadows` is strict — the prose must **frame
 the reference as deferred** ("we will need X, proved in chapter 9").
 
@@ -100,7 +129,9 @@ happens *elsewhere*: "we establish this in X", "we work this out
 separately", "the derivation is recorded in X". In a review of 274
 forward edges, every declaration that survived adversarial re-review had
 that shape, and **17 of 23** first-pass declarations did not and were
-withdrawn.
+withdrawn. Read that number in context: it was measured under the subset
+rule, when *every* forward pointer had to be declared. Most of the
+withdrawn ones were pure pointers, which now derive themselves.
 
 | Looks like a deferral | Actually |
 |---|---|
@@ -119,6 +150,17 @@ declaring:
 - **Mis-aimed deferral.** The quoted sentence hands off to a *different*
   block than the edge under review. A deferral pointed elsewhere cannot
   exempt this one.
+
+Both are about the *declared* case only. A derived pointer is aimed by
+the link itself, so it cannot be mis-aimed, and it carries no exemption
+to abuse.
+
+Two rules police the field now that the subset requirement is gone:
+`foreshadows-resolve` (every target must exist — the referential
+integrity `uses[]` validation used to provide incidentally) and
+`foreshadows-not-self`. The `foreshadows-point-forward` criterion catches
+a target the reader has already passed, which is either a prerequisite
+filed in the wrong field or an inert back-reference.
 
 ## A block's `uses[]` may be carrying the whole family
 


### PR DESCRIPTION
The owner ruling of 2026-08-10 made `foreshadows[]` **independent of `uses[]`** and removed `foreshadows-subset-of-uses`. This skill still described the field as *"a subset of `uses[]`, enforced by `foreshadows-subset-of-uses`"* — stale guidance naming a rule that no longer exists, in the file agents read **before doing exactly this work**.

## The ruling corrects a design flaw in the field as I originally built it

Requiring every foreshadow to sit in `uses[]` made it an annotation on an edge and nothing more. It couldn't express the case it was most wanted for — a chapter overview naming results it *previews but does not depend on* — because recording such a pointer meant first asserting a dependency that isn't real.

## The section now leads with the split

| case | in `uses[]`? | who records it | cost |
|---|---|---|---|
| **Pure forward pointer** | no | **derived** from the `.md`, not authored | zero by construction — never enters the dependency graph |
| **Deferred prerequisite** | yes | **declared**, and only the author can | exempt from ordering *cost*; still counted for cycles, cones, depth |

Plus explicit guidance **not to hand-author the first case**: `deriveForeshadows` already reads the links, `loadChapterGraph` re-derives on every load, and writing them into the manifest duplicates authored content into metadata where it goes stale the moment the prose changes.

## The derivation is not the trap the old guidance feared

It never reads deferral *language* — it matches links and backticked labels. Trying to detect phrasing is what once classified "**Below** $n^*$", a numeric comparison, as a deferral. Worth saying plainly, since the previous text's whole argument for authoring was that phrasing can't be detected mechanically. That argument was right about phrasing and wrong about the conclusion.

## Figures kept, with their context

The **17 of 23 withdrawn** figure stays but now says what it measured: it was taken under the subset rule, when *every* forward pointer had to be declared, and most of the withdrawn ones were pure pointers that now derive themselves. The bar it establishes still governs the declared case, which is why it stays rather than being deleted as obsolete.

The two traps — false locator, mis-aimed deferral — are now scoped to the declared case: a derived pointer is aimed by its own link and carries no exemption to abuse. The replacement rules are named: `foreshadows-resolve` (taking over the referential integrity the subset rule provided incidentally), `foreshadows-not-self`, and the `foreshadows-point-forward` criterion.

## Checks

678 tests pass, lint clean, generated instruction docs regenerated and in sync.

---
_Generated by [Claude Code](https://claude.ai/code/session_016hQePZH4xA7gxL5eLTP5av)_