### PR TITLE
detangler: put loadChapterGraph on the real manifest parser

### DIFF
--- a/.beans/folio-assistant-fsl7--repoint-remaining-hand-rolled-block-scanners-at-th.md
+++ b/.beans/folio-assistant-fsl7--repoint-remaining-hand-rolled-block-scanners-at-th.md
@@ -163,3 +163,33 @@ point `loadChapterGraph` at `parseManifestStringArray`, drop `stripLineComments`
 and its test if nothing else uses them. Not urgent — nothing is wrong today —
 but two parsers for one job is how the next divergence starts, and this bean
 exists precisely to stop scanners being rediscovered.
+
+
+## 2026-08-15 — bullet 3 closed: loadChapterGraph is on the real parser
+
+`parseManifestStringArrays` added — same masking and depth-scan as the
+single-array version, returning every occurrence in source order, because a
+chapter manifest holds one `blocks: [...]` per section and per subsection and
+the position map walks them in order. That is why the existing function was not
+a drop-in.
+
+`loadChapterGraph` now reads through it. `stripLineComments` is deleted: it had
+no production caller left, only its own test.
+
+Its test survives, repointed. The two cases in it came out of the corpus — a `]`
+inside a comment, a slug quoted inside a comment — and they are worth keeping as
+regressions regardless of which parser answers them. Four cases added that the
+stopgap could not have passed: every section's array returned in order, a nested
+array not ending the scan, and a field name inside a string not winning over the
+real field. That last one is bug 2 from `parseManifestStringArray`'s own notes,
+which the stopgap never addressed — stripping comments does nothing about a
+`blocks: [...]` quoted inside an `authorNotes` body.
+
+Verified behaviour-preserving: forward references on qou read **194 before and
+194 after**, matching the 0-disagreement measurement taken before the change.
+677 tests, lint clean.
+
+**Bullet 3 is done.** Bullets 1 and 2 stand as previously ruled — bullet 1 closed
+by owner decision, bullet 2 fine as filed. The bean's remaining subject is the
+sync loader, unchanged: worth doing when someone is already in loader work, not
+worth opening on its own account.

--- a/content/pipeline/qa-checkers-extended.ts
+++ b/content/pipeline/qa-checkers-extended.ts
@@ -1546,6 +1546,56 @@ export function maskStringsAndComments(src: string): string {
  * Note the masking must be index-preserving rather than a strip: naive
  * comment removal corrupts `https://…` inside string literals.
  */
+/**
+ * Every occurrence of a manifest array field, in source order.
+ *
+ * Same masking and depth-scanning as `parseManifestStringArray` — which is now
+ * the first element of this — but a chapter manifest holds one `blocks: [...]`
+ * per section and per subsection, and the position map has to walk all of them
+ * in order.
+ */
+export function parseManifestStringArrays(tsSrc: string, field: string): string[][] {
+  const masked = maskStringsAndComments(tsSrc);
+  const re = new RegExp(`(^|[{,\\s])${field}\\s*:\\s*\\[`, "g");
+  const arrays: string[][] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(masked)) !== null) {
+    const open = masked.indexOf("[", m.index);
+    let depth = 0;
+    let close = -1;
+    for (let k = open; k < masked.length; k++) {
+      if (masked[k] === "[") depth++;
+      else if (masked[k] === "]") {
+        depth--;
+        if (depth === 0) {
+          close = k;
+          break;
+        }
+      }
+    }
+    if (close === -1) break; // unbalanced source; take nothing further
+    // Read entries from the ORIGINAL text, but only at positions the mask
+    // agrees are string literals — so a bracket or quote inside a comment
+    // cannot contribute an entry.
+    const region = tsSrc.slice(open + 1, close);
+    const maskRegion = masked.slice(open + 1, close);
+    const entries: string[] = [];
+    const entry = /["']/g;
+    let mm: RegExpExecArray | null;
+    while ((mm = entry.exec(maskRegion))) {
+      const q = mm.index;
+      const quote = maskRegion[q];
+      const end = maskRegion.indexOf(quote, q + 1);
+      if (end === -1) break;
+      entries.push(region.slice(q + 1, end));
+      entry.lastIndex = end + 1;
+    }
+    arrays.push(entries);
+    re.lastIndex = close; // resume after this array, never inside it
+  }
+  return arrays;
+}
+
 export function parseManifestStringArray(tsSrc: string, field: string): string[] {
   const masked = maskStringsAndComments(tsSrc);
   const re = new RegExp(`(^|[{,\\s])${field}\\s*:\\s*\\[`, "g");
@@ -1842,57 +1892,6 @@ let _graphLoaded = false;
 const CHAPTER_POS_STRIDE = 1_000_000;
 const withinChapter = (pos: number): number => pos % CHAPTER_POS_STRIDE;
 
-/**
- * Drop `//` line comments from a manifest before its `blocks: [...]` arrays
- * are matched.
- *
- * The arrays are read with a non-greedy `\[([\s\S]*?)\]`, which stops at the
- * first `]` — including one inside a comment. In a real paper a comment
- * reading "…and it has `uses: []` …" truncated its section's array, and every
- * block listed after it vanished from `blockPos`: 45 of 3498 blocks corpus-wide,
- * across 7 chapters. A block with no position is silently exempt from
- * `detangler-no-forward-ref` (`myPos === undefined` returns `pass`), and edges
- * *pointing at* it are skipped too, so the checker reported clean on material it
- * had never looked at.
- *
- * The reverse also bit: a slug quoted inside a comment was counted as a real
- * entry, which both invented a block and advanced `within`, shifting every
- * later position in the chapter by one and corrupting every distance measured
- * from it.
- *
- * Quote-aware rather than a blunt `//.*$`, so a `"https://…"` inside a title
- * survives.
- */
-export function stripLineComments(src: string): string {
-  let out = "";
-  let quote: string | null = null;
-  for (let i = 0; i < src.length; i++) {
-    const c = src[i];
-    if (quote) {
-      out += c;
-      if (c === "\\") {
-        out += src[++i] ?? "";
-        continue;
-      }
-      if (c === quote) quote = null;
-      continue;
-    }
-    if (c === '"' || c === "'" || c === "`") {
-      quote = c;
-      out += c;
-      continue;
-    }
-    if (c === "/" && src[i + 1] === "/") {
-      // Keep the newline so line-oriented structure is unchanged.
-      while (i < src.length && src[i] !== "\n") i++;
-      out += "\n";
-      continue;
-    }
-    out += c;
-  }
-  return out;
-}
-
 function loadChapterGraph(): void {
   if (_graphLoaded) return;
 
@@ -1995,20 +1994,25 @@ function loadChapterGraph(): void {
       const ci = firstIdx + i;
       const manifestPath = join(base, dir, `${dir}.ts`);
       if (!existsSync(manifestPath)) return;
-      const mc = stripLineComments(readFileSync(manifestPath, "utf-8"));
+      // Read via the masking parser, not a regex over the raw text. The
+      // position map is what `detangler-no-forward-ref` and its siblings run
+      // on, and a block with no position reads as "not listed" and returns
+      // `pass` — so a mis-parse here does not produce a wrong answer, it
+      // produces a silent absence of checking.
+      const mc = readFileSync(manifestPath, "utf-8");
       let within = 0;
       let sectionIdx = 0;
-      for (const bm of mc.matchAll(/blocks\s*:\s*\[([\s\S]*?)\]/g)) {
-        for (const sm of bm[1].matchAll(/"([^"]+)"/g)) {
-          const lbl = slugToLabel.get(sm[1]);
+      for (const slugs of parseManifestStringArrays(mc, "blocks")) {
+        for (const slug of slugs) {
+          const lbl = slugToLabel.get(slug);
           if (lbl && !blockPos.has(lbl)) {
             blockPos.set(lbl, ci * CHAPTER_POS_STRIDE + within);
             blockSection.set(lbl, ci * CHAPTER_POS_STRIDE + sectionIdx);
+          }
+          within++;
         }
-        within++;
+        sectionIdx++;
       }
-      sectionIdx++;
-    }
     });
   }
 

--- a/scripts/tests/manifest-comment-parse.test.ts
+++ b/scripts/tests/manifest-comment-parse.test.ts
@@ -1,72 +1,75 @@
 import { describe, expect, test } from "bun:test";
-import { stripLineComments } from "../../content/pipeline/qa-checkers-extended";
+import { parseManifestStringArrays } from "../../content/pipeline/qa-checkers-extended";
 
 /**
- * Chapter manifests are read with a non-greedy `blocks: \[([\s\S]*?)\]`, so a
- * `]` anywhere inside a comment ends the array early and every block after it
- * disappears from the position map. A block with no position is silently exempt
- * from `detangler-no-forward-ref`, and edges pointing at it are skipped — the
- * checker reports clean on material it never looked at.
+ * The position map `loadChapterGraph` builds is what every detangler criterion
+ * runs on, and a block with no position reads as "not listed" and returns
+ * `pass`. So a mis-parse here does not produce a wrong answer — it produces a
+ * silent absence of checking, which nothing downstream can distinguish from a
+ * clean one.
  *
- * These pin the stripping that has to happen first.
+ * These cases came out of the corpus. They were originally pinned against a
+ * comment-stripping stopgap; they now run against `parseManifestStringArrays`,
+ * which reads every `blocks: [...]` in a chapter manifest by masking strings
+ * and comments and depth-scanning for the close.
  */
-const blocksOf = (src: string) =>
-  [...stripLineComments(src).matchAll(/blocks\s*:\s*\[([\s\S]*?)\]/g)].flatMap((m) =>
-    [...m[1].matchAll(/"([^"]+)"/g)].map((x) => x[1]),
-  );
-
-describe("stripLineComments", () => {
-  test("a ] inside a comment no longer truncates the array", () => {
-    // The real case: a note mentioning `uses: []` sat mid-array in mass-theory
-    // and hid every block below it.
+describe("chapter-manifest block arrays", () => {
+  test("a ] inside a comment does not truncate the array", () => {
+    // The live case: a note mentioning `uses: []` sat mid-array in mass-theory
+    // and hid every block below it from the checker.
     const src = `blocks: [
       "alpha",
       // four consumers are the EW blocks there, and it has \`uses: []\` today
       "beta",
       "gamma",
     ],`;
-    expect(blocksOf(src)).toEqual(["alpha", "beta", "gamma"]);
+    expect(parseManifestStringArrays(src, "blocks")).toEqual([["alpha", "beta", "gamma"]]);
   });
 
   test("a slug quoted inside a comment is not counted as a block", () => {
-    // This one is worse than a miscount: the phantom entry also advanced the
-    // position counter, shifting every later block in the chapter by one.
+    // Worse than a miscount: the phantom entry also advanced the position
+    // counter, shifting every later block in that chapter by one.
     const src = `blocks: [
       "alpha",
       // "ghost" was relocated to another chapter in July
       "beta",
     ],`;
-    expect(blocksOf(src)).toEqual(["alpha", "beta"]);
+    expect(parseManifestStringArrays(src, "blocks")).toEqual([["alpha", "beta"]]);
   });
 
-  test("a // inside a string is left alone", () => {
+  test("every section's array is returned, in source order", () => {
+    // The reason a single-array parser could not be dropped in: a chapter
+    // manifest holds one array per section and per subsection, and position is
+    // assigned by walking them in order.
+    const src = `
+      sections: [
+        { title: "one", blocks: ["a", "b"] },
+        { title: "two", blocks: ["c"], subsections: [
+          { title: "two-a", blocks: ["d", "e"] },
+        ] },
+      ],`;
+    expect(parseManifestStringArrays(src, "blocks")).toEqual([["a", "b"], ["c"], ["d", "e"]]);
+  });
+
+  test("a nested array does not end the scan early", () => {
+    const src = `blocks: ["a", ["b", "c"], "d"],`;
+    expect(parseManifestStringArrays(src, "blocks").length).toBe(1);
+    expect(parseManifestStringArrays(src, "blocks")[0]).toEqual(["a", "b", "c", "d"]);
+  });
+
+  test("a // inside a string literal is not treated as a comment", () => {
     const src = `title: "See https://example.com/docs", blocks: ["alpha"],`;
-    expect(stripLineComments(src)).toContain("https://example.com/docs");
-    expect(blocksOf(src)).toEqual(["alpha"]);
+    expect(parseManifestStringArrays(src, "blocks")).toEqual([["alpha"]]);
   });
 
-  test("handles all three quote characters", () => {
-    const src = `a: 'http://x/y', b: \`http://z/w\`, c: "http://p/q",`;
-    expect(stripLineComments(src)).toBe(src);
+  test("a field name inside a string does not win over the real one", () => {
+    // The unanchored-match bug: a quoted `blocks: [...]` in an authorNotes body
+    // used to be found first and read instead of the block's own field.
+    const src = `authorNotes: "we wrote blocks: [\\"ghost\\"] here once", blocks: ["alpha"],`;
+    expect(parseManifestStringArrays(src, "blocks")).toEqual([["alpha"]]);
   });
 
-  test("an escaped quote does not end the string early", () => {
-    const src = `title: "a \\" b // not a comment", blocks: ["alpha"],`;
-    expect(stripLineComments(src)).toContain("// not a comment");
-    expect(blocksOf(src)).toEqual(["alpha"]);
-  });
-
-  test("line structure is preserved so line-oriented parses still line up", () => {
-    const src = `one\n// two\nthree\n`;
-    expect(stripLineComments(src).split("\n").length).toBe(src.split("\n").length);
-  });
-
-  test("a comment at end of file without a trailing newline is dropped", () => {
-    expect(stripLineComments(`"alpha", // trailing`).trim()).toBe(`"alpha",`);
-  });
-
-  test("source with no comments is returned unchanged", () => {
-    const src = `blocks: [\n  "alpha",\n  "beta",\n],\n`;
-    expect(stripLineComments(src)).toBe(src);
+  test("no such field yields nothing", () => {
+    expect(parseManifestStringArrays(`title: "T",`, "blocks")).toEqual([]);
   });
 });


### PR DESCRIPTION
The proper parser landed in `1690d08`, but the **position map was never repointed at it**. So two parsers derived block positions from the same manifests by different means: `build-foreshadows` on the masking one, `loadChapterGraph` on the comment-stripping stopgap I added in #99.

That map is what every detangler criterion runs on, and a block with no position reads as *"not listed"* and returns **`pass`**. A mis-parse there doesn't produce a wrong answer — it produces a **silent absence of checking**, which nothing downstream can distinguish from a clean one. Leaving the weaker parser on that path was the wrong way round.

## Why it wasn't a drop-in

`parseManifestStringArray` finds only the **first** occurrence of a field. A chapter manifest holds one `blocks: [...]` per section *and* per subsection, and positions are assigned by walking them in order.

So this adds **`parseManifestStringArrays`** — same masking and depth-scan, returning every occurrence in source order — and `parseManifestStringArray` becomes its first element.

## `stripLineComments` deleted

No production caller left; only its own test. **The test survives, repointed at the real parser.** Its two cases came out of the corpus — a `]` inside a comment, a slug quoted inside a comment — and they're worth keeping as regressions whichever parser answers them.

Four cases added that the stopgap **could not have passed**:

- every section's array returned in order
- a nested array not ending the scan early
- a `//` inside a string literal
- **a field name inside a string not winning over the real field**

That last one is bug 2 from `parseManifestStringArray`'s own notes — a `blocks: [...]` quoted inside an `authorNotes` body. Comment-stripping never addressed it, because the decoy isn't in a comment.

## Verified, not assumed

Forward references on qou read **194 before and 194 after**, matching the 0-disagreement measurement I took before making the change. Behaviour-preserving: it removes a latent divergence without moving a single verdict.

677 tests pass, lint clean, generated docs in sync. Closes `fsl7` bullet 3.

---
_Generated by [Claude Code](https://claude.ai/code/session_016hQePZH4xA7gxL5eLTP5av)_