### PR TITLE
Four defects in how the platform reads its own state: stale fetch refs, a private position map, an invisible `uses[]`, and a missing editorial relation

### DIFF
--- a/.beans/folio-assistant-9giz--session-start-sweep-trusts-originmain-without-forc.md
+++ b/.beans/folio-assistant-9giz--session-start-sweep-trusts-originmain-without-forc.md
@@ -1,7 +1,7 @@
 ---
 # folio-assistant-9giz
 title: Session-start sweep trusts origin/main without forcing the tracking ref
-status: in-progress
+status: completed
 type: task
 created_at: 2026-08-15T14:28:04Z
 updated_at: 2026-08-15T14:28:04Z
@@ -60,9 +60,59 @@ so.
 
 ## Plan
 
-- [ ] Force the tracking ref at all six sites:
+- [x] Force the tracking ref at all six sites:
       `git fetch origin "+refs/heads/$B:refs/remotes/origin/$B"`
-- [ ] Sweep warns when `remote.origin.fetch` does not cover `refs/heads/*`,
+- [x] Sweep warns when `remote.origin.fetch` does not cover `refs/heads/*`,
       naming section 3 as blind rather than empty
-- [ ] End-to-end test: run the real sweep inside the fixture and assert the
+- [x] End-to-end test: run the real sweep inside the fixture and assert the
       count, so the fix is pinned by behaviour and not by a grep over source
+
+## Summary of Changes
+
+Seven executable sites, not six — `publish.yml`'s latexdiff step has the same
+shape (`git checkout "origin/$BASE_REF" -- main.tex` after a bare fetch), and
+`actions/checkout` narrows the refspec to the ref being built. Included as
+hardening; **not** verified failing in CI, since the step is
+`continue-on-error` and its failure mode is an absent diff PDF rather than a
+red run.
+
+`lake-cache.sh`, `lake-cache-fetch.sh` and `lean-env.sh` were checked and left
+alone — they already use explicit refspecs or read `FETCH_HEAD`, which is
+correct.
+
+### The test pins behaviour, not source text
+
+`scripts/tests/fetch-tracking-ref.test.ts` builds a fixture remote, narrows a
+clone's refspec, advances `main`, and runs the **real sweep script** in it.
+Against the pre-fix script two of its four tests fail (reports `0` where the
+truth is `3`; no sibling warning); against the fixed script all four pass. A
+grep for `refs/heads/` in the source would have passed either way, and this
+repo already carries a bean (`6fnb`) for tests that cannot fail.
+
+### The skills were the other half
+
+Agents are *instructed* to run `git fetch origin main` and compare by hand.
+Four runnable snippets fixed (coordinate §8c, integration-watcher ×2, watch §1);
+the rule and its two corollaries recorded in coordinate.md §8c, whose prose
+already promised a "fresh fetch" its command did not deliver.
+
+The two Monitor loops were deliberately left alone: they resolve the head via
+`git ls-remote` and pass raw SHAs to `git log`, so the bare fetch's objects
+suffice. That is the better pattern where detection is the goal, and it was
+already correct.
+
+### A second bug, found on the way, and worse than the first
+
+`watch.md` §5b — monitor-timeout recovery, marked MANDATORY — fetched `main`
+and then measured `origin/<BRANCH>`. A different ref from the one it refreshed,
+so `LAST != CUR` never fired: **the step whose whole purpose is to catch what
+was missed while the watcher was down reported 0 missed, every time.** This one
+does not need a narrowed refspec to be wrong; it is wrong in any clone.
+
+### What this does not fix
+
+The container's `qou` clone was repaired in place
+(`git config --replace-all remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'`),
+but nothing prevents a clone from being created that way again. The sweep now
+*reports* the condition at session start, which is the detection half. Whoever
+owns clone provisioning would have to close the other half.

--- a/.beans/folio-assistant-9giz--session-start-sweep-trusts-originmain-without-forc.md
+++ b/.beans/folio-assistant-9giz--session-start-sweep-trusts-originmain-without-forc.md
@@ -1,0 +1,68 @@
+---
+# folio-assistant-9giz
+title: Session-start sweep trusts origin/main without forcing the tracking ref
+status: in-progress
+type: task
+created_at: 2026-08-15T14:28:04Z
+updated_at: 2026-08-15T14:28:04Z
+---
+
+Found by using it. The `qou` clone in this container had
+
+```
+remote.origin.fetch = +refs/heads/claude/lean-vacuity-z3k1-drain-2026-08-09:refs/remotes/origin/claude/lean-vacuity-z3k1-drain-2026-08-09
+```
+
+— a refspec narrowed to **one sibling branch**. `git fetch origin main` then
+updates `FETCH_HEAD` and *not* `refs/remotes/origin/main`, so every comparison
+against `origin/main` in that worktree answered from a ref last written on
+**2026-08-09**. Six days and 1374 commits of `main` were invisible. `git
+ls-remote` said `619561a3`; `origin/main` said `7e45748e`.
+
+The fetch **succeeds** — exit 0 — so nothing looks wrong. This is the
+`mcp1` / `pzdv` signature again: an absent baseline reads as agreement, and the
+report is indistinguishable from a clean one.
+
+## Reproduced deterministically
+
+Fixture: bare upstream, two clones, narrow the second's refspec, advance `main`
+by 3, then ask the question the sweep asks.
+
+```
+sweep TODAY   (git fetch origin main)  -> HEAD..origin/main = 0   [origin/main = dbbf316]
+sweep FIXED   (explicit refspec)       -> HEAD..origin/main = 3   [origin/main = da64fbf]
+```
+
+## Blast radius: six call sites, and three of them *branch* off the stale ref
+
+Every one fetches a branch and then reads `origin/<branch>`:
+
+| site | what it gets wrong |
+| --- | --- |
+| `scripts/session-start-coord-sweep.sh:61` | "**origin/main ahead by: 0**" — every agent, every session |
+| `scripts/check-upstream.sh:18` | "origin/main has N new commits" with N=0 |
+| `deploy/self-update.sh:31` | decides "already up to date" and skips the update |
+| `scripts/lean-compile-audit.sh:94` | `git checkout -B "$BRANCH" origin/main` — **audits a stale tree** |
+| `scripts/upload-to-uploads.sh:133` | `git checkout -b … origin/$DEFAULT_BRANCH` — **new work on an old base** |
+| `scripts/upload-bib-papers.sh:122` | same |
+
+The last three are worse than a wrong number: they silently *produce* work
+rooted six days back, which then has to be rebased or is merged as a
+regression.
+
+## The sweep's section 3 cannot be fixed the same way
+
+"Recent sibling `claude/*` branches" reads `refs/remotes/origin/claude/*`
+directly. Under a narrowed refspec that tree is empty and the section prints
+nothing — the sweep says there are no siblings while ~200 exist. No per-branch
+refspec repairs that, so the sweep has to *detect* the narrow refspec and say
+so.
+
+## Plan
+
+- [ ] Force the tracking ref at all six sites:
+      `git fetch origin "+refs/heads/$B:refs/remotes/origin/$B"`
+- [ ] Sweep warns when `remote.origin.fetch` does not cover `refs/heads/*`,
+      naming section 3 as blind rather than empty
+- [ ] End-to-end test: run the real sweep inside the fixture and assert the
+      count, so the fix is pinned by behaviour and not by a grep over source

--- a/.beans/folio-assistant-i8ad--count-interprets-as-an-editorial-edge-in-the-conte.md
+++ b/.beans/folio-assistant-i8ad--count-interprets-as-an-editorial-edge-in-the-conte.md
@@ -1,7 +1,7 @@
 ---
 # folio-assistant-i8ad
 title: Count interprets as an editorial edge in the content graph
-status: in-progress
+status: completed
 type: task
 created_at: 2026-08-15T21:20:00Z
 updated_at: 2026-08-15T21:20:00Z
@@ -59,12 +59,12 @@ Three consequences, all of which the decision accepts:
 
 ## Plan
 
-- [ ] Parse `interprets` through the shared masked field scanner, not a new regex
-- [ ] Add as an editorial edge, tagged with its provenance so a consumer can
+- [x] Parse `interprets` through the shared masked field scanner, not a new regex
+- [x] Add as an editorial edge, tagged with its provenance so a consumer can
       still tell `uses` from `interprets`
-- [ ] Update the module contract and `AGENTS.md`, which both currently say the
+- [x] Update the module contract and `AGENTS.md`, which both currently say the
       editorial relation *is* `uses[]`
-- [ ] Report the cycle and the ten forward refs rather than absorbing them
+- [x] Report the cycle and the ten forward refs rather than absorbing them
       silently
 
 ## Summary of Changes

--- a/.beans/folio-assistant-i8ad--count-interprets-as-an-editorial-edge-in-the-conte.md
+++ b/.beans/folio-assistant-i8ad--count-interprets-as-an-editorial-edge-in-the-conte.md
@@ -1,0 +1,113 @@
+---
+# folio-assistant-i8ad
+title: Count interprets as an editorial edge in the content graph
+status: in-progress
+type: task
+created_at: 2026-08-15T21:20:00Z
+updated_at: 2026-08-15T21:20:00Z
+---
+
+Owner decision, 2026-08-15, choosing (a) from the options put in `prn1`.
+
+`buildContentGraph` builds editorial edges from `uses[]` **alone**. But
+`interprets:` is equally authored and equally editorial — a remark interpreting
+a proposition cannot be followed without having read it, which is precisely what
+the editorial relation means. So the graph answered "what must a reader have
+read?" while omitting 342 authored statements of exactly that, and the
+prune-damage audit inherited the omission: 37 still-lost edges are declared,
+just in the other field.
+
+> **Correction to my own framing when I proposed this.** I argued that the
+> detangler "already treats `interprets` as an ordering constraint", so the
+> graph and the checker disagreed. **That was wrong.** `loadChapterGraph`
+> explicitly excludes it — the comment at its `uses` parse reads "only the uses
+> array — NOT cites/interprets/own-label". The guard I was remembering was in my
+> own scratchpad reordering tool, not the platform. The change stands on the
+> plain reading above; it did not need the argument I gave it.
+
+## Measured before changing anything
+
+| | |
+|---|---|
+| blocks declaring `interprets` | 1041 |
+| target does not exist (dangling) | **0** |
+| already in `uses[]` as well | 699 |
+| **new graph edges** | **342** |
+
+Three consequences, all of which the decision accepts:
+
+- **Cycles: exactly one.**
+  `rem:frobenius-packing-density → conj:mass-volume-factorization →
+  rem:frobenius-packing-density`. The remark interprets the conjecture and the
+  conjecture's `uses[]` reaches back. The `uses[]` graph was made acyclic
+  deliberately (#4881), so this breaks that invariant — but it does so by
+  *revealing* a genuine editorial cycle, not by inventing one. It is an author
+  question, not something to paper over.
+- **Forward references: the gate does NOT move.** I predicted 194 → 204. Wrong,
+  for two reasons. `detangler-no-forward-ref` reads `loadChapterGraph`'s own
+  `uses`-only adjacency and never touches this module, so it is untouched —
+  measured directly from the checker, it is **195** before and after. (195, not
+  194: 194 was a figure taken before the `extractUses` fix, and I had also
+  corrected it once already in this arc.)
+
+  Ten `interprets` edges *do* point forward. The gate cannot see them. That is a
+  real gap, now visible, and left as a **separate** decision rather than folded
+  into this one — widening what the gate counts would move a number five merged
+  PRs were measured against, and that deserves its own call.
+- **Prune damage: 658 → 581.** More than the 37 direct, because the new edges
+  restore transitive reachability for others.
+
+## Plan
+
+- [ ] Parse `interprets` through the shared masked field scanner, not a new regex
+- [ ] Add as an editorial edge, tagged with its provenance so a consumer can
+      still tell `uses` from `interprets`
+- [ ] Update the module contract and `AGENTS.md`, which both currently say the
+      editorial relation *is* `uses[]`
+- [ ] Report the cycle and the ten forward refs rather than absorbing them
+      silently
+
+## Summary of Changes
+
+`interprets` is now an editorial edge. Measured on the `qou` corpus: **4820
+`uses` edges + 342 `interprets` edges**, matching the dry run exactly.
+
+Parsed with a new `parseStringField` in `uses-field.ts`, sharing the masked
+locate that `findArrayField` uses. Not a fresh regex: a naive
+`/interprets:\s*"([^"]+)"/` falls to both traps this area keeps producing — a
+comment before the field, and the field name quoted in prose — and this corpus
+discusses `interprets:` by name inside block bodies, so the second is live.
+
+Each editorial edge now carries `editorialField: "uses" | "interprets"`. A
+reader cannot tell the two apart and should not have to; a tool proposing an
+edit must, because `uses[]` is a curated list and `interprets` is a single
+structural claim.
+
+`AGENTS.md` and the module contract updated — both previously stated that the
+editorial relation *is* `uses[]`, which is now wrong rather than merely
+incomplete.
+
+### The one cycle, reported not absorbed
+
+`rem:frobenius-packing-density → conj:mass-volume-factorization →
+rem:frobenius-packing-density`. The remark interprets the conjecture; the
+conjecture's `uses[]` reaches back to the remark. The editorial graph was
+deliberately made acyclic in `#4881` and is no longer, so this needs an author
+decision — but it is a genuine editorial cycle **revealed**, not one introduced
+by the change. Nothing here papers over it.
+
+### What did not happen, contrary to my prediction
+
+The forward-reference gate does not move: **195 before, 195 after**, taken
+straight from `checkDetanglerNoForwardRef` over every block.
+`loadChapterGraph` builds its own `uses`-only adjacency and never touches
+`content-graph`. Ten `interprets` edges do point forward and that gate cannot
+see them — left as a separate decision, because widening what it counts moves a
+number five merged PRs were measured against.
+
+### Effect on `prn1`
+
+Prune damage on the union: **658 → 581**. More than the 37 directly-declared,
+because the new edges restore transitive reachability for others.
+
+tsc 0 · 702 tests / 0 fail · eslint clean.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -645,7 +645,13 @@ jobs:
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref || 'main' }}
         run: |
-          git fetch origin "$BASE_REF"
+          # Explicit refspec: the checkout below reads refs/remotes/origin/$BASE_REF,
+          # and a bare `git fetch origin <ref>` only refreshes (or creates) that
+          # tracking ref when the clone's configured refspec covers it —
+          # actions/checkout narrows it to the single ref being built. Defensive:
+          # this step is continue-on-error, so a missing ref shows up as an absent
+          # diff PDF rather than a failure. See bean 9giz.
+          git fetch origin "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
           git checkout "origin/$BASE_REF" -- main.tex
           latexpand main.tex > main-base-flat.tex 2>/dev/null
           # main-flat.tex came from the paper-pdf job's artefact

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,8 +124,19 @@ a background subagent, not the foreground.
 
 ## More
 
-- **`uses[]` is the EDITORIAL relation** — what a *reader* must have read to
-  follow a block. Agent/human maintained, part of the authored content.
+- **`uses[]` and `interprets` are the EDITORIAL relation** — what a *reader*
+  must have read to follow a block. Agent/human maintained, part of the authored
+  content. `uses[]` is the curated list; `interprets` states the same
+  reader-facing fact for a remark or example about one specific block, and since
+  2026-08-15 (bean `i8ad`) `content-graph.ts` counts both. Each editorial edge
+  carries `editorialField` so a tool proposing an *edit* can still tell which
+  field an author wrote — they are interchangeable to a reader, not to a writer.
+  **Two caveats worth knowing before you quote a number:**
+  `detangler-no-forward-ref` builds its own `uses`-only adjacency in
+  `loadChapterGraph` and does **not** consume `content-graph`, so it is
+  unaffected and ten forward-pointing `interprets` edges are outside what it
+  counts; and the graph is no longer acyclic — one genuine editorial cycle is
+  revealed rather than introduced (see `i8ad`).
   It is **not** the formal dependency graph; that is machine-derived from
   `lean.ref`. The two diverge legitimately in both directions (a proof invokes
   `simp` lemmas nobody reads about; a theorem is motivated by an example it
@@ -133,8 +144,8 @@ a background subagent, not the foreground.
   every ordering metric is computed from. For impact questions ("what breaks if
   this changes?") use the union via `content/pipeline/content-graph.ts`, whose
   accessors default to it. Auditing: the `uses` QA axis (mechanical) plus the
-  `uses-editorial-review` skill (human/agent). Contract: `BlockBase.uses` in
-  `schemas/types.ts`.
+  `uses-editorial-review` skill (human/agent). Contract: `BlockBase.uses` and
+  `RemarkBlock.interprets` in `schemas/types.ts`.
 - Lean tooling roadmap (Lean Atlas / Compass, Nazrin, refactor cluster,
   LeanDojo) — where each earns a place and how it wires into existing skills:
   `docs/proposals/llm-authoring-tool-integration.md`.

--- a/content/pipeline/content-graph.ts
+++ b/content/pipeline/content-graph.ts
@@ -7,10 +7,30 @@
  * A content block participates in **two different** dependency
  * relations, and conflating them is a category error:
  *
- * - **editorial** — from the block manifest's `uses[]` array. Answers
- *   "what must a reader have read to follow this block?" Authored:
- *   agent/human maintained, part of the content. See
- *   `schemas/types.ts` → `BlockBase.uses`.
+ * - **editorial** — from the block manifest's `uses[]` array **and its
+ *   `interprets` field**. Answers "what must a reader have read to follow
+ *   this block?" Authored: agent/human maintained, part of the content. See
+ *   `schemas/types.ts` → `BlockBase.uses` and `RemarkBlock.interprets`.
+ *
+ *   Both fields state the same reader-facing fact, so both are editorial: a
+ *   remark interpreting a proposition cannot be followed without it. This was
+ *   `uses[]` alone until 2026-08-15 (owner decision, bean `i8ad`), so the graph
+ *   answered "what must a reader have read?" while omitting 342 authored
+ *   statements of exactly that, and they were absent from every cone, energy
+ *   and reachability measure.
+ *
+ *   Note what this does **not** change: `loadChapterGraph` in
+ *   `qa-checkers-extended.ts` builds its own `uses`-only adjacency and does not
+ *   consume this module, so `detangler-no-forward-ref` is unaffected and its
+ *   count stands at 195. Ten `interprets` edges do point forward, and that gate
+ *   does not see them — a real gap, now visible, and deliberately left as a
+ *   separate decision rather than folded into this one.
+ *
+ *   Each editorial edge carries `editorialField` so a consumer can still tell
+ *   which field an author wrote. That matters for anything *proposing* an
+ *   edit: `uses[]` is a curated list, `interprets` is a single structural
+ *   claim, and they are not interchangeable to a writer even though they are
+ *   to a reader.
  * - **formal** — from the Lean dependency graph, resolved through each
  *   block's `lean.ref`. Answers "what does this proof actually invoke?"
  *   Machine-derived, never hand-written, never stored in a manifest.
@@ -57,7 +77,7 @@ import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { walkBlocks } from "./qa-utils";
 import { findContentRepoRoot } from "./repo-root";
-import { findUsesField } from "./uses-field";
+import { findUsesField, parseStringField } from "./uses-field";
 
 /** Provenance of a dependency edge. */
 export type EdgeKind = "editorial" | "formal";
@@ -85,6 +105,18 @@ export interface ContentEdge {
   /** Target block label (the dependency). */
   to: string;
   kind: EdgeKind;
+  /**
+   * Which authored field produced an editorial edge. Set only on
+   * `kind: "editorial"`.
+   *
+   * Both fields state a reader-facing prerequisite, so both are editorial — but
+   * they are not interchangeable to a *writer*. `uses[]` is a list a maintainer
+   * curates; `interprets` is a single structural claim ("this remark is about
+   * that proposition"). A tool proposing an edit must know which it is looking
+   * at, and evidence messages read better naming the field the author actually
+   * wrote.
+   */
+  editorialField?: "uses" | "interprets";
   /** Set only on `kind: "formal"`. */
   formalKind?: FormalEdgeKind;
   /**
@@ -390,7 +422,23 @@ export function buildContentGraph(rootDir: string, repoRoot?: string): ContentGr
         declToLabel.set(decl, b.label);
       }
     }
-    for (const u of uses) g.addEdge({ from: b.label, to: u, kind: "editorial" });
+    for (const u of uses) {
+      g.addEdge({ from: b.label, to: u, kind: "editorial", editorialField: "uses" });
+    }
+    // `interprets` is an editorial edge too: a remark interpreting a
+    // proposition cannot be followed without having read it, which is exactly
+    // what the editorial relation means. 342 authored dependencies were absent
+    // from every cone, energy and reachability measure until this landed.
+    // Owner decision 2026-08-15, bean i8ad.
+    const interprets = parseStringField(src, "interprets");
+    if (interprets) {
+      g.addEdge({
+        from: b.label,
+        to: interprets,
+        kind: "editorial",
+        editorialField: "interprets",
+      });
+    }
   }
 
   // ── Pass 2: formal edges from the Atlas cache ──────────────────

--- a/content/pipeline/content-graph.ts
+++ b/content/pipeline/content-graph.ts
@@ -57,6 +57,7 @@ import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { walkBlocks } from "./qa-utils";
 import { findContentRepoRoot } from "./repo-root";
+import { findUsesField } from "./uses-field";
 
 /** Provenance of a dependency edge. */
 export type EdgeKind = "editorial" | "formal";
@@ -167,15 +168,20 @@ const ATLAS_CACHE_REL = "docs/audits/lean-atlas-deps.json";
 export function extractUses(
   tsSrc: string,
 ): { entries: string[]; index: number } | undefined {
-  const m = tsSrc.match(/(?:^|[{,])\s*uses\s*:\s*\[([\s\S]*?)\]/);
-  if (!m) return undefined;
-  const body = m[1]
-    .replace(/\/\*[\s\S]*?\*\//g, "") // block comments
-    .replace(/\/\/[^\n]*/g, ""); // line comments
-  return {
-    entries: [...body.matchAll(/["']([^"']+)["']/g)].map((x) => x[1]),
-    index: m.index ?? 0,
-  };
+  // Delegates to the shared field scanner rather than carrying a fourth
+  // hand-rolled parser. The regex this replaced anchored on
+  // /(?:^|[{,])\s*uses\s*:\s*\[/ — the anchor was right (it stops a `uses:`
+  // quoted in an authorNotes body winning), but `\s*` does not span comments,
+  // so a `//` line between the previous field's comma and the `uses:` key made
+  // the match fail outright. The block then contributed NO editorial edges,
+  // indistinguishable from one that genuinely declares nothing: 27 blocks and
+  // 53 declared edges were invisible to every graph metric.
+  //
+  // `findUsesField` anchors on an identifier boundary instead and matches the
+  // close by bracket depth, so neither comments nor nesting can defeat it.
+  const f = findUsesField(tsSrc);
+  if (!f) return undefined;
+  return { entries: f.entries, index: f.fieldStart };
 }
 
 /**

--- a/content/pipeline/qa-checkers-extended.ts
+++ b/content/pipeline/qa-checkers-extended.ts
@@ -28,7 +28,7 @@ import { fileURLToPath } from "url";
 import { Q_USAGE_AUTOMATED_CHECKERS } from "./qa-checkers-q-usage";
 import { hashFile } from "./qa-utils";
 import { findContentRepoRoot, findPapers } from "./repo-root";
-import { stripArrayField } from "./uses-field";
+import { maskStringsAndComments, stripArrayField } from "./uses-field";
 
 const __filename = fileURLToPath(import.meta.url);
 // Resolve content-repo paths (witnesses under <repo>/computations, Lean
@@ -1469,51 +1469,11 @@ export function checkDetanglerSectionBand(
  * applies to the `uses:` parse in `loadChapterGraph`. Do not write a closing
  * bracket in a comment inside one of these arrays.
  */
-/**
- * Blank out string-literal CONTENTS and comment bodies, preserving every
- * index so offsets into the result are valid offsets into the original.
- *
- * Used to locate manifest array fields without being fooled by text that
- * merely looks like one. Handles `"`, `'` and backtick literals (with
- * escapes), plus `//` and block comments.
- */
-export function maskStringsAndComments(src: string): string {
-  const out = src.split("");
-  let i = 0;
-  const n = src.length;
-  const blank = (from: number, to: number) => {
-    for (let k = from; k < to && k < n; k++) if (out[k] !== "\n") out[k] = " ";
-  };
-  while (i < n) {
-    const c = src[i];
-    const d = src[i + 1];
-    if (c === "/" && d === "/") {
-      const end = src.indexOf("\n", i);
-      blank(i, end === -1 ? n : end);
-      i = end === -1 ? n : end;
-      continue;
-    }
-    if (c === "/" && d === "*") {
-      const end = src.indexOf("*/", i + 2);
-      blank(i, end === -1 ? n : end + 2);
-      i = end === -1 ? n : end + 2;
-      continue;
-    }
-    if (c === '"' || c === "'" || c === "`") {
-      let j = i + 1;
-      while (j < n) {
-        if (src[j] === "\\") { j += 2; continue; }
-        if (src[j] === c) break;
-        j++;
-      }
-      blank(i + 1, j); // keep the quotes, blank the contents
-      i = j + 1;
-      continue;
-    }
-    i++;
-  }
-  return out.join("");
-}
+// `maskStringsAndComments` now lives in `./uses-field`, next to the field
+// scanner that needs it, and is re-exported here so existing importers and
+// tests keep working. Two copies of a masking primitive is how the manifest
+// parsers diverged in the first place (see `fsl7`).
+export { maskStringsAndComments };
 
 /**
  * Extract a manifest array field's string entries.

--- a/content/pipeline/qa-checkers-extended.ts
+++ b/content/pipeline/qa-checkers-extended.ts
@@ -1892,6 +1892,62 @@ let _graphLoaded = false;
 const CHAPTER_POS_STRIDE = 1_000_000;
 const withinChapter = (pos: number): number => pos % CHAPTER_POS_STRIDE;
 
+/**
+ * Where a block sits, for callers outside this module.
+ *
+ * Three outcomes, kept distinct on purpose. The position map is the only
+ * source of block ordering in the platform, and it was private — so a consumer
+ * that needed to ask "where is this block?" had to hand-roll a second manifest
+ * parser. That duplication is what `fsl7` exists to prevent and what `#116`
+ * finished undoing for `loadChapterGraph` itself; re-creating it one caller out
+ * would be the same mistake with extra steps.
+ *
+ * - `ok` — the block is listed, and `pos` orders it within `chapter`.
+ * - `unlisted` — the graph loaded and this label is not in any manifest.
+ * - `unavailable` — the graph could not be built (no paper manifest, multi-paper
+ *   folio). **Nothing is known.**
+ *
+ * The last two are separated because conflating them is the recurring defect in
+ * this area: `checkDetanglerNoForwardRef` returns `pass` for an unpositioned
+ * block, so an unbuilt graph and a clean corpus produce the same report. A new
+ * consumer should not inherit that.
+ */
+export type BlockPlacement =
+  | { status: "ok"; chapter: string; pos: number; within: number }
+  | { status: "unlisted" }
+  | { status: "unavailable" };
+
+/** Placement of `label`, building the chapter graph on first call. */
+export function blockPlacement(label: string): BlockPlacement {
+  loadChapterGraph();
+  if (!_graphLoaded || !_blockPos || !_labelToChapter) return { status: "unavailable" };
+  const pos = _blockPos.get(label);
+  const chapter = _labelToChapter.get(label);
+  if (pos === undefined || chapter === undefined) return { status: "unlisted" };
+  return { status: "ok", chapter, pos, within: withinChapter(pos) };
+}
+
+/**
+ * Would an edge `from → to` be a **forward reference**?
+ *
+ * The rule `checkDetanglerNoForwardRef` applies, exported once rather than
+ * re-derived per caller: an edge counts as forward only when both blocks sit in
+ * the **same chapter** and the target comes later. A cross-chapter edge
+ * reflects the paper's intended chapter order and is not a local tangle.
+ *
+ * `undefined` means the question could not be answered — either block unlisted,
+ * or no graph. Callers must not read that as `false`; the whole point of
+ * costing a proposed `uses[]` edge is to avoid silently undoing ordering work,
+ * and "I could not check" is not "it is fine".
+ */
+export function pointsForward(from: string, to: string): boolean | undefined {
+  const a = blockPlacement(from);
+  const b = blockPlacement(to);
+  if (a.status !== "ok" || b.status !== "ok") return undefined;
+  if (a.chapter !== b.chapter) return false;
+  return b.pos > a.pos;
+}
+
 function loadChapterGraph(): void {
   if (_graphLoaded) return;
 

--- a/content/pipeline/uses-field.ts
+++ b/content/pipeline/uses-field.ts
@@ -245,6 +245,39 @@ export function findUsesField(text: string): UsesField | undefined {
 }
 
 /**
+ * A scalar string field's value — `interprets: "def:x"` — or `undefined`.
+ *
+ * Same masked locate as `findArrayField`, for the same reasons: a `//` note
+ * between the previous field and this one must not hide it, and the field name
+ * quoted inside a string must not win. A plain
+ * `/interprets:\s*"([^"]+)"/` would fall to both, and the second is not
+ * hypothetical — prose in this corpus discusses `interprets:` by name.
+ */
+export function parseStringField(text: string, name: string): string | undefined {
+  const scan = maskStringsAndComments(text);
+  let from = 0;
+  for (;;) {
+    const fieldStart = findFieldStart(scan, name, from);
+    if (fieldStart < 0) return undefined;
+    let i = fieldStart + name.length;
+    while (i < scan.length && scan[i] !== ":") i++;
+    i++;
+    while (i < scan.length && /\s/.test(scan[i])) i++;
+    const quote = scan[i];
+    if (quote !== '"' && quote !== "'") {
+      // Not a string literal — a template, a variable, a nested object.
+      from = fieldStart + name.length;
+      continue;
+    }
+    // The masked copy keeps quote positions, so the end is findable there and
+    // the value is sliced from the original.
+    const end = scan.indexOf(quote, i + 1);
+    if (end < 0) return undefined;
+    return text.slice(i + 1, end);
+  }
+}
+
+/**
  * Remove an array field's `name: [...]` text entirely, leaving the rest
  * intact. Used to blank downstream-reference fields before scanning the
  * remaining source for evidence about the block itself.

--- a/content/pipeline/uses-field.ts
+++ b/content/pipeline/uses-field.ts
@@ -33,6 +33,104 @@
 /** Identifier characters, for deciding what is a whole field name. */
 const IDENT = /[A-Za-z0-9_$]/;
 
+/**
+ * Blank out `//` and `/* *\/` comments, **keeping string contents intact**.
+ *
+ * Index-preserving: comment characters become spaces, newlines survive, so
+ * offsets computed on the result are valid in the original.
+ *
+ * String-aware, which is the whole difficulty: a `"https://example.com"` entry
+ * must not have its second half eaten as a line comment. Conversely a label
+ * quoted *inside* a comment must not be read as an entry — that is the `mcp1`
+ * defect, where a slug mentioned in a note became a phantom dependency and
+ * shifted every later position in its chapter.
+ *
+ * Distinct from `maskStringsAndComments`, which blanks string *contents* too —
+ * right for locating field names, useless for reading the entries out of one.
+ */
+/**
+ * Blank out string-literal CONTENTS and comment bodies, preserving every index
+ * so offsets into the result are valid offsets into the original.
+ *
+ * Used to **locate** manifest array fields without being fooled by text that
+ * merely looks like one — a `uses: ["def:ghost"]` written inside an
+ * `authorNotes` body must not win over the block's real field.
+ *
+ * Lives here rather than in the checkers because both the checkers and the
+ * content graph need it, and a second copy is how the parsers diverged in the
+ * first place.
+ */
+export function maskStringsAndComments(src: string): string {
+  const out = src.split("");
+  let i = 0;
+  const n = src.length;
+  const blank = (from: number, to: number) => {
+    for (let k = from; k < to && k < n; k++) if (out[k] !== "\n") out[k] = " ";
+  };
+  while (i < n) {
+    const c = src[i];
+    const d = src[i + 1];
+    if (c === "/" && d === "/") {
+      const end = src.indexOf("\n", i);
+      blank(i, end === -1 ? n : end);
+      i = end === -1 ? n : end;
+      continue;
+    }
+    if (c === "/" && d === "*") {
+      const end = src.indexOf("*/", i + 2);
+      blank(i, end === -1 ? n : end + 2);
+      i = end === -1 ? n : end + 2;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === "`") {
+      let j = i + 1;
+      while (j < n) {
+        if (src[j] === "\\") { j += 2; continue; }
+        if (src[j] === c) break;
+        j++;
+      }
+      blank(i + 1, j); // keep the quotes, blank the contents
+      i = j + 1;
+      continue;
+    }
+    i++;
+  }
+  return out.join("");
+}
+
+export function maskComments(src: string): string {
+  const out = src.split("");
+  const blank = (from: number, to: number) => {
+    for (let k = from; k < to && k < src.length; k++) if (out[k] !== "\n") out[k] = " ";
+  };
+  let i = 0;
+  while (i < src.length) {
+    const c = src[i];
+    const d = src[i + 1];
+    if (c === '"' || c === "'" || c === "`") {
+      // Skip the literal whole, honouring backslash escapes.
+      let k = i + 1;
+      while (k < src.length && src[k] !== c) k += src[k] === "\\" ? 2 : 1;
+      i = k + 1;
+      continue;
+    }
+    if (c === "/" && d === "/") {
+      const end = src.indexOf("\n", i);
+      blank(i, end === -1 ? src.length : end);
+      i = end === -1 ? src.length : end;
+      continue;
+    }
+    if (c === "/" && d === "*") {
+      const end = src.indexOf("*/", i + 2);
+      blank(i, end === -1 ? src.length : end + 2);
+      i = end === -1 ? src.length : end + 2;
+      continue;
+    }
+    i++;
+  }
+  return out.join("");
+}
+
 export interface UsesField {
   /** Offset of the `u` in `uses:`. */
   fieldStart: number;
@@ -106,26 +204,37 @@ function matchingBracket(text: string, open: number): number {
  * append one.
  */
 export function findArrayField(text: string, name: string): UsesField | undefined {
+  // LOCATE on a string- and comment-masked copy. Masking is index-preserving,
+  // so every offset found here is valid in `text`. Without it the scan is
+  // fooled by a `uses: [...]` written inside an `authorNotes` body, and it
+  // reads that block's phantom dependencies instead of the real ones.
+  const scan = maskStringsAndComments(text);
   let from = 0;
   for (;;) {
-    const fieldStart = findFieldStart(text, name, from);
+    const fieldStart = findFieldStart(scan, name, from);
     if (fieldStart < 0) return undefined;
     // Skip past the name + optional spaces + `:` to the value.
     let i = fieldStart + name.length;
-    while (i < text.length && text[i] !== ":") i++;
+    while (i < scan.length && scan[i] !== ":") i++;
     i++;
-    while (i < text.length && /\s/.test(text[i])) i++;
-    if (text[i] !== "[") {
+    while (i < scan.length && /\s/.test(scan[i])) i++;
+    if (scan[i] !== "[") {
       // A field that is not an array literal — a spread, a variable.
       // Not something this scanner can read; keep looking rather than
       // silently reporting the next array along.
       from = fieldStart + name.length;
       continue;
     }
-    const arrayEnd = matchingBracket(text, i);
+    const arrayEnd = matchingBracket(scan, i);
     if (arrayEnd < 0) return undefined;
+    // Mask comments before reading entries: a label quoted inside a note is
+    // not a dependency, and counting it invents one (the `mcp1` defect).
+    // Masking is index-preserving, so entries are still sliced from `text`.
     const inner = text.slice(i + 1, arrayEnd - 1);
-    const entries = [...inner.matchAll(/"([^"]*)"|'([^']*)'/g)].map((m) => m[1] ?? m[2]);
+    const masked = maskComments(inner);
+    const entries = [...masked.matchAll(/"([^"]*)"|'([^']*)'/g)].map(
+      (m) => (m[1] ?? m[2]) && inner.slice(m.index! + 1, m.index! + 1 + (m[1] ?? m[2]).length),
+    );
     return { fieldStart, arrayStart: i, arrayEnd, entries };
   }
 }

--- a/content/pipeline/validate.ts
+++ b/content/pipeline/validate.ts
@@ -166,8 +166,14 @@ async function loadBlocksFromDir(
       // dependency graph entirely. Three more carry `is_mathematics`. The same
       // class bit this schema once before — `of` itself was declared on the TS
       // type and missing from the Zod object, and was stripped until noticed.
-      for (const key of Object.keys(block as Record<string, unknown>)) {
-        if (key in (result.data as Record<string, unknown>)) continue;
+      //
+      // No casts here: `Object.keys` takes `object` and `in` takes any object
+      // type, so both operands work as they stand. The `as Record<string,
+      // unknown>` this first carried was not merely redundant — it does not
+      // typecheck, because `TableBlock` has no index signature and `Block` is a
+      // union containing it. That is what took `tsc` red on main.
+      for (const key of Object.keys(block)) {
+        if (key in result.data) continue;
         issues.push({
           level: "warning",
           block: name,

--- a/deploy/self-update.sh
+++ b/deploy/self-update.sh
@@ -28,7 +28,11 @@ COMPOSE_FILE="docker-compose.folio.yml"
 
 # ── 1. Check git for new commits ─────────────────────────────────
 cd "$REPO_ROOT"
-git fetch origin main --quiet 2>/dev/null
+# Explicit refspec — a bare `git fetch origin main` updates FETCH_HEAD but only
+# opportunistically refreshes refs/remotes/origin/main, so a clone with a
+# narrowed refspec would compare against a stale ref and decide it is already
+# up to date forever. See bean 9giz.
+git fetch origin '+refs/heads/main:refs/remotes/origin/main' --quiet 2>/dev/null
 
 LOCAL_SHA=$(git rev-parse HEAD 2>/dev/null)
 REMOTE_SHA=$(git rev-parse origin/main 2>/dev/null)

--- a/docs/reference/skill-instructions/coordinate.md
+++ b/docs/reference/skill-instructions/coordinate.md
@@ -384,11 +384,33 @@ leave `origin/main` unfetched. Before any push, force a fresh fetch
 and compute the upstream delta:
 
 ```bash
-git fetch origin main 2>/dev/null
+git fetch origin '+refs/heads/main:refs/remotes/origin/main' 2>/dev/null
 DELTA=$(git rev-list --count HEAD..origin/main)
 SIBS=$(git log --oneline ${MERGE_BASE:-$(git merge-base HEAD origin/main)}..origin/main 2>/dev/null | wc -l)
 echo "main is ${DELTA} commits ahead since branch base"
 ```
+
+> **Fetch the ref you are about to read, with an explicit refspec.**
+> `git fetch origin main` writes `FETCH_HEAD`; it refreshes
+> `refs/remotes/origin/main` only when the clone's configured
+> `remote.origin.fetch` covers that branch — and it **exits 0 either way**. A
+> clone whose refspec has been narrowed to one branch (this happens: a `qou`
+> clone was found pinned to a single sibling) answers every `origin/main`
+> question from a ref that has not moved for days, and nothing in the output
+> distinguishes that from being up to date. Use
+> `+refs/heads/<b>:refs/remotes/origin/<b>`, which is correct whatever the
+> clone is configured with.
+>
+> Two corollaries, both of which have bitten:
+>
+> - **Fetch the same ref you then read.** `watch.md §5b` fetched `main` and
+>   measured `origin/<BRANCH>`, so its mandatory missed-commit recovery
+>   reported 0 missed by construction.
+> - **A per-branch refspec does not repair `for-each-ref`.** Anything walking
+>   `refs/remotes/origin/claude/*` sees only what was fetched by name, so an
+>   empty result means "never fetched", not "no siblings". Check
+>   `git config --get-all remote.origin.fetch | grep 'refs/heads/\*'` before
+>   believing it.
 
 Decision matrix:
 

--- a/docs/reference/skill-instructions/integration-watcher.md
+++ b/docs/reference/skill-instructions/integration-watcher.md
@@ -250,8 +250,10 @@ NAME="<your-watcher-name>"
 |----------|-------|-------|----------|--------|
 EOF
 
-# Stash main baseline so §5f timeout-recovery can diff cleanly
-git fetch origin main 2>/dev/null
+# Stash main baseline so §5f timeout-recovery can diff cleanly.
+# Explicit refspec — see coordinate.md §8a: a bare fetch may not write
+# refs/remotes/origin/main, and a baseline read from an unwritten ref is not one.
+git fetch origin '+refs/heads/main:refs/remotes/origin/main' 2>/dev/null
 git rev-parse origin/main > "/tmp/_${NAME}_main.sha"
 ```
 
@@ -1089,7 +1091,8 @@ surface a structured suggestion to the user.
 2. **Compute the unreviewed-commits queue.** For each criterion `C`:
 
    ```bash
-   git fetch origin main 2>/dev/null
+   # Explicit refspec (coordinate.md §8a) — CUR below reads the tracking ref.
+   git fetch origin '+refs/heads/main:refs/remotes/origin/main' 2>/dev/null
    # jq --arg passes $C safely (no shell-quoting injection).
    LAST=$(jq -r --arg c "$C" '.reviewed_up_to[$c] // empty' "$QUEUE")
    CUR=$(git rev-parse origin/main)

--- a/docs/reference/skill-instructions/watch.md
+++ b/docs/reference/skill-instructions/watch.md
@@ -35,7 +35,11 @@ Before arming anything, record the current state so the §3 review
 compares cleanly:
 
 ```bash
-git fetch origin <BRANCH> 2>/dev/null
+# Explicit refspec, ALWAYS. `git fetch origin <BRANCH>` writes FETCH_HEAD and
+# refreshes refs/remotes/origin/<BRANCH> only when the clone's configured
+# refspec covers it — and exits 0 either way. A baseline read from a tracking
+# ref that was never updated is not a baseline.
+git fetch origin "+refs/heads/<BRANCH>:refs/remotes/origin/<BRANCH>" 2>/dev/null
 # Sanitize branch name for use in a file path: replace `/` with `_`
 # (e.g. `feature/foo` → `feature_foo`).  Without this, branches with
 # slashes silently land in non-existent directory trees.
@@ -283,8 +287,15 @@ timeout, main may have moved substantially. Mandatory steps on
 timeout-recovery:
 
 ```bash
-# Compare current baseline against actual main HEAD
-git fetch origin main 2>/dev/null
+# Compare the stashed baseline against the WATCHED BRANCH's actual head.
+#
+# This fetched `main` and then measured `origin/<BRANCH>` — a different ref
+# from the one it refreshed. The recovery step that exists to catch what was
+# missed while the watcher was down therefore compared the baseline against a
+# tracking ref nothing had updated, found them equal, and reported 0 missed
+# every time. Fetch the ref you are about to read, with an explicit refspec so
+# the tracking ref is actually written.
+git fetch origin "+refs/heads/<BRANCH>:refs/remotes/origin/<BRANCH>" 2>/dev/null
 SAFE=$(echo "<BRANCH>" | tr '/' '_')
 LAST=$(cat /tmp/_watch_baseline_${SAFE}.sha 2>/dev/null || echo "")
 CUR=$(git rev-parse origin/<BRANCH>)

--- a/scripts/check-upstream.sh
+++ b/scripts/check-upstream.sh
@@ -14,8 +14,11 @@ DECLINED_FILE="$STATE_DIR/declined-upstream-shas"
 mkdir -p "$STATE_DIR"
 touch "$DECLINED_FILE"
 
-# Fetch latest main (quiet, tolerate network failure)
-if ! git fetch origin main --quiet 2>/dev/null; then
+# Fetch latest main (quiet, tolerate network failure).
+# Explicit refspec: `git fetch origin main` refreshes refs/remotes/origin/main
+# only if the clone's configured refspec covers it, and exits 0 either way — so
+# a narrowed refspec makes every comparison below read a stale ref. See 9giz.
+if ! git fetch origin '+refs/heads/main:refs/remotes/origin/main' --quiet 2>/dev/null; then
   exit 0  # network issue — silently skip
 fi
 

--- a/scripts/lean-compile-audit.sh
+++ b/scripts/lean-compile-audit.sh
@@ -91,7 +91,11 @@ trap restore_state EXIT
 
 # ── Fetch origin/main + branch FIRST (before slow audit) ────────
 echo "Fetching origin/main..."
-git fetch origin main --quiet
+# Explicit refspec: the branch below is cut from refs/remotes/origin/main, and a
+# bare `git fetch origin main` refreshes that ref only when the clone's
+# configured refspec covers it. Under a narrowed refspec the audit would run
+# against a stale tree and report on code that is not what main holds. See 9giz.
+git fetch origin '+refs/heads/main:refs/remotes/origin/main' --quiet
 
 # Stash any uncommitted work so the audit branch is scoped to its own diff
 if ! git diff --quiet HEAD 2>/dev/null || ! git diff --quiet --cached 2>/dev/null; then

--- a/scripts/session-start-coord-sweep.sh
+++ b/scripts/session-start-coord-sweep.sh
@@ -58,7 +58,14 @@ CURRENT_BRANCH="$(git symbolic-ref --short HEAD 2>/dev/null || echo DETACHED)"
 DEFAULT_BRANCH="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')"
 [ -n "$DEFAULT_BRANCH" ] || DEFAULT_BRANCH=main
 
-if ! git fetch origin "$DEFAULT_BRANCH" >/dev/null 2>&1; then
+# Fetch with an EXPLICIT refspec. `git fetch origin <branch>` writes FETCH_HEAD
+# and updates refs/remotes/origin/<branch> only opportunistically — it does so
+# when the configured remote.origin.fetch covers that branch, and silently does
+# not when it doesn't. A clone whose refspec has been narrowed (this container
+# had a qou clone pinned to one sibling branch) then answers every question
+# below from a tracking ref that has not moved for days, while the fetch itself
+# exits 0. See bean 9giz.
+if ! git fetch origin "+refs/heads/$DEFAULT_BRANCH:refs/remotes/origin/$DEFAULT_BRANCH" >/dev/null 2>&1; then
   echo "## Coord sweep"
   echo
   echo "_origin/$DEFAULT_BRANCH fetch failed (offline?). Branch: \`$CURRENT_BRANCH\`._"
@@ -79,15 +86,34 @@ if [ "${NEW_ON_DEFAULT:-0}" -gt 0 ] 2>/dev/null; then
 fi
 
 # ── 3. Recent sibling agent branches ────────────────────────────────────────
-RECENT_SIBLINGS="$(git for-each-ref --sort=-committerdate \
-  --format='%(refname:short) %(committerdate:relative) %(subject)' \
-  refs/remotes/origin/claude 2>/dev/null \
-  | grep -v "$CURRENT_BRANCH" \
-  | head -8 || true)"
+# This reads the remote-tracking tree directly, so unlike §2 it cannot be
+# repaired by fetching one branch harder: if the clone's refspec does not cover
+# refs/heads/*, that tree is empty and "no siblings" means "never fetched any".
+# An empty section is the same shape as a quiet repo, so say which one it is.
+if git config --get-all remote.origin.fetch 2>/dev/null | grep -q 'refs/heads/\*'; then
+  RECENT_SIBLINGS="$(git for-each-ref --sort=-committerdate \
+    --format='%(refname:short) %(committerdate:relative) %(subject)' \
+    refs/remotes/origin/claude 2>/dev/null \
+    | grep -v "$CURRENT_BRANCH" \
+    | head -8 || true)"
 
-if [ -n "$RECENT_SIBLINGS" ]; then
-  echo "**Recent sibling \`claude/*\` branches:**"
-  echo "$RECENT_SIBLINGS" | sed 's/^/- /'
+  if [ -n "$RECENT_SIBLINGS" ]; then
+    echo "**Recent sibling \`claude/*\` branches:**"
+    echo "$RECENT_SIBLINGS" | sed 's/^/- /'
+    echo
+  fi
+else
+  echo "**Sibling branches: not visible from this clone.**"
+  echo
+  echo "\`remote.origin.fetch\` does not cover \`refs/heads/*\`, so"
+  echo "\`refs/remotes/origin/claude/*\` is whatever was fetched by name — not the"
+  echo "set of sibling branches. Treat this section as unread, not as empty."
+  echo
+  echo "Restore it with:"
+  echo '```sh'
+  echo "git config --replace-all remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'"
+  echo "git fetch origin --prune"
+  echo '```'
   echo
 fi
 

--- a/scripts/tests/block-placement.test.ts
+++ b/scripts/tests/block-placement.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { blockPlacement, pointsForward } from "../../content/pipeline/qa-checkers-extended";
+import { hasFolio } from "./helpers";
+
+/**
+ * `blockPlacement` / `pointsForward` exist so a caller can cost a proposed
+ * `uses[]` edge before writing it — restoring a pruned dependency adds a
+ * `uses[]` entry, and if the target sits later in the same chapter that is a
+ * forward reference, which is the metric the detangler arc has been reducing.
+ *
+ * The contract these pin is the three-way outcome. `unlisted` and
+ * `unavailable` must stay distinct, and `pointsForward` must answer
+ * `undefined` rather than `false` when it cannot tell — conflating "I could not
+ * check" with "it is fine" is the exact defect this area keeps producing
+ * (`checkDetanglerNoForwardRef` returns `pass` for an unpositioned block, so an
+ * unbuilt graph and a clean corpus read identically).
+ */
+describe("blockPlacement", () => {
+  test("a label nothing could ever list is never reported as ok", () => {
+    // True with or without a folio attached: with one, the graph builds and the
+    // label is `unlisted`; without one, the graph cannot build and it is
+    // `unavailable`. Either way it must not come back positioned.
+    const p = blockPlacement("def:not-a-real-block-xyzzy");
+    expect(p.status === "unlisted" || p.status === "unavailable").toBe(true);
+    expect(p.status).not.toBe("ok");
+  });
+
+  test("an unanswerable comparison is undefined, not false", () => {
+    expect(pointsForward("def:not-a-real-block-xyzzy", "def:also-not-real-xyzzy")).toBeUndefined();
+  });
+
+  test.skipIf(!hasFolio())("a real block resolves, and within is the intra-chapter index", () => {
+    // Any block the attached folio lists will do — take one from the graph via
+    // a label the corpus is known to carry.
+    const p = blockPlacement("def:crossing-energy");
+    if (p.status !== "ok") {
+      // The folio attached may not be qou; that is not a failure of this API.
+      expect(p.status === "unlisted").toBe(true);
+      return;
+    }
+    expect(p.pos).toBeGreaterThanOrEqual(0);
+    expect(p.within).toBe(p.pos % 1_000_000);
+    expect(p.chapter.length).toBeGreaterThan(0);
+  });
+
+  test.skipIf(!hasFolio())("a block never points forward to itself", () => {
+    const p = blockPlacement("def:crossing-energy");
+    if (p.status !== "ok") return;
+    expect(pointsForward("def:crossing-energy", "def:crossing-energy")).toBe(false);
+  });
+});

--- a/scripts/tests/fetch-tracking-ref.test.ts
+++ b/scripts/tests/fetch-tracking-ref.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { execFileSync, spawnSync } from "child_process";
+import { mkdtempSync, mkdirSync, cpSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join, resolve } from "path";
+
+/**
+ * `git fetch origin <branch>` writes FETCH_HEAD and refreshes
+ * `refs/remotes/origin/<branch>` only *opportunistically* — when the clone's
+ * configured `remote.origin.fetch` covers that branch. When it doesn't, the
+ * fetch still exits 0 and every later comparison against `origin/<branch>`
+ * answers from a ref that has not moved.
+ *
+ * That is not hypothetical. The `qou` clone in the container this was found in
+ * had its refspec narrowed to a single sibling branch, so the sweep reported
+ * "origin/main ahead by: 0" while main was six days and 1374 commits ahead.
+ *
+ * These tests run the REAL sweep script against a local fixture remote, so what
+ * is pinned is the number it prints — not the presence of a refspec string in
+ * the source, which a later rewrite could satisfy while still being wrong.
+ */
+
+const SWEEP = resolve(import.meta.dir, "..", "session-start-coord-sweep.sh");
+
+let root = "";
+let upstream = "";
+
+/** Narrow the refspec exactly as the qou clone had it: one branch, by name. */
+const NARROW = "+refs/heads/some-sibling:refs/remotes/origin/some-sibling";
+const WIDE = "+refs/heads/*:refs/remotes/origin/*";
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf-8" });
+}
+
+/**
+ * A clone of the fixture upstream with `refspec` configured and the sweep
+ * script installed at the path the script expects to find itself at (it
+ * resolves its repo root as `dirname($BASH_SOURCE)/..`, so the copy — not the
+ * cwd — is what selects the repo it reports on).
+ */
+function makeClone(name: string, refspec: string): string {
+  const dir = join(root, name);
+  git(root, "clone", "--quiet", upstream, dir);
+  git(dir, "config", "user.email", "t@example.com");
+  git(dir, "config", "user.name", "T");
+  git(dir, "config", "--replace-all", "remote.origin.fetch", refspec);
+  mkdirSync(join(dir, "scripts"), { recursive: true });
+  cpSync(SWEEP, join(dir, "scripts", "session-start-coord-sweep.sh"));
+  return dir;
+}
+
+function runSweep(dir: string): string {
+  const r = spawnSync("bash", [join(dir, "scripts", "session-start-coord-sweep.sh")], {
+    cwd: dir,
+    encoding: "utf-8",
+    timeout: 60_000,
+  });
+  return `${r.stdout ?? ""}${r.stderr ?? ""}`;
+}
+
+/** The "ahead by: N" the sweep reports, or null if it never printed one. */
+function aheadBy(out: string): number | null {
+  const m = out.match(/ahead by:\*\*\s+(\d+)\s+commit/);
+  return m ? Number(m[1]) : null;
+}
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), "fetch-tracking-ref-"));
+  upstream = join(root, "upstream.git");
+
+  git(root, "init", "--quiet", "--bare", "-b", "main", upstream);
+
+  const seed = join(root, "seed");
+  git(root, "clone", "--quiet", upstream, seed);
+  git(seed, "config", "user.email", "t@example.com");
+  git(seed, "config", "user.name", "T");
+  execFileSync("bash", ["-c", "echo one > f"], { cwd: seed });
+  git(seed, "add", "f");
+  git(seed, "commit", "--quiet", "-m", "c1");
+  git(seed, "push", "--quiet", "-u", "origin", "main");
+  // A sibling agent branch, so §3 has something real to find.
+  git(seed, "push", "--quiet", "origin", "main:refs/heads/claude/sibling-work");
+});
+
+afterAll(() => {
+  if (root) rmSync(root, { recursive: true, force: true });
+});
+
+/** Advance upstream main by `n` commits after the clones were taken. */
+function advanceUpstream(n: number): void {
+  const seed = join(root, "seed");
+  for (let i = 0; i < n; i++) {
+    execFileSync("bash", ["-c", `echo ${i} > f`], { cwd: seed });
+    git(seed, "commit", "--quiet", "-am", `advance-${i}`);
+  }
+  git(seed, "push", "--quiet", "origin", "main");
+}
+
+describe("session-start sweep: origin/<default> must be refreshed, not assumed", () => {
+  test("reports the true distance when the clone's refspec is narrowed", () => {
+    const clone = makeClone("narrow", NARROW);
+    advanceUpstream(3);
+
+    const out = runSweep(clone);
+
+    // The regression: a bare `git fetch origin main` leaves origin/main at the
+    // clone point here, and the sweep reported 0 — indistinguishable from a
+    // branch that is genuinely current.
+    expect(aheadBy(out)).toBe(3);
+  });
+
+  test("reports the true distance under a normal refspec too", () => {
+    // Each clone is taken at the current upstream tip, so the distance is
+    // exactly what this test pushes afterwards — not a running total.
+    const clone = makeClone("wide", WIDE);
+    advanceUpstream(2);
+
+    const out = runSweep(clone);
+
+    expect(aheadBy(out)).toBe(2);
+  });
+
+  test("a narrowed refspec is named as blind, not reported as no siblings", () => {
+    // §3 reads refs/remotes/origin/claude/* directly, so no per-branch fetch
+    // repairs it. An empty list and an unfetched tree look identical, and the
+    // sweep's job is to say which one it is.
+    const out = runSweep(makeClone("narrow-siblings", NARROW));
+
+    expect(out).toContain("Sibling branches: not visible from this clone");
+    expect(out).toContain("remote.origin.fetch");
+  });
+
+  test("with a normal refspec the sibling branch is listed and no warning fires", () => {
+    const out = runSweep(makeClone("wide-siblings", WIDE));
+
+    expect(out).toContain("claude/sibling-work");
+    expect(out).not.toContain("not visible from this clone");
+  });
+});

--- a/scripts/tests/interprets-editorial-edge.test.ts
+++ b/scripts/tests/interprets-editorial-edge.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { parseStringField } from "../../content/pipeline/uses-field";
+
+/**
+ * `interprets` became an editorial edge on 2026-08-15 (owner decision, bean
+ * `i8ad`). Before that the graph read `uses[]` alone while
+ * `detangler-no-forward-ref` already refused to let a block precede one it
+ * interprets — so a constraint was being enforced on a relation the graph did
+ * not have, and 342 authored dependencies were absent from every cone, energy
+ * and reachability measure.
+ *
+ * The field is parsed through the shared masked scanner rather than a fresh
+ * regex, because a naive `/interprets:\s*"([^"]+)"/` falls to both traps this
+ * area keeps producing: a comment before the field, and the field name quoted
+ * inside prose. Neither is hypothetical here — this corpus discusses
+ * `interprets:` by name in block bodies.
+ */
+describe("parseStringField", () => {
+  test("reads a plain scalar field", () => {
+    expect(parseStringField(`interprets: "def:x",`, "interprets")).toBe("def:x");
+  });
+
+  test("a comment before the field does not hide it", () => {
+    // The extractUses defect, in the scalar case: an anchor whose \s* cannot
+    // span a comment silently reports "no such field".
+    const src = `title: "T",\n  // this remark is about the proposition below\n  interprets: "prop:y",`;
+    expect(parseStringField(src, "interprets")).toBe("prop:y");
+  });
+
+  test("the field name quoted in prose does not win over the real field", () => {
+    const src = `body: "set interprets: \\"def:ghost\\" on the remark", interprets: "def:real",`;
+    expect(parseStringField(src, "interprets")).toBe("def:real");
+  });
+
+  test("a label mentioned only in a comment is not the value", () => {
+    const src = `// interprets: "def:ghost" was removed in July\n  interprets: "def:real",`;
+    expect(parseStringField(src, "interprets")).toBe("def:real");
+  });
+
+  test("an absent field is undefined", () => {
+    expect(parseStringField(`label: "rem:x",`, "interprets")).toBeUndefined();
+  });
+
+  test("a non-string value is skipped rather than mis-read", () => {
+    // A variable or template is not something this scanner can resolve; it must
+    // say so rather than returning a fragment of source as a label.
+    expect(parseStringField(`interprets: someVar,`, "interprets")).toBeUndefined();
+  });
+
+  test("the identifier boundary keeps a longer field name out", () => {
+    expect(parseStringField(`reinterprets: "def:no", interprets: "def:yes",`, "interprets"))
+      .toBe("def:yes");
+  });
+});

--- a/scripts/tests/uses-field-comments.test.ts
+++ b/scripts/tests/uses-field-comments.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import { maskComments, findUsesField, parseUsesField } from "../../content/pipeline/uses-field";
+import { extractUses, parseUses } from "../../content/pipeline/content-graph";
+
+/**
+ * The editorial graph is built from `uses[]`, and a block whose array cannot be
+ * parsed contributes no edges — which is indistinguishable from a block that
+ * genuinely declares nothing. So a parse failure here does not produce a wrong
+ * answer, it produces a silent absence of one, and every ordering, cone and
+ * reachability metric quietly under-counts.
+ *
+ * That is not hypothetical: `content-graph.extractUses` anchored on
+ * `/(?:^|[{,])\s*uses\s*:\s*\[/`, and `\s*` does not span comments — so a `//`
+ * note between the previous field's comma and the `uses:` key made the match
+ * fail outright. **27 blocks and 53 declared edges were invisible**, including
+ * `def:crossing-energy` and `def:borromean-baryon`, and a prune-damage audit
+ * built on this graph reported those blocks as declaring nothing.
+ */
+describe("uses[] parsing survives comments", () => {
+  const withCommentBeforeField = `export default proposition({
+  label: "prop:x",
+  title: "T",
+  // def:crossing-energy, which clause 2 reduces at Q = 0, is NOT listed:
+  // it is reached through def:coulomb-charge.
+  uses: ["def:coulomb-charge"],
+});`;
+
+  test("a comment between the previous field and uses: does not hide the array", () => {
+    // The regression. Before the fix this returned undefined.
+    expect(extractUses(withCommentBeforeField)?.entries).toEqual(["def:coulomb-charge"]);
+    expect(parseUses(withCommentBeforeField)).toEqual(["def:coulomb-charge"]);
+  });
+
+  test("labels named only in that comment are not picked up as dependencies", () => {
+    // The comment names def:crossing-energy; it is prose about why the edge is
+    // absent, not a declaration of it.
+    expect(parseUses(withCommentBeforeField)).not.toContain("def:crossing-energy");
+  });
+
+  test("a label quoted inside a comment INSIDE the array is not an entry", () => {
+    const src = `uses: [
+      "def:a",
+      // "def:ghost" was relocated in July
+      "def:b",
+    ],`;
+    expect(parseUsesField(src)).toEqual(["def:a", "def:b"]);
+  });
+
+  test("the field boundary still keeps causes/reuses out", () => {
+    const src = `causes: ["def:not-this"], uses: ["def:this"],`;
+    expect(parseUsesField(src)).toEqual(["def:this"]);
+  });
+
+  test("a uses: quoted inside an authorNotes body does not win", () => {
+    const src = `authorNotes: "we wrote uses: [\\"def:ghost\\"] once", uses: ["def:real"],`;
+    expect(parseUsesField(src)).toEqual(["def:real"]);
+  });
+
+  test("no uses field is undefined, not an empty array", () => {
+    // Writers depend on the distinction: rewriting an absent field appends one.
+    expect(findUsesField(`label: "prop:x",`)).toBeUndefined();
+    expect(extractUses(`label: "prop:x",`)).toBeUndefined();
+  });
+});
+
+describe("maskComments", () => {
+  test("a // inside a string literal is not a comment", () => {
+    const src = `["https://example.com/docs"]`;
+    expect(maskComments(src)).toBe(src);
+  });
+
+  test("comments are blanked, and offsets are preserved", () => {
+    const src = `a // note\nb`;
+    const out = maskComments(src);
+    expect(out).toBe(`a        \nb`);
+    expect(out.length).toBe(src.length);
+  });
+
+  test("block comments are blanked across lines, keeping newlines", () => {
+    const src = `a /* x\ny */ b`;
+    const out = maskComments(src);
+    expect(out.length).toBe(src.length);
+    expect(out).not.toContain("x");
+    expect(out.split("\n").length).toBe(2);
+  });
+
+  test("an escaped quote does not end the string early", () => {
+    const src = `"a\\"b" // c`;
+    const out = maskComments(src);
+    expect(out.startsWith(`"a\\"b"`)).toBe(true);
+    expect(out).not.toContain("c");
+  });
+});

--- a/scripts/upload-bib-papers.sh
+++ b/scripts/upload-bib-papers.sh
@@ -118,8 +118,11 @@ else
   echo "$ssh_probe" | head -2 >&2
 fi
 
-# Branch off main
-git fetch origin "$DEFAULT_BRANCH" --quiet 2>/dev/null || true
+# Branch off main. Explicit refspec: a bare `git fetch origin <branch>`
+# refreshes refs/remotes/origin/<branch> only when the clone's configured
+# refspec covers it, so the checkout below would silently cut from a stale
+# base. See bean 9giz.
+git fetch origin "+refs/heads/$DEFAULT_BRANCH:refs/remotes/origin/$DEFAULT_BRANCH" --quiet 2>/dev/null || true
 if git rev-parse --verify --quiet "$BRANCH" >/dev/null; then
   echo "[git] branch $BRANCH already exists locally; checking out"
   git checkout "$BRANCH"

--- a/scripts/upload-to-uploads.sh
+++ b/scripts/upload-to-uploads.sh
@@ -130,7 +130,11 @@ else
 fi
 
 # ─── Branch + commit + push ────────────────────────────────────
-git fetch origin "$DEFAULT_BRANCH" --quiet 2>/dev/null || true
+# Explicit refspec: the new branch is cut from origin/$DEFAULT_BRANCH below, and
+# a bare `git fetch origin <branch>` refreshes that tracking ref only when the
+# clone's configured refspec covers it — silently rooting the upload on a stale
+# base otherwise. See bean 9giz.
+git fetch origin "+refs/heads/$DEFAULT_BRANCH:refs/remotes/origin/$DEFAULT_BRANCH" --quiet 2>/dev/null || true
 
 UTC_YMD="$(date -u +%Y-%m-%d)"
 SAFE_NAME="$(echo "$TARGET" | sed 's/[^A-Za-z0-9._-]/-/g' | cut -c1-40)"

--- a/skills/folio-core/coordinate.md
+++ b/skills/folio-core/coordinate.md
@@ -381,11 +381,33 @@ leave `origin/main` unfetched. Before any push, force a fresh fetch
 and compute the upstream delta:
 
 ```bash
-git fetch origin main 2>/dev/null
+git fetch origin '+refs/heads/main:refs/remotes/origin/main' 2>/dev/null
 DELTA=$(git rev-list --count HEAD..origin/main)
 SIBS=$(git log --oneline ${MERGE_BASE:-$(git merge-base HEAD origin/main)}..origin/main 2>/dev/null | wc -l)
 echo "main is ${DELTA} commits ahead since branch base"
 ```
+
+> **Fetch the ref you are about to read, with an explicit refspec.**
+> `git fetch origin main` writes `FETCH_HEAD`; it refreshes
+> `refs/remotes/origin/main` only when the clone's configured
+> `remote.origin.fetch` covers that branch — and it **exits 0 either way**. A
+> clone whose refspec has been narrowed to one branch (this happens: a `qou`
+> clone was found pinned to a single sibling) answers every `origin/main`
+> question from a ref that has not moved for days, and nothing in the output
+> distinguishes that from being up to date. Use
+> `+refs/heads/<b>:refs/remotes/origin/<b>`, which is correct whatever the
+> clone is configured with.
+>
+> Two corollaries, both of which have bitten:
+>
+> - **Fetch the same ref you then read.** `watch.md §5b` fetched `main` and
+>   measured `origin/<BRANCH>`, so its mandatory missed-commit recovery
+>   reported 0 missed by construction.
+> - **A per-branch refspec does not repair `for-each-ref`.** Anything walking
+>   `refs/remotes/origin/claude/*` sees only what was fetched by name, so an
+>   empty result means "never fetched", not "no siblings". Check
+>   `git config --get-all remote.origin.fetch | grep 'refs/heads/\*'` before
+>   believing it.
 
 Decision matrix:
 

--- a/skills/folio-core/integration-watcher.md
+++ b/skills/folio-core/integration-watcher.md
@@ -255,8 +255,10 @@ NAME="<your-watcher-name>"
 |----------|-------|-------|----------|--------|
 EOF
 
-# Stash main baseline so §5f timeout-recovery can diff cleanly
-git fetch origin main 2>/dev/null
+# Stash main baseline so §5f timeout-recovery can diff cleanly.
+# Explicit refspec — see coordinate.md §8a: a bare fetch may not write
+# refs/remotes/origin/main, and a baseline read from an unwritten ref is not one.
+git fetch origin '+refs/heads/main:refs/remotes/origin/main' 2>/dev/null
 git rev-parse origin/main > "/tmp/_${NAME}_main.sha"
 ```
 
@@ -1094,7 +1096,8 @@ surface a structured suggestion to the user.
 2. **Compute the unreviewed-commits queue.** For each criterion `C`:
 
    ```bash
-   git fetch origin main 2>/dev/null
+   # Explicit refspec (coordinate.md §8a) — CUR below reads the tracking ref.
+   git fetch origin '+refs/heads/main:refs/remotes/origin/main' 2>/dev/null
    # jq --arg passes $C safely (no shell-quoting injection).
    LAST=$(jq -r --arg c "$C" '.reviewed_up_to[$c] // empty' "$QUEUE")
    CUR=$(git rev-parse origin/main)

--- a/skills/folio-core/watch.md
+++ b/skills/folio-core/watch.md
@@ -32,7 +32,11 @@ Before arming anything, record the current state so the §3 review
 compares cleanly:
 
 ```bash
-git fetch origin <BRANCH> 2>/dev/null
+# Explicit refspec, ALWAYS. `git fetch origin <BRANCH>` writes FETCH_HEAD and
+# refreshes refs/remotes/origin/<BRANCH> only when the clone's configured
+# refspec covers it — and exits 0 either way. A baseline read from a tracking
+# ref that was never updated is not a baseline.
+git fetch origin "+refs/heads/<BRANCH>:refs/remotes/origin/<BRANCH>" 2>/dev/null
 # Sanitize branch name for use in a file path: replace `/` with `_`
 # (e.g. `feature/foo` → `feature_foo`).  Without this, branches with
 # slashes silently land in non-existent directory trees.
@@ -280,8 +284,15 @@ timeout, main may have moved substantially. Mandatory steps on
 timeout-recovery:
 
 ```bash
-# Compare current baseline against actual main HEAD
-git fetch origin main 2>/dev/null
+# Compare the stashed baseline against the WATCHED BRANCH's actual head.
+#
+# This fetched `main` and then measured `origin/<BRANCH>` — a different ref
+# from the one it refreshed. The recovery step that exists to catch what was
+# missed while the watcher was down therefore compared the baseline against a
+# tracking ref nothing had updated, found them equal, and reported 0 missed
+# every time. Fetch the ref you are about to read, with an explicit refspec so
+# the tracking ref is actually written.
+git fetch origin "+refs/heads/<BRANCH>:refs/remotes/origin/<BRANCH>" 2>/dev/null
 SAFE=$(echo "<BRANCH>" | tr '/' '_')
 LAST=$(cat /tmp/_watch_baseline_${SAFE}.sha 2>/dev/null || echo "")
 CUR=$(git rev-parse origin/<BRANCH>)


### PR DESCRIPTION
Beans `fa/9giz` and `fa/i8ad`. Every one of these was found by *using* the platform on real content, not by reading the code — and all four share a signature: **an absent answer read as a clean one.**

`tsc 0` · **702 tests / 0 fail** · `eslint` clean · generated docs in sync · `origin/main` merged in and an ancestor.

---

## 1. `git fetch origin main` does not refresh `origin/main` (`9giz`)

The `qou` clone in this container had its fetch refspec narrowed to a single sibling branch, so `git fetch origin main` wrote `FETCH_HEAD` and left `refs/remotes/origin/main` untouched — six days and 1374 commits stale, while the fetch **exited 0**.

Seven sites read `origin/<branch>` straight after fetching it. Three of them *cut a branch* from it (`lean-compile-audit`, both upload scripts), so the failure isn't a wrong number — it roots work on a stale tree. Fixed uniformly with `+refs/heads/<b>:refs/remotes/origin/<b>`.

The sweep's sibling section couldn't be fixed that way — it walks `refs/remotes/origin/claude/*`, where an empty result means *never fetched*, not *no siblings*. It now detects the refspec and says the section is unread.

**A second bug, worse because it needs no narrowed refspec:** `watch.md` §5b (monitor-timeout recovery, marked MANDATORY) fetched `main` and then measured `origin/<BRANCH>` — a different ref from the one it refreshed. `LAST != CUR` never fired, so the step whose whole purpose is catching what was missed while the watcher was down reported **0 missed, every time**, in any clone.

Pinned by behaviour: `fetch-tracking-ref.test.ts` builds a fixture remote and runs the **real sweep** in it — 2 of 4 tests fail against the pre-fix script, all 4 pass after. A grep for `refs/heads/` would have passed either way.

## 2. Block placement had no accessor (`prn1` needed it)

The position map was private to `qa-checkers-extended.ts`, so a caller asking "where is this block?" had to hand-roll another manifest parser — the duplication `fsl7` exists to prevent.

`blockPlacement` returns three outcomes kept deliberately distinct: `ok`, `unlisted`, and `unavailable`. `pointsForward` exports the forward-reference rule once (same chapter **and** target later) and returns `undefined` — never `false` — when it can't tell. *"I could not check" is not "it is fine."*

## 3. A comment before `uses:` made 27 blocks declare nothing

`content-graph.extractUses` was a **fourth** hand-rolled parser anchored on `/(?:^|[{,])\s*uses\s*:\s*\[/`. The anchor's intent was right, but `\s*` doesn't span comments — so a `//` note between the previous field's comma and the `uses:` key made the match fail outright, and the block contributed **no editorial edges at all**.

**27 blocks, 53 declared edges**, invisible to every ordering, cone and reachability metric — including `def:crossing-energy`, `def:borromean-baryon`, and `rem:archimedean-stpart-strategy`, which a prune-damage audit built on this graph reported as declaring nothing.

Fixed by retiring the parser: `extractUses` delegates to `uses-field.ts`'s scanner, hardened on both sides — it **locates** on a string-masked copy (restoring the protection the old anchor gave) and **masks comments** when reading entries (killing the `mcp1` phantom-entry defect). `maskStringsAndComments` moves next to the scanner that needs it; two copies of a masking primitive is how these diverged to begin with.

It also vindicated an author: `prop:strangelet-crossing-energy` documents an edge as deliberately absent "because it is reached through `def:coulomb-charge`". A candidate list contradicted that, which shouldn't have been possible — the block's whole array was invisible.

## 4. `interprets` is an editorial edge (`i8ad`, owner decision)

The editorial relation answers *"what must a reader have read to follow this block?"* A remark interpreting a proposition can't be followed without it — so **342 authored dependencies** were outside the graph entirely.

Parsed via `parseStringField`, sharing the masked locate. Edges carry `editorialField` so a tool proposing an **edit** can still tell a curated list from a single structural claim; a *reader* can't and shouldn't have to.

**Two corrections to my own account of this change:**

- I argued the detangler already treated `interprets` as an ordering constraint. **It doesn't** — `loadChapterGraph` explicitly excludes it. The guard I remembered was in my own scratch tool. The change stands on the plain reading of the relation; it never needed that argument.
- I predicted forward references would go 194 → 204. **They don't move**: 195 before, 195 after, measured from `checkDetanglerNoForwardRef` over every block, because that checker builds its own `uses`-only adjacency and never touches this module.

**Two things this surfaces for an author, deliberately not absorbed:** one genuine editorial cycle (`rem:frobenius-packing-density ↔ conj:mass-volume-factorization` — revealed, not introduced), and ten forward-pointing `interprets` edges the gate cannot see. Widening the gate would move a number five merged PRs were measured against, so that's a separate call.

## Merge integration

`origin/main` merged in. One conflict, in `validate.ts`: two sessions independently fixed the same `tsc` breakage from #113. `7496081` dropped one impossible cast; this branch's `159e1d8` dropped both. Resolved to the superset — `in` takes any object type, so the second cast was redundant too — and taking the file wholesale lost nothing, since `7496081` was main's only change to it since the merge base.

## Net effect on the `qou` audit

Prune damage **785 → 581**. A quarter of the reported damage was never damage; the graph simply couldn't see the dependencies that were there.