### PR TITLE
beans(fsl7): bullet 3 is half-discharged, and the half that mattered is not

### DIFF
--- a/.beans/folio-assistant-fsl7--repoint-remaining-hand-rolled-block-scanners-at-th.md
+++ b/.beans/folio-assistant-fsl7--repoint-remaining-hand-rolled-block-scanners-at-th.md
@@ -132,3 +132,34 @@ gate, not about parsing. But it does move this bean from "filed so the remaining
 scanners are known rather than rediscovered" to "one of them has already
 mis-parsed real content and hidden findings behind a pass". Still not blocking;
 now with a demonstrated cost.
+
+
+## 2026-08-15 — bullet 3 is half-discharged, and the half that mattered is not
+
+`1690d08` ("manifest parsing: read the array, not the text that looks like one")
+adds `parseManifestStringArray`, which is the right implementation and strictly
+better than the stopgap: it **masks** strings and comments index-preservingly
+rather than stripping them, then matches the array by **bracket depth**. So a
+`]` inside a comment cannot terminate it, a `https://` inside a literal survives,
+and — unlike the stopgap — a legitimately nested array is handled.
+
+It has a 113-line test file. This is the class being retired properly rather
+than patched, which is what this bean asks for.
+
+**But `loadChapterGraph` was not repointed at it.** The position map that every
+detangler criterion depends on — the exact code path `mcp1` was a bug in — still
+runs `stripLineComments` plus the non-greedy `blocks: \[([\s\S]*?)\]`. Two
+parsers now derive block positions from the same manifests by different means:
+`build-foreshadows.ts` on the new one, `loadChapterGraph` on the old.
+
+Measured on the qou corpus today: **they agree, 0 disagreements across 3515
+slugs**, so this is latent rather than live. The stopgap handles the two shapes
+that actually occur (a `]` in a comment, a slug quoted in a comment). It would
+diverge on a nested array inside a `blocks: [...]`, which no manifest currently
+has.
+
+So the remaining work here is small and worth doing while the context is fresh:
+point `loadChapterGraph` at `parseManifestStringArray`, drop `stripLineComments`
+and its test if nothing else uses them. Not urgent — nothing is wrong today —
+but two parsers for one job is how the next divergence starts, and this bean
+exists precisely to stop scanners being rediscovered.


### PR DESCRIPTION
Bean record only.

`1690d08` adds **`parseManifestStringArray`**, and it's the right implementation — strictly better than the stopgap I landed in #99. It **masks** strings and comments index-preservingly rather than stripping them, then matches the array by **bracket depth**. So a `]` inside a comment can't terminate it, a `https://` inside a literal survives, and — unlike the stopgap — a legitimately nested array is handled. With a 113-line test file.

That's this bean's subject being **retired properly rather than patched**.

## But `loadChapterGraph` wasn't repointed at it

The position map every detangler criterion depends on — the exact code path `mcp1` was a bug in — still runs `stripLineComments` plus the non-greedy `blocks: \[([\s\S]*?)\]`.

Two parsers now derive block positions from the same manifests by different means: `build-foreshadows.ts` on the new one, `loadChapterGraph` on the old.

## Measured before writing this

They **agree on the qou corpus today — 0 disagreements across 3515 slugs.** So this is latent, not live. The stopgap handles the two shapes that actually occur (a `]` in a comment, a slug quoted in a comment) and would diverge only on a nested array inside a `blocks: [...]`, which no manifest currently has.

## Why I recorded it as half-done rather than closed

*"The good parser exists"* and *"the code that had the bug uses it"* are different claims, and only the first is true. Closing on the first would leave the next reader believing the position map is on the new parser.

The remaining work is small: point `loadChapterGraph` at `parseManifestStringArray`, and drop `stripLineComments` and its test if nothing else uses them. Not urgent — nothing is wrong today — but two parsers for one job is how the next divergence starts, and this bean exists precisely to stop scanners being rediscovered.

---
_Generated by [Claude Code](https://claude.ai/code/session_016hQePZH4xA7gxL5eLTP5av)_