### PR TITLE
wall-base-ring-minimal: 57% of the axis was checker noise (321 → 137 hits)

### DIFF
--- a/content/pipeline/qa-checkers-voice.ts
+++ b/content/pipeline/qa-checkers-voice.ts
@@ -661,9 +661,31 @@ export function checkBaseRingMinimal(
     .replace(/\/-[\s\S]*?-\/|--.*$/gm, "")
     .replace(/^\s*import\s+[^\n]*$/gm, "");
   // Archimedean side: a field / ℝ / division is legitimate there.
-  if (ARCHIMEDEAN_LEAN_RE.test(stripped)) {
+  //
+  // The skip is the UNION of the two archimedean signals, because neither
+  // alone covers it. `ARCHIMEDEAN_LEAN_RE` carries the arithmetic tactics
+  // (`linarith`/`norm_num`/`positivity`) but its `\(ℝ\)` / `: ℝ\b` tokens
+  // cannot fire on spaced Lean forms, since `\b` next to the non-word `ℝ`
+  // never matches; `ARCHIMEDEAN_TYPE_RE` catches `ℝ` in any position but
+  // deliberately omits those tactics (they discharge goals over any ordered
+  // field, so they are not evidence of an ℝ specialisation -- correct for
+  // `checkWallSide`'s mixed-signal split, which is where it is used).
+  //
+  // Swapping the narrow regex for the broad one -- the fix as originally
+  // proposed -- therefore trades one blind spot for another and scores
+  // WORSE: measured over `content/quantum-observable-universe`, 321 hits
+  // -> 445, because every generic file closing a literal with `norm_num`
+  // starts being scored. The union gives 137. See qou#4886 / qou#4901.
+  if (
+    ARCHIMEDEAN_LEAN_RE.test(stripped) ||
+    ARCHIMEDEAN_TYPE_RE.test(stripped)
+  ) {
     return { result: "pass", hits: [] };
   }
+  // A bare `⁻¹` is only a RING inverse if the file has ring structure at
+  // all; in a file with none it is an `Inv` on a group / `Equiv.Perm`, and
+  // asking for a "division-free restatement" there is meaningless.
+  const isAlgebraic = ALGEBRAIC_LEAN_RE.test(stripped);
   const hits: CheckerHit[] = [];
   // Blank out block comments (preserving line numbers) so docstring math
   // such as `α_EM = q⁻¹/(...)` does not false-flag.
@@ -676,7 +698,8 @@ export function checkBaseRingMinimal(
     const fieldHit = FIELD_MARKER_RE.test(code);
     // ring-element inverse `q⁻¹` (needs Inv/Field), but NOT a Units
     // coercion `↑q⁻¹` over a CommRing — that is the target pattern.
-    const ringInvHit = RING_INV_RE.test(code) && !/↑|Rˣ|Units/.test(code);
+    const ringInvHit =
+      isAlgebraic && RING_INV_RE.test(code) && !/↑|Rˣ|Units/.test(code);
     if (fieldHit || ringInvHit) {
       hits.push({
         file: leanPath,


### PR DESCRIPTION
Fixes the two `checkBaseRingMinimal` defects reported from qou#4886 → qou#4901 → qou#4917. All three reported them and none could fix them, because this is a separate repo and those sessions' GitHub scope did not include it.

Measured on the qou corpus (`content/quantum-observable-universe`, 1176 distinct `.lean`): **184 of 321 hits, across 44 of 93 files, were artifacts** — not §7c debt. That is what made the axis unworkable: an agent told to reduce the count on the worst-scoring file would have been pushed toward inventing a ring structure for a group-cohomology file to satisfy a regex.

## The two defects

**1. The bare-`⁻¹` branch fired on group inverses.** `RING_INV_RE` is just `/⁻¹/`, guarded only against a Units coercion, so a file with no ring structure at all still scored. `CoxeterReflectionCocycle.lean` took **29 hits with FIELD=0** — every one an `Inv` on a Coxeter group or `Equiv.Perm` in a ℤ/2-valued group-cohomology file. Now gated on `ALGEBRAIC_LEAN_RE`, which is already defined in this module and already used by `checkWallSide`. `FIELD_MARKER_RE` hits are untouched, so a genuine `Field`/`field_simp` file still scores exactly as before.

**2. The archimedean skip missed ℝ-typed files that avoid `Real.*`.** `ARCHIMEDEAN_LEAN_RE`'s `\(ℝ\)` / `: ℝ\b` tokens cannot fire on spaced Lean forms — `\b` next to the non-word character `ℝ` never matches. `bloch-group-quotient-construction.lean` took **25 hits** this way while being ℝ-typed throughout.

## The originally-proposed fix makes it worse — measured, not argued

qou#4886 proposed swapping the narrow `ARCHIMEDEAN_LEAN_RE` for `ARCHIMEDEAN_TYPE_RE`, reasoning that the two wall checkers ought to agree on what "archimedean side" means. They ought not, and the swap scores **worse than doing nothing**:

| variant | warn files | hits |
|---|---|---|
| before (unfixed) | 93 | 321 |
| fix 1 only | 63 | 191 |
| fix 1 + swap to `ARCHIMEDEAN_TYPE_RE` | 82 | **445** |
| fix 1 + **union** of both | 49 | **137** |

`ARCHIMEDEAN_TYPE_RE` deliberately omits `linarith`/`norm_num`/`positivity` — correct for `checkWallSide`'s mixed-signal split, where a tactic is not evidence of an ℝ specialisation, but wrong for a **skip**, where it is evidence the file is archimedean-side and a field is legitimate there. Swapping trades one blind spot for another: every generic file that closes a literal with `norm_num` starts being scored. The union keeps both signals, which is what the two defect reports actually asked for.

The rationale is recorded as a comment at the call site, since the swap is the intuitive move and will otherwise be re-proposed.

## Verification

- Acceptance: both files the defects were reported against — `CoxeterReflectionCocycle.lean` and `bloch-group-quotient-construction.lean` — now score **0 hits** each.
- Four full corpus sweeps, one per row of the table, via `scripts/check-base-ring.ts --sweep content/quantum-observable-universe` in litlfred/qou.
- No test file covers `checkBaseRingMinimal` in this repo; the sweep numbers above are the evidence.

## Downstream, not in this PR

Landing this invalidates the `wall-base-ring-minimal` sidecar verdict on the ~44 qou blocks whose score changes. Those need a `qa-sweep --only wall-base-ring-minimal` re-run in litlfred/qou, which I will do as a separate PR there once this merges — flagging it so the two do not land out of order.

Context: qou#5119.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7UaMoA5dvHUrvAAsNFdor)_