### PR TITLE
Document ingestion: pdf-structure + pdf-ocr (built, run) + options assessment

### DIFF
--- a/.beans/folio-assistant-p2en--formal-rag-document-ingestion-layer-options-assess.md
+++ b/.beans/folio-assistant-p2en--formal-rag-document-ingestion-layer-options-assess.md
@@ -43,3 +43,24 @@ Those ~20 are where Docling earns its place; the other 312 do not need it.
 Next: Stage B extractors (candidates.json) — math claims -> formalization
 candidates, WHO L1 -> recommendation blocks. Both propose, never write to
 content/.
+
+## Follow-ups landed (qou PR #5134)
+
+- corpus-grep checklist gains path 5, `library/*/sections/` — the 24.7M
+  chars are now reachable by the discipline that most needs them.
+- 43 references.ts entries marked `stage: "missing"` (claimed upload,
+  file never committed). Recorded, not repaired.
+- 246 uncited library documents queued in
+  `docs/audits/2026-08-15-library-uncited-triage.md`, ranked by extracted
+  formalizable content (a proxy for offered material, NOT relevance).
+
+## Stage 3 (Docling) is network-blocked, like Stage 2
+
+huggingface.co and cdn-lfs.huggingface.co return the same 403 policy
+denial as arxiv.org, and that is where Docling's layout/TableFormer/
+formula models come from. So BOTH network-dependent stages are dead in a
+sandbox, which is the strongest version of the argument for the
+pypdf-only Stage 1. Stage 3 is a workstation/CI stage: run where egress
+allows, commit artefacts, let sandboxed sessions consume them.
+
+Work list is ~20 documents (7 no-TOC, 17 unsectioned, 7 scanned).

--- a/.beans/folio-assistant-p2en--formal-rag-document-ingestion-layer-options-assess.md
+++ b/.beans/folio-assistant-p2en--formal-rag-document-ingestion-layer-options-assess.md
@@ -64,3 +64,24 @@ pypdf-only Stage 1. Stage 3 is a workstation/CI stage: run where egress
 allows, commit artefacts, let sandboxed sessions consume them.
 
 Work list is ~20 documents (7 no-TOC, 17 unsectioned, 7 scanned).
+
+## L1 extractor: logic tested, real layout still unproven
+
+who.int / iris.who.int / cdn.who.int are 403 like arxiv and huggingface,
+and no guideline-like document exists in the library, so validation
+against a real WHO L1 PDF is impossible in a sandboxed session. Added
+`scripts/tests/who-l1-extractor.test.py` instead: a synthetic fixture
+built from document-intake's documented L1 structure, asserting all five
+normative elements map to the right block kinds, GRADE + strength are
+detected, routing goes to l2-dak-authoring, and no formalization
+candidates are emitted.
+
+The negative half of that test found a real bug: RE_GRADE alternated on
+bare `\bhigh|moderate|low`, so "high malaria burden" in a nearby
+paragraph flagged a recommendation as GRADE-adjacent. Certainty levels
+must now bind to a certainty/quality/evidence noun.
+
+`candidates.json` still reports `"validated": false` for who-l1 and must
+keep doing so until a real guideline runs through it. Only affects the
+who-l1 class; the 332 math-class candidates are unchanged (extract_math
+never touches RE_GRADE).

--- a/.beans/folio-assistant-p2en--formal-rag-document-ingestion-layer-options-assess.md
+++ b/.beans/folio-assistant-p2en--formal-rag-document-ingestion-layer-options-assess.md
@@ -23,3 +23,23 @@ For WHO L2 DAK the generic-first ordering is destructive — BPMN/DMN/Excel
 have structured extractors in `smart-base` already.
 
 Next: author picks a stage to build (§10) and answers §11 Q1–Q3.
+
+## Stage 1 built and run (scripts/pdf-structure.py)
+
+Egress checked per the author's hunch: the MCP servers DO exist
+(`qou/.mcp.json` has paper-search-mcp + openalex-paper-search) but
+arxiv.org / export.arxiv.org / api.openalex.org all return 403 policy
+denials. PyPI is reachable. So the offline PDF path had to be Stage 1,
+not the network acquire — proposal §10 reordered accordingly.
+
+Whole-corpus run: 339 PDFs / 12,166 pages -> 332 docs, 0 failures,
+**7,313 sections / 24.7M chars greppable** (52 MB). Title 96.7% (vs
+DocInfo 37%), authors 72.6%, abstract 68.4%, arXiv id 64.2% from the
+page-1 stamp. TOC: 188 outline / 137 inferred / 7 none.
+
+Residue that defines Stage 3: 7 no-TOC, 17 unsectioned, 7 likely-scanned.
+Those ~20 are where Docling earns its place; the other 312 do not need it.
+
+Next: Stage B extractors (candidates.json) — math claims -> formalization
+candidates, WHO L1 -> recommendation blocks. Both propose, never write to
+content/.

--- a/.beans/folio-assistant-p2en--formal-rag-document-ingestion-layer-options-assess.md
+++ b/.beans/folio-assistant-p2en--formal-rag-document-ingestion-layer-options-assess.md
@@ -5,6 +5,21 @@ status: in-progress
 type: task
 priority: normal
 created_at: 2026-08-15T15:27:40Z
-updated_at: 2026-08-15T15:27:47Z
+updated_at: 2026-08-15T15:31:11Z
 ---
 
+
+## Assessment landed (PR #119)
+
+`docs/proposals/rag-document-ingestion.md`. Three measured constraints
+decided it: 230/339 uploads (68%) are arXiv (source beats OCR); host is
+cx23 = 2 vCPU/4 GB vs RAGFlow's 16 GB minimum (no co-hosting); and
+`content/**` is already semantically chunked with a `uses[]` graph (a RAG
+engine would hold a weaker second copy).
+
+Recommends acquire → parse (Docling) → route-by-class → index (LanceDB,
+embedded), with generic RAG as the *fallback* rather than the front door.
+For WHO L2 DAK the generic-first ordering is destructive — BPMN/DMN/Excel
+have structured extractors in `smart-base` already.
+
+Next: author picks a stage to build (§10) and answers §11 Q1–Q3.

--- a/.beans/folio-assistant-p2en--formal-rag-document-ingestion-layer-options-assess.md
+++ b/.beans/folio-assistant-p2en--formal-rag-document-ingestion-layer-options-assess.md
@@ -1,0 +1,10 @@
+---
+# folio-assistant-p2en
+title: 'Formal RAG document-ingestion layer: options assessment + integration contract'
+status: in-progress
+type: task
+priority: normal
+created_at: 2026-08-15T15:27:40Z
+updated_at: 2026-08-15T15:27:47Z
+---
+

--- a/content/pipeline/script-sidecars/bib-cite-resolves.script.json
+++ b/content/pipeline/script-sidecars/bib-cite-resolves.script.json
@@ -2,13 +2,13 @@
   "$schema": "qa-script/v1",
   "criterion_id": "bib-cite-resolves",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
+  "script_hash": "9b284af269a5",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
   "extra_inputs": [
     "content/schema/references.ts"
   ],
   "deps_hash": "c6456bf489a8",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/bib-cited-ref-has-screenshot.script.json
+++ b/content/pipeline/script-sidecars/bib-cited-ref-has-screenshot.script.json
@@ -2,13 +2,13 @@
   "$schema": "qa-script/v1",
   "criterion_id": "bib-cited-ref-has-screenshot",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
+  "script_hash": "d3202b194d13",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
   "extra_inputs": [
     "content/schema/references.ts"
   ],
   "deps_hash": "c6456bf489a8",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/bib-cited-ref-has-url.script.json
+++ b/content/pipeline/script-sidecars/bib-cited-ref-has-url.script.json
@@ -2,13 +2,13 @@
   "$schema": "qa-script/v1",
   "criterion_id": "bib-cited-ref-has-url",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
+  "script_hash": "a730f195e37d",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
   "extra_inputs": [
     "content/schema/references.ts"
   ],
   "deps_hash": "c6456bf489a8",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/bib-cited-ref-metadata-ok.script.json
+++ b/content/pipeline/script-sidecars/bib-cited-ref-metadata-ok.script.json
@@ -2,13 +2,13 @@
   "$schema": "qa-script/v1",
   "criterion_id": "bib-cited-ref-metadata-ok",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
+  "script_hash": "b7cc0ee7d062",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
   "extra_inputs": [
     "content/schema/references.ts"
   ],
   "deps_hash": "c6456bf489a8",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/canonical-cal4-acknowledged.script.json
+++ b/content/pipeline/script-sidecars/canonical-cal4-acknowledged.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "canonical-cal4-acknowledged",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "2ca3d3131a21",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/canonical-calibration-count.script.json
+++ b/content/pipeline/script-sidecars/canonical-calibration-count.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "canonical-calibration-count",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "c58bf6bca27b",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/canonical-ck-tiered-not-binary.script.json
+++ b/content/pipeline/script-sidecars/canonical-ck-tiered-not-binary.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "canonical-ck-tiered-not-binary",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "5fb9d70acf54",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/canonical-dilogarithm-context.script.json
+++ b/content/pipeline/script-sidecars/canonical-dilogarithm-context.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "canonical-dilogarithm-context",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "a065b3633f0f",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/canonical-no-hardcoded-observable.script.json
+++ b/content/pipeline/script-sidecars/canonical-no-hardcoded-observable.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "canonical-no-hardcoded-observable",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "96a346415fd2",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/canonical-no-negative-result-in-paper.script.json
+++ b/content/pipeline/script-sidecars/canonical-no-negative-result-in-paper.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "canonical-no-negative-result-in-paper",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "5c2b3e6cb87e",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/canonical-no-numerology.script.json
+++ b/content/pipeline/script-sidecars/canonical-no-numerology.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "canonical-no-numerology",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "49e4352f8aa9",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/canonical-script-not-deprecated.script.json
+++ b/content/pipeline/script-sidecars/canonical-script-not-deprecated.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "canonical-script-not-deprecated",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "89bcd82bd3ff",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/canonical-witness-pinned.script.json
+++ b/content/pipeline/script-sidecars/canonical-witness-pinned.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "canonical-witness-pinned",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "3050ae1775d6",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/cite-named-theorem.script.json
+++ b/content/pipeline/script-sidecars/cite-named-theorem.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "cite-named-theorem",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "f20ae4311d21",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/code_is_commented.script.json
+++ b/content/pipeline/script-sidecars/code_is_commented.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "code_is_commented",
   "source_file": "content/pipeline/qa-checkers-python.ts",
-  "script_hash": "a08e6e1469fd",
-  "script_commit_sha": "109a4ffe24513dd0f328bfb0e48bb4e88df08765",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "f29b20b77d60",
+  "script_commit_sha": "6c50eca618fd27d1528d2f27fbc9256f0d176d35",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/compute-lp-dual-present.script.json
+++ b/content/pipeline/script-sidecars/compute-lp-dual-present.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "compute-lp-dual-present",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "772b3e8dc930",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/compute-prop-has-consumer.script.json
+++ b/content/pipeline/script-sidecars/compute-prop-has-consumer.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "compute-prop-has-consumer",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "209764615ecb",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/compute-prop-has-probe.script.json
+++ b/content/pipeline/script-sidecars/compute-prop-has-probe.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "compute-prop-has-probe",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "2db4e9696dc0",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/compute-witness-exists.script.json
+++ b/content/pipeline/script-sidecars/compute-witness-exists.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "compute-witness-exists",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "47384e4fd1b4",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/compute_no_mpf_to_float_cast.script.json
+++ b/content/pipeline/script-sidecars/compute_no_mpf_to_float_cast.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "compute_no_mpf_to_float_cast",
   "source_file": "content/pipeline/qa-checkers-python.ts",
-  "script_hash": "a08e6e1469fd",
-  "script_commit_sha": "109a4ffe24513dd0f328bfb0e48bb4e88df08765",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "f29b20b77d60",
+  "script_commit_sha": "6c50eca618fd27d1528d2f27fbc9256f0d176d35",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/connected_to_ci_pipeline.script.json
+++ b/content/pipeline/script-sidecars/connected_to_ci_pipeline.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "connected_to_ci_pipeline",
   "source_file": "content/pipeline/qa-checkers-python.ts",
-  "script_hash": "a08e6e1469fd",
-  "script_commit_sha": "109a4ffe24513dd0f328bfb0e48bb4e88df08765",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "f29b20b77d60",
+  "script_commit_sha": "6c50eca618fd27d1528d2f27fbc9256f0d176d35",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/deprecated.script.json
+++ b/content/pipeline/script-sidecars/deprecated.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "deprecated",
   "source_file": "content/pipeline/qa-checkers-python.ts",
-  "script_hash": "a08e6e1469fd",
-  "script_commit_sha": "109a4ffe24513dd0f328bfb0e48bb4e88df08765",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "f29b20b77d60",
+  "script_commit_sha": "6c50eca618fd27d1528d2f27fbc9256f0d176d35",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/detangler-archimedean-wall.script.json
+++ b/content/pipeline/script-sidecars/detangler-archimedean-wall.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "detangler-archimedean-wall",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "3edb7220507a",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/detangler-block-tanglement.script.json
+++ b/content/pipeline/script-sidecars/detangler-block-tanglement.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "detangler-block-tanglement",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "080654c93cc4",
-  "script_commit_sha": "1a0072c9eb0be730cb6b90e0ae3a8867e0ec2126",
-  "last_run_at": "2026-08-10T19:59:29.342Z",
-  "last_run_sha": "b508ca3925ce303b7ea4090f82c03f54c6cffa3e",
+  "script_hash": "b1730597cf6e",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/detangler-graph-energy.script.json
+++ b/content/pipeline/script-sidecars/detangler-graph-energy.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "detangler-graph-energy",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "d8d7fa2bb342",
-  "script_commit_sha": "1a0072c9eb0be730cb6b90e0ae3a8867e0ec2126",
-  "last_run_at": "2026-08-10T19:59:29.342Z",
-  "last_run_sha": "b508ca3925ce303b7ea4090f82c03f54c6cffa3e",
+  "script_hash": "a8b5882fb213",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/detangler-no-dependency-cycle.script.json
+++ b/content/pipeline/script-sidecars/detangler-no-dependency-cycle.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "detangler-no-dependency-cycle",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "791537cf7c0d",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/detangler-no-forward-ref.script.json
+++ b/content/pipeline/script-sidecars/detangler-no-forward-ref.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "detangler-no-forward-ref",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "df7a68d30c46",
-  "script_commit_sha": "1a0072c9eb0be730cb6b90e0ae3a8867e0ec2126",
-  "last_run_at": "2026-08-10T19:59:29.342Z",
-  "last_run_sha": "b508ca3925ce303b7ea4090f82c03f54c6cffa3e",
+  "script_hash": "94430f4850ae",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/detangler-no-xchapter-fwd.script.json
+++ b/content/pipeline/script-sidecars/detangler-no-xchapter-fwd.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "detangler-no-xchapter-fwd",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "b01f61430d2a",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/detangler-section-band.script.json
+++ b/content/pipeline/script-sidecars/detangler-section-band.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "detangler-section-band",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "696ee4c80040",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/detangler-topic-coherence.script.json
+++ b/content/pipeline/script-sidecars/detangler-topic-coherence.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "detangler-topic-coherence",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "280aea9a61d8",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/does_not_default_to_float.script.json
+++ b/content/pipeline/script-sidecars/does_not_default_to_float.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "does_not_default_to_float",
   "source_file": "content/pipeline/qa-checkers-python.ts",
-  "script_hash": "a08e6e1469fd",
-  "script_commit_sha": "109a4ffe24513dd0f328bfb0e48bb4e88df08765",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "f29b20b77d60",
+  "script_commit_sha": "6c50eca618fd27d1528d2f27fbc9256f0d176d35",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/foreshadows-point-forward.script.json
+++ b/content/pipeline/script-sidecars/foreshadows-point-forward.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "foreshadows-point-forward",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "296e68ad2618",
-  "script_commit_sha": "1a0072c9eb0be730cb6b90e0ae3a8867e0ec2126",
-  "last_run_at": "2026-08-10T19:23:08.419Z",
-  "last_run_sha": "b508ca3925ce303b7ea4090f82c03f54c6cffa3e",
+  "script_hash": "39faba636029",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/framework-canonical.script.json
+++ b/content/pipeline/script-sidecars/framework-canonical.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "framework-canonical",
   "source_file": "content/pipeline/qa-checkers-voice.ts",
-  "script_hash": "12287b8916ca",
-  "script_commit_sha": "65c634965ee0c458d8a309cdb893a5b0accab8fe",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "cf3d4ea0ab0a",
+  "script_commit_sha": "0c22b648b32310d2d7847fa06d843542caac1b11",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/has_references_to_paper.script.json
+++ b/content/pipeline/script-sidecars/has_references_to_paper.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "has_references_to_paper",
   "source_file": "content/pipeline/qa-checkers-python.ts",
-  "script_hash": "a08e6e1469fd",
-  "script_commit_sha": "109a4ffe24513dd0f328bfb0e48bb4e88df08765",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "f29b20b77d60",
+  "script_commit_sha": "6c50eca618fd27d1528d2f27fbc9256f0d176d35",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/lean-ref-owns-decl.script.json
+++ b/content/pipeline/script-sidecars/lean-ref-owns-decl.script.json
@@ -2,13 +2,13 @@
   "$schema": "qa-script/v1",
   "criterion_id": "lean-ref-owns-decl",
   "source_file": "content/pipeline/qa-checkers-uses.ts",
-  "script_hash": "51e33f456ef9",
-  "script_commit_sha": "7b12c02ea38e6126e44e887d9e5f3242d0916315",
+  "script_hash": "b1c323c3439c",
+  "script_commit_sha": "f8585b0e839506a0b5745665e7480610a9093204",
   "extra_inputs": [
     "content/pipeline/content-graph.ts"
   ],
   "deps_hash": "c7f602946422",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/proof-build-green.script.json
+++ b/content/pipeline/script-sidecars/proof-build-green.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "proof-build-green",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "492c533d3fbe",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/proof-compile-cost.script.json
+++ b/content/pipeline/script-sidecars/proof-compile-cost.script.json
@@ -2,13 +2,13 @@
   "$schema": "qa-script/v1",
   "criterion_id": "proof-compile-cost",
   "source_file": "content/pipeline/qa-checkers-cost.ts",
-  "script_hash": "103ddbfa09ca",
-  "script_commit_sha": "6f3cf6a0c1d29dd9e8c3da3f6073a776ad58c456",
+  "script_hash": "3eb5d65c22b2",
+  "script_commit_sha": "f8585b0e839506a0b5745665e7480610a9093204",
   "extra_inputs": [
     "docs/audits/lean-profile.json"
   ],
   "deps_hash": "4df6f652b039",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/proof-conditional-class-banner.script.json
+++ b/content/pipeline/script-sidecars/proof-conditional-class-banner.script.json
@@ -2,13 +2,13 @@
   "$schema": "qa-script/v1",
   "criterion_id": "proof-conditional-class-banner",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
+  "script_hash": "5857d128ab93",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
   "extra_inputs": [
     "docs/audits/2026-05-09-conditional-class-banner.witness.json"
   ],
   "deps_hash": "8285870ddd65",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/proof-lean-compiles.script.json
+++ b/content/pipeline/script-sidecars/proof-lean-compiles.script.json
@@ -2,13 +2,13 @@
   "$schema": "qa-script/v1",
   "criterion_id": "proof-lean-compiles",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
+  "script_hash": "badf9b8e012f",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
   "extra_inputs": [
     "docs/audits/lean-compile-diagnostics.json"
   ],
   "deps_hash": "16d8c7a8984e",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/proof-no-axiom-growth.script.json
+++ b/content/pipeline/script-sidecars/proof-no-axiom-growth.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "proof-no-axiom-growth",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "e5bf3e1d32ef",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/proof-no-bare-sorries.script.json
+++ b/content/pipeline/script-sidecars/proof-no-bare-sorries.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "proof-no-bare-sorries",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "5f54e3f82f73",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/proof-no-conj-propagation-violation.script.json
+++ b/content/pipeline/script-sidecars/proof-no-conj-propagation-violation.script.json
@@ -2,13 +2,13 @@
   "$schema": "qa-script/v1",
   "criterion_id": "proof-no-conj-propagation-violation",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
+  "script_hash": "5ad4256cd7b2",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
   "extra_inputs": [
     "docs/audits/2026-05-01-p3-1-conjectural-propagation.witness.json"
   ],
   "deps_hash": "22292b18c779",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/proof-no-cost-regression.script.json
+++ b/content/pipeline/script-sidecars/proof-no-cost-regression.script.json
@@ -2,13 +2,13 @@
   "$schema": "qa-script/v1",
   "criterion_id": "proof-no-cost-regression",
   "source_file": "content/pipeline/qa-checkers-cost.ts",
-  "script_hash": "103ddbfa09ca",
-  "script_commit_sha": "6f3cf6a0c1d29dd9e8c3da3f6073a776ad58c456",
+  "script_hash": "96b9bdc29ac9",
+  "script_commit_sha": "f8585b0e839506a0b5745665e7480610a9093204",
   "extra_inputs": [
     "docs/audits/lean-profile.json"
   ],
   "deps_hash": "4df6f652b039",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/proof-no-placeholder-stub.script.json
+++ b/content/pipeline/script-sidecars/proof-no-placeholder-stub.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "proof-no-placeholder-stub",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "f20ae4311d21",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/proof-no-trivial-skeleton.script.json
+++ b/content/pipeline/script-sidecars/proof-no-trivial-skeleton.script.json
@@ -2,13 +2,13 @@
   "$schema": "qa-script/v1",
   "criterion_id": "proof-no-trivial-skeleton",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
+  "script_hash": "78239d5e66a5",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
   "extra_inputs": [
     "docs/audits/2026-05-08-trivial-skeleton-audit.json"
   ],
   "deps_hash": "21d9ff417741",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/proof-not-machine-trivial.script.json
+++ b/content/pipeline/script-sidecars/proof-not-machine-trivial.script.json
@@ -2,13 +2,13 @@
   "$schema": "qa-script/v1",
   "criterion_id": "proof-not-machine-trivial",
   "source_file": "content/pipeline/qa-checkers-triviality.ts",
-  "script_hash": "9c17b0ea8c56",
-  "script_commit_sha": "65c634965ee0c458d8a309cdb893a5b0accab8fe",
+  "script_hash": "81d5de6b388d",
+  "script_commit_sha": "96eaa7c2abe8b647e398d37b47af88b9bb730ebb",
   "extra_inputs": [
     "docs/audits/lean-triviality.json"
   ],
   "deps_hash": "458b1a3606a3",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/proof-substantive.script.json
+++ b/content/pipeline/script-sidecars/proof-substantive.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "proof-substantive",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "a5244d874f38",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/respects_archimedean_wall.script.json
+++ b/content/pipeline/script-sidecars/respects_archimedean_wall.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "respects_archimedean_wall",
   "source_file": "content/pipeline/qa-checkers-python.ts",
-  "script_hash": "a08e6e1469fd",
-  "script_commit_sha": "109a4ffe24513dd0f328bfb0e48bb4e88df08765",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "f29b20b77d60",
+  "script_commit_sha": "6c50eca618fd27d1528d2f27fbc9256f0d176d35",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/uses-editorial-hygiene.script.json
+++ b/content/pipeline/script-sidecars/uses-editorial-hygiene.script.json
@@ -3,12 +3,12 @@
   "criterion_id": "uses-editorial-hygiene",
   "source_file": "content/pipeline/qa-checkers-uses.ts",
   "script_hash": "1d50b09b0497",
-  "script_commit_sha": "7b12c02ea38e6126e44e887d9e5f3242d0916315",
+  "script_commit_sha": "f8585b0e839506a0b5745665e7480610a9093204",
   "extra_inputs": [
     "content/pipeline/content-graph.ts"
   ],
   "deps_hash": "c7f602946422",
-  "last_run_at": "2026-08-10T19:36:28.892Z",
-  "last_run_sha": "b508ca3925ce303b7ea4090f82c03f54c6cffa3e",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/uses-formal-coverage.script.json
+++ b/content/pipeline/script-sidecars/uses-formal-coverage.script.json
@@ -2,14 +2,14 @@
   "$schema": "qa-script/v1",
   "criterion_id": "uses-formal-coverage",
   "source_file": "content/pipeline/qa-checkers-uses.ts",
-  "script_hash": "51e33f456ef9",
-  "script_commit_sha": "7b12c02ea38e6126e44e887d9e5f3242d0916315",
+  "script_hash": "b7b208d4a0c4",
+  "script_commit_sha": "f8585b0e839506a0b5745665e7480610a9093204",
   "extra_inputs": [
     "docs/audits/lean-atlas-deps.json",
     "content/pipeline/content-graph.ts"
   ],
   "deps_hash": "f9b547e15cfd",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/uses_library_framework_appropriately.script.json
+++ b/content/pipeline/script-sidecars/uses_library_framework_appropriately.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "uses_library_framework_appropriately",
   "source_file": "content/pipeline/qa-checkers-python.ts",
-  "script_hash": "a08e6e1469fd",
-  "script_commit_sha": "109a4ffe24513dd0f328bfb0e48bb4e88df08765",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "f29b20b77d60",
+  "script_commit_sha": "6c50eca618fd27d1528d2f27fbc9256f0d176d35",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/variables_typed.script.json
+++ b/content/pipeline/script-sidecars/variables_typed.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "variables_typed",
   "source_file": "content/pipeline/qa-checkers-python.ts",
-  "script_hash": "a08e6e1469fd",
-  "script_commit_sha": "109a4ffe24513dd0f328bfb0e48bb4e88df08765",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "f29b20b77d60",
+  "script_commit_sha": "6c50eca618fd27d1528d2f27fbc9256f0d176d35",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/voice-agent-speak.script.json
+++ b/content/pipeline/script-sidecars/voice-agent-speak.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "voice-agent-speak",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "f20ae4311d21",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/voice-ai-slop.script.json
+++ b/content/pipeline/script-sidecars/voice-ai-slop.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "voice-ai-slop",
   "source_file": "content/pipeline/qa-checkers-voice.ts",
-  "script_hash": "12287b8916ca",
-  "script_commit_sha": "65c634965ee0c458d8a309cdb893a5b0accab8fe",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "20fe4199458f",
+  "script_commit_sha": "0c22b648b32310d2d7847fa06d843542caac1b11",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/voice-author-notes-pollution.script.json
+++ b/content/pipeline/script-sidecars/voice-author-notes-pollution.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "voice-author-notes-pollution",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "f20ae4311d21",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/voice-editorializing.script.json
+++ b/content/pipeline/script-sidecars/voice-editorializing.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "voice-editorializing",
   "source_file": "content/pipeline/qa-checkers-voice.ts",
-  "script_hash": "12287b8916ca",
-  "script_commit_sha": "65c634965ee0c458d8a309cdb893a5b0accab8fe",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "5a542b9ddb77",
+  "script_commit_sha": "0c22b648b32310d2d7847fa06d843542caac1b11",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/voice-emoji-content.script.json
+++ b/content/pipeline/script-sidecars/voice-emoji-content.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "voice-emoji-content",
   "source_file": "content/pipeline/qa-checkers-voice.ts",
-  "script_hash": "12287b8916ca",
-  "script_commit_sha": "65c634965ee0c458d8a309cdb893a5b0accab8fe",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "d3230d986a2b",
+  "script_commit_sha": "0c22b648b32310d2d7847fa06d843542caac1b11",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/voice-first-person-work.script.json
+++ b/content/pipeline/script-sidecars/voice-first-person-work.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "voice-first-person-work",
   "source_file": "content/pipeline/qa-checkers-voice.ts",
-  "script_hash": "12287b8916ca",
-  "script_commit_sha": "65c634965ee0c458d8a309cdb893a5b0accab8fe",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "6d35011108e2",
+  "script_commit_sha": "0c22b648b32310d2d7847fa06d843542caac1b11",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/voice-probe-narrative.script.json
+++ b/content/pipeline/script-sidecars/voice-probe-narrative.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "voice-probe-narrative",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "f20ae4311d21",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/voice-scholarly-default.script.json
+++ b/content/pipeline/script-sidecars/voice-scholarly-default.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "voice-scholarly-default",
   "source_file": "content/pipeline/qa-checkers-voice.ts",
-  "script_hash": "12287b8916ca",
-  "script_commit_sha": "65c634965ee0c458d8a309cdb893a5b0accab8fe",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "7e311e463351",
+  "script_commit_sha": "0c22b648b32310d2d7847fa06d843542caac1b11",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/voice-status-leak.script.json
+++ b/content/pipeline/script-sidecars/voice-status-leak.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "voice-status-leak",
   "source_file": "content/pipeline/qa-checkers-voice.ts",
-  "script_hash": "12287b8916ca",
-  "script_commit_sha": "65c634965ee0c458d8a309cdb893a5b0accab8fe",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "bbc03dd9670f",
+  "script_commit_sha": "0c22b648b32310d2d7847fa06d843542caac1b11",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/voice-status-section.script.json
+++ b/content/pipeline/script-sidecars/voice-status-section.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "voice-status-section",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "f20ae4311d21",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/voice-time-stamped-notes.script.json
+++ b/content/pipeline/script-sidecars/voice-time-stamped-notes.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "voice-time-stamped-notes",
   "source_file": "content/pipeline/qa-checkers-voice.ts",
-  "script_hash": "12287b8916ca",
-  "script_commit_sha": "65c634965ee0c458d8a309cdb893a5b0accab8fe",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "4dc9ee1f7d79",
+  "script_commit_sha": "0c22b648b32310d2d7847fa06d843542caac1b11",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/voice-title-scholarly.script.json
+++ b/content/pipeline/script-sidecars/voice-title-scholarly.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "voice-title-scholarly",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "dbe50250022f",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/voice-unicode-crash.script.json
+++ b/content/pipeline/script-sidecars/voice-unicode-crash.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "voice-unicode-crash",
   "source_file": "content/pipeline/qa-checkers-voice.ts",
-  "script_hash": "12287b8916ca",
-  "script_commit_sha": "65c634965ee0c458d8a309cdb893a5b0accab8fe",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "c35d809edf9a",
+  "script_commit_sha": "0c22b648b32310d2d7847fa06d843542caac1b11",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/wall-base-ring-minimal.script.json
+++ b/content/pipeline/script-sidecars/wall-base-ring-minimal.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "wall-base-ring-minimal",
   "source_file": "content/pipeline/qa-checkers-extended.ts",
-  "script_hash": "94a0ef92b287",
-  "script_commit_sha": "f80ade0d8a2551f16bc7de167b7cf30af0f4a188",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "f20ae4311d21",
+  "script_commit_sha": "15e39e3189312d27900335c4b01fb643c030cedd",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/content/pipeline/script-sidecars/wall-side-correct.script.json
+++ b/content/pipeline/script-sidecars/wall-side-correct.script.json
@@ -2,9 +2,9 @@
   "$schema": "qa-script/v1",
   "criterion_id": "wall-side-correct",
   "source_file": "content/pipeline/qa-checkers-voice.ts",
-  "script_hash": "12287b8916ca",
-  "script_commit_sha": "65c634965ee0c458d8a309cdb893a5b0accab8fe",
-  "last_run_at": "2026-08-07T15:25:15.693Z",
-  "last_run_sha": "1b82747f277723fe0f8bf372a3de88561240ed85",
+  "script_hash": "37b3fa59a3bc",
+  "script_commit_sha": "0c22b648b32310d2d7847fa06d843542caac1b11",
+  "last_run_at": "2026-08-16T11:16:26.887Z",
+  "last_run_sha": "8c73f57bd8c504687866b07f7308bee853839d44",
   "engine_version": "bun-1.3.11"
 }

--- a/docs/proposals/rag-document-ingestion.md
+++ b/docs/proposals/rag-document-ingestion.md
@@ -530,7 +530,22 @@ the ledger's reference join.
 absent. Two populations need it and `pypdf` will not serve them: the
 scanned/no-text-layer documents Stage 1 flags as `likely_scanned`, and
 the **WHO L1 guidelines**, where boxed recommendations and GRADE tables
-are layout facts a text extractor destroys (§9.1).
+are layout facts a text extractor destroys (§9.1). Measured work list
+from the Stage 1 run: **7 no-TOC, 17 unsectioned, 7 likely-scanned** —
+about twenty documents, not the other 312.
+
+> **Blocked in a sandboxed session, for the same reason as Stage 2.**
+> Docling's layout, TableFormer and formula models are fetched from
+> HuggingFace, and `huggingface.co` / `cdn-lfs.huggingface.co` return the
+> same 403 policy denial as `arxiv.org` (measured 2026-08-15). So *both*
+> network-dependent stages are unavailable where most agent work happens.
+>
+> This is the strongest form of the §2a argument. A pipeline whose first
+> step needs the network produces nothing in a sandbox; the `pypdf`-only
+> Stage 1 produced 7,313 sections there. Stage 3 is therefore a
+> **workstation / CI stage** — run it where egress allows, commit the
+> artefacts, and let sandboxed sessions consume them. The capability probe
+> is what makes that degrade honestly instead of silently.
 
 **Stage 3-bis — Route + Stage B extractors (§7, §7-bis).** The class
 router, the candidate extractors, and math normalisation (§8.3) as a

--- a/docs/proposals/rag-document-ingestion.md
+++ b/docs/proposals/rag-document-ingestion.md
@@ -1,0 +1,345 @@
+# Proposal — a document-ingestion layer, and where RAG actually belongs
+
+**Status:** proposal · **Bean:** `p2en`
+
+The folio has an informal ingestion path: documents land in a flat
+`uploads/` directory, an agent opens them one at a time, and what it
+learned survives only as a row in a source ledger and whatever prose it
+wrote. This proposal assesses the tools that would formalise that path —
+RAGFlow, Docling, MinerU, Marker, visual retrievers — and argues for a
+particular shape: **route by document class first, and fall through to
+generic RAG only when the structured path is unavailable.**
+
+That ordering is the substantive claim here. The obvious design is a
+generic RAG front-end with math and SMART-Guidelines specialisations
+bolted on downstream. Measured against this corpus, that design does the
+most expensive thing first and throws away structure it could have had
+for free.
+
+---
+
+## 1. What exists today
+
+Measured on `litlfred/qou` at `73784ff0`, not asserted:
+
+| Fact | Value |
+|---|---|
+| Documents in `uploads/` | 339 PDFs, 289 MB, flat — no per-document directory |
+| Documents whose filename is an arXiv ID | **230 (68 %)** — 147 new-style (`YYMM.NNNNN`), 83 old-style (`YYMMNNN`) |
+| Remaining | 109 journal PDFs (Elsevier `1-s2.0-*`, Numdam `AIF_*`/`BSMF_*`, misc scans) |
+| Documents with the `document-intake` per-document directory | **1** — the skill's own §"Per-upload state" note concedes this |
+| Rows in the source ledger `content/bib-qa-verifications.json` | 432 |
+| Open beans that are *manually read this one paper* | **15** |
+
+So the ledger works and the intake convention does not. The 15 beans are
+the tell: each is a human-scheduled unit of work to open a PDF and
+extract what it says. That is the labour an ingestion layer amortises,
+and it is the right thing to measure any candidate against.
+
+Retrieval today is `grep` over `content/` plus an agent reading a whole
+PDF into context. There are no embeddings, no chunk store, no index. The
+`/api/relevance/*` routes present the ledger; they do not search it.
+
+---
+
+## 2. Three constraints that decide most of this
+
+**(a) Two thirds of the corpus has a LaTeX source, and we are OCR-ing
+it.** For 230 documents the authoritative representation — the actual
+`.tex` the author wrote, with every macro, every `\label`, every
+alignment — is a fetch away from arXiv. Any PDF pipeline, however good,
+is reconstructing by inference something we can simply download. No
+formula-recognition model beats the source. This is not a RAG problem; it
+is an acquisition problem, and it is close to free.
+
+**(b) The deployment host cannot run RAGFlow.** `lean-mcp.config.json`
+pins `server_type: cx23` — a Hetzner shared-vCPU instance at **2 vCPU /
+4 GB RAM / 40 GB disk**, €3.49/mo. RAGFlow documents a minimum of **4
+cores / 16 GB RAM / 50 GB disk**, and its Docker Compose stack brings
+Elasticsearch (or Infinity), MySQL, Redis and MinIO. The RAM figure is
+not advisory — the vector engine freezes below it. Co-hosting is out.
+RAGFlow means a second box at roughly 4× the current hosting cost, or
+batch runs on a workstation.
+
+**(c) The folio's retrieval unit is the content block, not a chunk.**
+This is the one most likely to be missed. `content/**` is *already*
+chunked — by hand, semantically, one claim per file — and each chunk
+carries a typed manifest, an editorial `uses[]` edge set, a Lean ref, and
+QA sidecars. A generic RAG engine wants to own a corpus: ingest it, chunk
+it its own way, embed it, and serve it. Pointed at `content/`, it would
+discard a richer structure than it can build, and hold a second copy that
+drifts. **The folio does not need a chunker for its own content.** It
+needs one for *incoming* documents, which is a much smaller job.
+
+---
+
+## 3. Separate the four jobs "RAG" conflates
+
+Most of the confusion in tool comparisons comes from products that span
+different subsets of these. Assessed separately, the choices are clearer.
+
+```
+  ACQUIRE  ──▶  PARSE  ──▶  INDEX  ──▶  INGEST
+  best available   →structured  →searchable   →content objects
+  representation   document                   (folio-specific)
+```
+
+| Job | What it means here | Folio status |
+|---|---|---|
+| **Acquire** | Get the best representation that exists — LaTeX source, publisher XML, DAK spreadsheet — before settling for a PDF | **absent**; PDFs are dropped in by hand |
+| **Parse** | Whatever is left as PDF → structured document with layout, tables, formulae | **absent**; agent reads the PDF |
+| **Index** | Make 339 documents searchable without loading them into context | **absent** |
+| **Ingest** | Structured document → typed content blocks with `uses[]`, labels, citations | **exists** as `document-intake` / `paper-importer` skills; unautomated |
+
+The fourth is the folio-specific one and is not for sale. The first three
+are.
+
+---
+
+## 4. Options, by job
+
+### 4.1 Acquire
+
+| Tool | Fit |
+|---|---|
+| **`arxiv-to-prompt` / arxiv-latex MCP** | Fetches arXiv LaTeX source and flattens it for a model. Directly addresses constraint (a). MIT-ish, tiny, no infrastructure. |
+| **LaTeXML** | `.tex` → structured XML/HTML5 with MathML; the engine behind ar5iv. The rigorous route once source is in hand. Heavier, Perl, but battle-tested on all of arXiv. |
+| **`paper-search-mcp` / OpenAlex (`alex-mcp`)** | Already named in `document-intake.md §Stage 1` as the preferred fetch path. Gives canonical metadata + PDF in one call, which is also how the ledger's reference join gets populated without hand-typing. |
+| Publisher XML (JATS) | Available for some of the 109 non-arXiv items; Numdam and Elsevier both expose it. Worth a probe before OCR. |
+
+**This layer is the highest value per unit of effort in the whole
+proposal and needs no RAG engine at all.**
+
+### 4.2 Parse
+
+For what remains as PDF-only — the ~109 journal items, scans, and WHO L1
+narrative guidelines.
+
+| Tool | License | Runs on CPU | Math | Tables | Shape |
+|---|---|---|---|---|---|
+| **Docling** (IBM) | **MIT** | **yes** | formula enrichment → LaTeX | TableFormer, strong | **library**, emits `DoclingDocument`; also `docling-serve`, `docling-mcp` |
+| **MinerU** | AGPL-3.0 | GPU strongly preferred | **best in class** (UniMERNet) | good | service/CLI |
+| **Marker** (Datalab) | GPL + commercial threshold | GPU preferred | good (Surya/texify) | good | CLI |
+| **RAGFlow DeepDoc** | Apache-2.0, but bundled | no (part of the stack) | moderate | good | **inside a product** |
+| **Nougat** (Meta) | MIT | GPU | math-native | weak | largely unmaintained; hallucinates |
+
+Docling is the right default: it is MIT, it runs on the CPU we actually
+have, and — decisively for this repo — **it is a library that produces a
+cached artefact**, which is precisely the shape of the existing
+integration contract (§5). MinerU is better at formulae, but constraint
+(a) means the documents where formula recognition matters most are the
+ones we should not be OCR-ing at all. Keep MinerU as an escalation for a
+math-heavy scan with no source.
+
+### 4.3 Index
+
+| Option | Fit |
+|---|---|
+| **LanceDB** | Embedded, file-backed, no server, no daemon — fits a 4 GB host and commits alongside `.beans/`. Best default for a 339-document corpus. |
+| **Qdrant** | Excellent, but a service. Justified only once the corpus outgrows embedded. |
+| **`sqlite-vec` / pgvector** | Viable if a SQL store already exists. It doesn't here. |
+| **ColPali / ColQwen** (visual late-interaction) | Retrieves over *page images*, no text extraction — so figures, tables and formulae stay intact. Genuinely strong for exactly this corpus. But it is GPU-bound and stores ~1024 patch vectors per page. **Park it**; revisit if text retrieval demonstrably fails on diagram-bearing pages. |
+
+At 339 documents, retrieval quality is not the bottleneck — *having any
+index at all* is. Start embedded.
+
+### 4.4 Ingest
+
+Already specified by `document-intake.md` and `paper-importer.md`, and
+the block schema is the target. Nothing to buy. What changes is that
+Stages 2–3 stop being an agent reading a PDF and become a parse artefact
+the agent adjudicates.
+
+---
+
+## 5. How anything enters: the existing contract
+
+`docs/proposals/llm-authoring-tool-integration.md §1` already defines how
+an external tool is absorbed, and it applies unchanged:
+
+```
+capability probe          .claude/skills/capabilities/<tool>.json
+        ↓                 (detection + `requires`, gates --check-deps)
+cached ingest artefact    uploads/<id>/parsed.json  (SHA-stamped)
+        ↓
+registered criterion      content/pipeline/qa-criteria-registry.ts
+        ↓
+checker or skill          qa-checkers-*.ts | skills/**/<skill>.md
+        ↓
+watcher axis              WATCHER_CRITERIA_BY_AXIS → integration-backlog
+```
+
+Its four properties are what keep an ingestion layer honest, and two
+matter especially here:
+
+- **Absent tool ⇒ `n/a`, never a false pass.** A document nobody parsed
+  must not read as a document with nothing in it.
+- **Stale cache ⇒ `n/a`.** A parse artefact carries the source PDF's SHA,
+  so a re-uploaded or corrected document invalidates its own extraction
+  rather than silently serving the old one.
+
+This is also the argument against adopting a product that owns its own
+store: RAGFlow's index has no place to record *which* SHA it parsed in
+terms the folio's staleness machinery can read.
+
+---
+
+## 6. Where RAGFlow does fit
+
+Not as the primary, but it is not nothing:
+
+- Its **orchestrable ingestion pipeline** (0.22+) treats parsing as
+  pluggable, and can call Docling Serve (`DOCLING_SERVER_URL`) or MinerU
+  (`MINERU_APISERVER`) as backends. So "RAGFlow *or* Docling" is a false
+  choice — RAGFlow is an orchestrator + store + UI over parsers you would
+  pick anyway.
+- Its **template-based chunking** (one template per document class:
+  paper, manual, table, laws) is the right *idea*, and is worth stealing
+  even if the engine isn't adopted. It is §7's routing table by another
+  name.
+- If a **human-facing corpus-browsing UI** over `uploads/` becomes a real
+  requirement, RAGFlow supplies one, and that is a genuine argument for
+  standing it up on its own box.
+
+What it should not do is become the folio's retrieval layer for
+`content/`. That would put a second, weaker copy of the corpus behind an
+API and orphan the `uses[]` graph.
+
+---
+
+## 7. Route by document class
+
+The corrective this proposal argues for. Rather than *generic RAG →
+specialised*, the router runs **first**, and generic RAG is the fallback:
+
+| Class | Detected by | Route | Falls back to |
+|---|---|---|---|
+| arXiv paper | arXiv ID in filename or ledger | **fetch `.tex` source** → LaTeXML → blocks | Docling on the PDF |
+| Journal paper w/ XML | DOI → publisher JATS | **JATS** → blocks | Docling |
+| Journal PDF, no source | — | Docling → blocks | MinerU if formula-dense |
+| Scan / photograph | no text layer | Docling OCR, or vision | agent transcription |
+| **WHO L2 DAK** | DAK repo structure | **structured extractors** (§9) | — never generic |
+| **WHO L1 guideline** | narrative PDF | Docling → recommendation-boxed blocks | — |
+| Lean / formal source | `.lean` | Lean Atlas, not a text pipeline | — |
+
+Each row's *first* choice preserves structure the document already has.
+Generic RAG is what happens when that fails, not what happens first.
+
+---
+
+## 8. Math-specialised ingest
+
+The specialisation is mostly **not** a model — it is three disciplines:
+
+1. **Prefer source over pixels.** Covered above; 230 documents.
+2. **Preserve the label graph.** A `.tex` carries `\label`/`\ref`, which
+   is a dependency relation over the *source* document — and folio's
+   whole model is a dependency relation over blocks. An ingest that
+   flattens a paper to prose throws away the edges that make the imported
+   blocks navigable. LaTeXML keeps them; a PDF parser cannot recover them.
+3. **Normalise math to one dialect at the boundary.** Blocks are
+   KaTeX-rendered, and `AGENTS.md`'s render-QA gate already bans
+   `\operatorname{}` and unfenced align-family environments. Imported math
+   must pass the same battery, which means the ingest pipeline needs a
+   normalisation step — not an afterthought, a gate.
+
+Downstream, the existing Lean-side proposal (`llm-authoring-tool-integration.md`)
+already covers premise retrieval via LeanDojo and the formal dependency
+graph via Lean Atlas. Those are the math-specific *retrieval* story and
+need no duplication here.
+
+**Deliberately not proposed:** a math-aware embedding model. At 339
+documents, lexical + structural retrieval over well-parsed LaTeX will
+outperform any embedding of mangled PDF text, and costs nothing to run.
+
+---
+
+## 9. SMART-Guidelines-specialised ingest
+
+Here the "generic RAG first" ordering is not merely suboptimal — it is
+**destructive**, and this is the strongest instance of §7.
+
+A WHO Digital Adaptation Kit is *already machine-readable*. Its L2
+artefacts are structured by construction:
+
+| L2 artefact | Native form | Correct extractor |
+|---|---|---|
+| Data dictionary | Excel | `smart-base` DAK extraction scripts |
+| Decision-support logic | DMN / tables | DMN parser → `dmn-authoring` skill |
+| Business processes | **BPMN XML** | BPMN parser → `bpmn-authoring` skill |
+| Indicators | structured | DAK extractors |
+| Terminology | CodeSystem / ValueSet | FHIR terminology tooling |
+| Personas, scenarios, requirements | DAK components | DAK API logical models |
+
+WHO's `WorldHealthOrganization/smart-base` ships these extraction scripts
+under `input/scripts/` (slated to move to a dedicated repo), and the
+**DAK API** publishes logical models for the components. Running a BPMN
+file or a data-dictionary spreadsheet through a PDF-oriented RAG parser
+converts a graph and a table into prose — it is lossy in exactly the
+dimension that matters, and folio already has `l2-dak-authoring`,
+`bpmn-authoring`, `dmn-authoring` and `fhir-validation` skills expecting
+the structured form.
+
+**Generic ingest has exactly one job in this domain:** the **L1 narrative
+guideline PDF** — the published recommendations document that a DAK is
+derived *from*. That is unstructured prose with boxed recommendations and
+GRADE tables, and `document-intake.md` already specifies the mapping
+(recommendation → `definition`, remark → `remark`, good-practice
+statement → `proposition`, research priority → `conjecture`). Docling's
+table handling is the relevant strength there, because GRADE tables are
+the part a naive extractor mangles.
+
+So the SMART-Guidelines answer is: **structured extractors for L2/L3,
+Docling for L1 only, and no vector store in the loop at all** until
+someone wants to search across many guidelines.
+
+---
+
+## 10. Recommendation
+
+A staged adoption, cheapest and highest-value first. Each stage is
+independently useful and independently abandonable.
+
+**Stage 1 — Acquire (no new infrastructure).** Add an `acquire` step that
+resolves each `uploads/` document to its best available representation:
+arXiv source for the 230, publisher XML where available, PDF otherwise.
+Write the result into the per-document directory `document-intake.md`
+already specifies, and backfill the ledger's reference join from the
+fetched metadata. *This is the stage that pays for itself.*
+
+**Stage 2 — Parse (Docling).** Capability probe
+`.claude/skills/capabilities/docling.json`, a cached SHA-stamped
+`parsed.json` per document, degrading to `n/a` when absent. Covers the
+109 PDF-only items and the WHO L1 path.
+
+**Stage 3 — Route (§7).** The class router, plus math normalisation
+(§8.3) as a gate rather than a nicety.
+
+**Stage 4 — Index (LanceDB, embedded).** Only once Stages 1–2 have
+produced clean text worth embedding. Indexing bad extractions is how RAG
+systems get a reputation for confident wrongness.
+
+**Stage 5 — reassess RAGFlow.** With Stages 1–4 done, the open question
+is narrow and answerable: *is a browsing UI over the corpus worth a
+second VPS?* Ask it then, with the parse quality already known, rather
+than now.
+
+**Not recommended now:** ColPali/ColQwen (GPU, premature at this corpus
+size), a math-specific embedding model (§8), and pointing any RAG engine
+at `content/**` (§2c).
+
+---
+
+## 11. Open questions for the author
+
+1. Should the parse artefacts be **committed** (reproducible, greppable,
+   but adds tens of MB) or **gitignored and rebuilt** (clean tree, but a
+   fresh container re-parses)? The Lean cache precedent suggests
+   committing to an orphan branch.
+2. Is a **human browsing UI** over `uploads/` actually wanted? It is the
+   only thing that would justify RAGFlow's footprint, and the answer
+   changes Stage 5 entirely.
+3. Does the SMART-Guidelines side want ingest of **WHO's published DAKs**
+   (consuming `smart-base` extractors) or authoring support for **new**
+   DAKs (producing artefacts those extractors read)? The skills package
+   suggests the latter; §9 assumed both.

--- a/docs/proposals/rag-document-ingestion.md
+++ b/docs/proposals/rag-document-ingestion.md
@@ -44,13 +44,41 @@ PDF into context. There are no embeddings, no chunk store, no index. The
 
 ## 2. Three constraints that decide most of this
 
-**(a) Two thirds of the corpus has a LaTeX source, and we are OCR-ing
-it.** For 230 documents the authoritative representation — the actual
-`.tex` the author wrote, with every macro, every `\label`, every
-alignment — is a fetch away from arXiv. Any PDF pipeline, however good,
-is reconstructing by inference something we can simply download. No
-formula-recognition model beats the source. This is not a RAG problem; it
-is an acquisition problem, and it is close to free.
+**(a) Two thirds of the corpus has a LaTeX source — but the network
+often cannot reach it.** For 230 documents the authoritative
+representation — the actual `.tex` the author wrote, with every macro and
+every `\label` — exists on arXiv, and `qou/.mcp.json` already configures
+`paper-search-mcp` and `openalex-paper-search` to fetch it. **In a
+sandboxed session that path is dead:** measured 2026-08-15, the egress
+proxy returns 403 (organisation policy denial) for `arxiv.org`,
+`export.arxiv.org` and `api.openalex.org` alike. PyPI is reachable;
+arXiv is not.
+
+The correction this forces is important. Source-first is still right
+*when the network allows it*, so it stays the preferred route in §7. But
+it cannot be the **only** route, or ingestion stops dead in exactly the
+sandboxed sessions where most agent work happens. **The PDF path must be
+complete on its own, offline.**
+
+Fortunately the PDF carries more than expected — see §2a-bis.
+
+**(a-bis) The PDFs are in far better shape than "PDF" suggests.**
+Measured over all 339 with `pypdf`, **zero read errors across 12,437
+pages**:
+
+| Signal | Count | Consequence |
+|---|---|---|
+| Has a PDF outline (bookmarks) | **194 (57 %)** | the table of contents is *free* — no inference needed |
+| …with ≥ 5 entries | 181 (53 %) | deep enough to section the document |
+| Has a plausible DocInfo `/Title` | 126 (37 %) | too unreliable to trust — derive from text instead |
+| arXiv stamp in page-1 text | ~230 | **identity, version, primary class and date, offline** |
+
+That third row is why metadata must come from the text and not the
+DocInfo dictionary. The fourth is the one that rescues constraint (a):
+arXiv prints its own stamp down the left margin of page 1, in both eras
+(`arXiv:0706.2213v3 [math.GT] 9 Mar 2008` and `arXiv:hep-th/0001202v2`),
+so **a blocked network costs us the LaTeX source but not the paper's
+identity**. The ledger join still works offline.
 
 **(b) The deployment host cannot run RAGFlow.** `lean-mcp.config.json`
 pins `server_type: cx23` — a Hetzner shared-vCPU instance at **2 vCPU /
@@ -227,6 +255,113 @@ Generic RAG is what happens when that fails, not what happens first.
 
 ---
 
+## 7-bis. Where processed content goes
+
+The single most important design question, and the answer has to be the
+same shape for a knot-theory preprint and a WHO L1 guideline.
+
+### The layout
+
+A processed document stops being a flat PDF and becomes the per-document
+directory `document-intake.md` already specifies (followed today by 1 of
+339 documents — the convention is right, it was just never automated):
+
+```
+uploads/<doc-id>/
+  original.pdf            the upload, unchanged
+  structure.json          pdf-structure/v1 — metadata + TOC + section index
+  sections/               ← THE GREPPABLE ARTEFACT
+    sec-000-introduction.md
+    sec-001-preliminaries.md
+    ...
+  candidates.json         class-specific extraction (§8, §9) — proposals only
+  intake.json             pipeline state
+```
+
+`<doc-id>` is derived, not assigned: `arxiv-0706.2213v3` when the stamp is
+present, else the slugified filename. So the identifier is stable across
+re-uploads and is the join key to `content/bib-qa-verifications.json`.
+
+### Why plain Markdown, and not a vector store
+
+Because **this project's agents find things by grepping.** The qou
+`AGENTS.md` corpus-grep checklist is a STRICT gate before any agent may
+declare an item open, and it names four paths — `docs/audits/`,
+`content/`, `computations/`, `docs/coordination/`. `uploads/` is not one
+of them, and cannot be: it is 339 PDFs and 289 MB of binary.
+
+Extracting sections to `.md` **makes `uploads/` a fifth grep path**, which
+is a larger practical win than semantic search would be at this corpus
+size:
+
+```sh
+grep -rn "Reidemeister torsion" uploads/*/sections/
+# → uploads/arxiv-0706.2213v3/sections/sec-004-review-on-the-non-abelian.md:42
+```
+
+Each section file opens with YAML front-matter naming the document,
+section, page range and source SHA, so a grep hit is immediately citable
+— which is what the ledger and `-- Ref:` citations need anyway. A vector
+index (§4.3) can be layered on top later; it reads the same files. The
+files are the substrate, the index is an accelerator.
+
+### Two stages, and the boundary between them matters
+
+```
+original.pdf
+     │
+     ├── STAGE A — pdf-structure          domain-neutral, mechanical
+     │        structure.json + sections/*.md
+     │        no math logic, no WHO logic
+     │
+     └── STAGE B — class-specific extractor      routed by §7
+              ├─ math paper → candidates.json: claims, theorems,
+              │                 formalization candidates
+              └─ WHO L1     → candidates.json: recommendations,
+                                remarks, GRADE tables
+                          │
+                          └── ADJUDICATION (agent proposes, human accepts)
+                                  → content/<paper>/<block>.ts + .md
+```
+
+Stage A is shared and already built (`scripts/pdf-structure.py`). Stage B
+is where math and SMART Guidelines diverge, and it emits **candidates,
+never content**. That boundary is the anti-laundering rule applied to
+ingestion: a sentence extracted from someone else's paper is *a claim
+attributed to a source*, not a folio claim. It reaches `content/` only
+when an agent or the author promotes it, exactly as
+`document-intake.md §Stage 4` already requires.
+
+### Does it need Lean formalization?
+
+That is a Stage-B verdict on a math document, and it must be a
+**proposal**, not an action. `candidates.json` carries, per extracted
+claim: the section it came from, its page, the claim text, a kind guess
+(`definition`/`theorem`/`lemma`), and a `formalization_candidate` flag
+with a reason.
+
+What the flag means is narrow and worth stating, because the failure mode
+is obvious: **an extracted theorem is not a proved theorem.** It is
+someone else's result, and importing it creates a block that must cite
+them, not a Lean obligation the folio has discharged. So the routing is:
+
+1. **Relevant + already cited** → the ledger row gains the section
+   pointer; nothing else happens.
+2. **Relevant + not cited** → `paper-relevance-triage` verdict, then a
+   `references.ts` entry and a citation.
+3. **Relevant + the folio wants to *use* the result** → a bean, routed to
+   `formalizer`. The Lean either states it with `sorry` + `-- Ref:` to
+   the source (the honest "imported, not reproved" marker), or proves it.
+   Both are governed by the existing Strict Lean Discipline; ingestion
+   grants no exemption and creates no Lean by itself.
+
+The generalisation is that Stage B always answers "what does this
+document *offer*, and to which downstream skill?" For a math paper the
+answer routes to `formalizer`. For an L1 guideline it routes to
+`l2-dak-authoring`. Same shape, different registry.
+
+---
+
 ## 8. Math-specialised ingest
 
 The specialisation is mostly **not** a model — it is three disciplines:
@@ -290,8 +425,61 @@ table handling is the relevant strength there, because GRADE tables are
 the part a naive extractor mangles.
 
 So the SMART-Guidelines answer is: **structured extractors for L2/L3,
-Docling for L1 only, and no vector store in the loop at all** until
-someone wants to search across many guidelines.
+generic ingest for L1 only, and no vector store in the loop at all**
+until someone wants to search across many guidelines.
+
+### 9.1 The L1 path — narrative guideline → recommendations
+
+This is the one place in the SMART domain where the §7-bis machinery
+applies unchanged, and it is worth spelling out because it is the mirror
+image of the math path.
+
+**Stage A is identical.** A WHO L1 guideline is a long PDF with a real
+table of contents — usually a *better* one than a preprint has, since
+these are professionally typeset and almost always carry bookmarks. So
+`pdf-structure.py` sections it with no WHO-specific logic at all, and
+`uploads/who-<guideline>/sections/*.md` becomes greppable the same way.
+
+**Stage B is a different extractor.** Where the math extractor looks for
+theorem environments, the L1 extractor looks for WHO's normative
+furniture, which `document-intake.md` already maps:
+
+| Found in the L1 text | Candidate block | Label |
+|---|---|---|
+| boxed, numbered **Recommendation** | `definition` | `def:who-<g>-rec-<n>` |
+| **Remarks** bullets under it | `remark` | `rem:who-<g>-remark-<n>` |
+| **Good practice statement** | `proposition` | `prop:who-<g>-gps-<n>` |
+| **Research priority** | `conjecture` | `conj:who-<g>-research-<n>` |
+| Evidence summary narrative | `prose` | — |
+| **GRADE** certainty table | `diagram` + `meta.gradeLevel` | — |
+
+Two things make this harder than the math case, and both argue for
+Docling over a plain text extractor at Stage A for this document class:
+
+1. **Recommendations are boxes.** The normative statement is set in a
+   ruled box, and its boundary is what separates *the recommendation* from
+   the surrounding evidence discussion. Plain text extraction flattens the
+   box away and the boundary is lost. Docling's layout model keeps it.
+2. **GRADE tables carry the strength/certainty grading** (`strong` /
+   `conditional`, `⊕⊕⊕◯`), which the block's `meta` needs. That is table
+   structure recognition, which is precisely Docling's TableFormer
+   strength and precisely what naive extraction mangles.
+
+**Where it goes** is the same as §7-bis: `candidates.json` proposing
+blocks, then adjudication into `content/<guideline>/`. The verdict
+question differs — not "does this need Lean?" but "**is this L1
+recommendation already represented in the L2 DAK?**" — and it routes to
+`l2-dak-authoring` rather than `formalizer`. That is the whole
+generalisation: same two stages, same artefacts, a different registry of
+what to look for and a different downstream skill.
+
+A useful property falls out for free: once L1 recommendations are
+extracted as candidates with stable labels, the gap between an L1
+guideline and its L2 DAK becomes **diffable** — recommendations present
+in the narrative with no corresponding DAK decision-logic row are exactly
+the DAK's coverage gaps. That is a QA axis the existing watcher
+infrastructure could carry, and it is not reachable while the L1 document
+remains an opaque PDF.
 
 ---
 
@@ -300,20 +488,36 @@ someone wants to search across many guidelines.
 A staged adoption, cheapest and highest-value first. Each stage is
 independently useful and independently abandonable.
 
-**Stage 1 — Acquire (no new infrastructure).** Add an `acquire` step that
-resolves each `uploads/` document to its best available representation:
-arXiv source for the 230, publisher XML where available, PDF otherwise.
-Write the result into the per-document directory `document-intake.md`
-already specifies, and backfill the ledger's reference join from the
-fetched metadata. *This is the stage that pays for itself.*
+> **Ordering revised after the egress measurement (§2a).** An earlier
+> draft made network acquisition Stage 1. That was wrong for the sessions
+> that matter: with `arxiv.org` 403-blocked, an acquire-first pipeline
+> produces nothing in a sandbox. The offline PDF path is now Stage 1, and
+> network acquisition is an *enrichment* that runs when it can.
 
-**Stage 2 — Parse (Docling).** Capability probe
-`.claude/skills/capabilities/docling.json`, a cached SHA-stamped
-`parsed.json` per document, degrading to `n/a` when absent. Covers the
-109 PDF-only items and the WHO L1 path.
+**Stage 1 — Structure, offline (`scripts/pdf-structure.py`, built).**
+PDF → `structure.json` + `sections/*.md`, pure `pypdf`, no network, no
+GPU, no service. Delivers the metadata/TOC/section split and — the
+practical win — makes `uploads/` greppable (§7-bis). Works in every
+session regardless of egress policy.
 
-**Stage 3 — Route (§7).** The class router, plus math normalisation
-(§8.3) as a gate rather than a nicety.
+**Stage 2 — Acquire, when the network allows (enrichment).** Where
+`arxiv.org` is reachable, fetch the LaTeX source for the 230 arXiv
+documents and upgrade that document's structure from inferred to
+authoritative. The arXiv ID needed to do it is already in
+`structure.json`, extracted offline from the page-1 stamp — so Stage 1
+prepares Stage 2's work list even when it cannot do it. Also backfills
+the ledger's reference join.
+
+**Stage 3 — Parse harder, where it pays (Docling).** Capability probe
+`.claude/skills/capabilities/docling.json`, degrading to `n/a` when
+absent. Two populations need it and `pypdf` will not serve them: the
+scanned/no-text-layer documents Stage 1 flags as `likely_scanned`, and
+the **WHO L1 guidelines**, where boxed recommendations and GRADE tables
+are layout facts a text extractor destroys (§9.1).
+
+**Stage 3-bis — Route + Stage B extractors (§7, §7-bis).** The class
+router, the candidate extractors, and math normalisation (§8.3) as a
+gate rather than a nicety.
 
 **Stage 4 — Index (LanceDB, embedded).** Only once Stages 1–2 have
 produced clean text worth embedding. Indexing bad extractions is how RAG

--- a/docs/proposals/rag-document-ingestion.md
+++ b/docs/proposals/rag-document-ingestion.md
@@ -483,6 +483,76 @@ remains an opaque PDF.
 
 ---
 
+## 9-bis. OCR: which engine, and why the choice is not about accuracy
+
+Two document classes defeat text extraction completely, and no amount of
+parser work reaches them:
+
+| Class | Symptom | Count in the qou library |
+|---|---|---|
+| Scan, no text layer | `pypdf` returns 0 characters | 7 |
+| Scan, JIS-encoded font, no ToUnicode map | ~1,100 chars/page of `Fs=E2=7k$SL\$Ncolored Jones` | 5 |
+
+The second is the nastier one: it *looks* like text, so every "did we get
+characters" test passes and the mojibake flows into the index, the title
+and the grep path.
+
+### The choice is made by egress, not by benchmark scores
+
+Every model-based OCR fetches weights on first run, and `huggingface.co`
+returns **403** here under organisation policy (§2a). That single fact
+eliminates most of the field regardless of how well it reads:
+
+| Engine | Licence | Weights | Works here | Notes |
+|---|---|---|---|---|
+| **Tesseract 5** | Apache-2.0 | apt (`tesseract-ocr-*`) | **yes** | 100+ languages as distro packages; CPU; what this repo uses |
+| **RapidOCR** (`rapidocr-onnxruntime`) | Apache-2.0 | **in the wheel** | **yes** | ONNX, CPU, ~15 MB; the natural second string |
+| PaddleOCR | Apache-2.0 | HF / Baidu CDN | no | strongest on dense CJK layout, unreachable |
+| docTR | Apache-2.0 | HF | no | |
+| Surya | GPL-3.0 / commercial | HF | no | best-in-class reading order; licence also needs review |
+| EasyOCR | Apache-2.0 | JAIDED CDN | no | |
+| Cloud OCR (Google, AWS, Azure) | — | — | no | egress, and it sends the corpus to a third party |
+
+So the shortlist is **Tesseract** and **RapidOCR**, and Tesseract wins on
+language packaging alone: `tesseract-ocr-jpn` is one apt package, and the
+Japanese scans are precisely the hard cases here.
+
+### Two things that are easy to get wrong
+
+**`poppler-data` is not optional.** Without it `pdftoppm` fails on CJK
+with *"Missing language pack for 'Adobe-Japan1' mapping"*, produces no
+image, and **exits 0** — so an OCR pipeline reads nothing and reports
+success. `pdf-ocr.py` raises on an empty rasterisation for this reason.
+
+**Language must be detected, not assumed.** A Japanese page read as
+`-l eng` returns near-nothing. Tesseract's own script detection
+(`--psm 0`) is cheap and does not need the pack for the script it finds;
+a detected pack that is not installed is dropped rather than passed
+through, because Tesseract exits non-zero and returns nothing at all when
+asked for a language it lacks.
+
+### What it recovered
+
+Run over the blocked documents, with page-level caching and
+`source.text_source: "ocr"` recorded so a consumer knows the text is a
+transcription:
+
+- McMullen — *Braiding of the attractor and the failure of iterative
+  algorithms*, Invent. math. **91**, 259–272 (1988). The filename claims
+  2013; the paper is 1988.
+- Birman — *On Markov's Theorem*, J. Knot Theory Ramifications **11**(3).
+- RIMS Kôkyûroku 1172 — 岡本美雪 (Miyuki Okamoto), *二重化結び目の colored
+  Jones 多項式の計算方法について*.
+
+### What OCR does not fix
+
+It recovers *text*, not *judgement*. An OCR'd masthead is still a
+masthead, and the title/byline separation problems of §7-bis apply
+unchanged to the transcribed text — several OCR'd documents still needed
+a hand-verified entry in `library-title-overrides.json`. OCR moves a
+document from "unreadable" to "readable and subject to the usual
+extraction defects"; it does not move it to "registered".
+
 ## 10. Recommendation
 
 A staged adoption, cheapest and highest-value first. Each stage is

--- a/docs/proposals/rag-document-ingestion.md
+++ b/docs/proposals/rag-document-ingestion.md
@@ -494,11 +494,28 @@ independently useful and independently abandonable.
 > produces nothing in a sandbox. The offline PDF path is now Stage 1, and
 > network acquisition is an *enrichment* that runs when it can.
 
-**Stage 1 — Structure, offline (`scripts/pdf-structure.py`, built).**
-PDF → `structure.json` + `sections/*.md`, pure `pypdf`, no network, no
-GPU, no service. Delivers the metadata/TOC/section split and — the
-practical win — makes `uploads/` greppable (§7-bis). Works in every
-session regardless of egress policy.
+**Stage 1 — Structure, offline (`scripts/pdf-structure.py`, built and
+run).** PDF → `structure.json` + `sections/*.md`, pure `pypdf`, no
+network, no GPU, no service. Works in every session regardless of egress
+policy. Measured over the whole corpus:
+
+| | Result |
+|---|---|
+| Input | 339 PDFs, 12,166 pages |
+| Processed | **332 documents, 0 failures** (7 PDFs collided on derived `doc_id` — duplicate uploads, deduplicated for free) |
+| **Output** | **7,313 sections, 24.7 M characters greppable**, 52 MB |
+| Title | **321 (96.7 %)** — against DocInfo's 126 (37 %), a 2.6× improvement that justifies deriving from text |
+| Authors | 241 (72.6 %) |
+| Abstract | 227 (68.4 %) |
+| arXiv id | 213 (64.2 %) — matches the 68 % filename estimate, now confirmed from page-1 stamps rather than filenames |
+| TOC route | outline 188 · inferred 137 · **none 7** |
+
+The weak cells are the honest part and they define Stage 3's work list:
+**7 documents yield no TOC, 17 stay unsectioned, 7 look scanned.** Those
+~20 documents are where `pypdf` genuinely runs out and Docling or OCR
+earns its place — not the other 312. Author and abstract recall
+(73 %/68 %) are the next quality target; both are page-1 layout problems
+that Docling would also improve.
 
 **Stage 2 — Acquire, when the network allows (enrichment).** Where
 `arxiv.org` is reachable, fetch the LaTeX source for the 230 arXiv

--- a/scripts/extract-candidates.py
+++ b/scripts/extract-candidates.py
@@ -73,7 +73,20 @@ RE_WHO_REC = re.compile(
 RE_WHO_GPS = re.compile(r"^\s*Good\s+practice\s+statement\s*[.:—-]?\s*(?P<body>.*)$", re.M | re.I)
 RE_WHO_REMARK = re.compile(r"^\s*Remarks?\s*[.:—-]\s*(?P<body>.*)$", re.M | re.I)
 RE_WHO_RESEARCH = re.compile(r"^\s*Research\s+(?:priority|priorities|gap)\w*\s*[.:—-]?\s*(?P<body>.*)$", re.M | re.I)
-RE_GRADE = re.compile(r"(⊕|\bGRADE\b|\bcertainty of (?:the )?evidence\b|\bhigh|moderate|low|very low\b\s+certainty)", re.I)
+# A GRADE marker, not merely a word that appears in GRADE tables. The
+# certainty levels must be *bound* to a certainty/evidence/quality noun:
+# an earlier form alternated on bare `\bhigh|moderate|low`, so the phrase
+# "high malaria burden" three paragraphs away flagged a recommendation as
+# GRADE-adjacent. Caught by the extractor's own negative test.
+RE_GRADE = re.compile(
+    r"(?:⊕"
+    r"|\bGRADE\b"
+    r"|\b(?:certainty|quality)\s+of\s+(?:the\s+)?evidence\b"
+    r"|\b(?:very\s+low|low|moderate|high)\s+(?:certainty|quality)\b"
+    r"|\b(?:certainty|quality)\s*[:=]\s*(?:very\s+low|low|moderate|high)\b"
+    r")",
+    re.I,
+)
 RE_STRENGTH = re.compile(r"\b(strong|conditional|context[- ]specific)\b\s+recommendation", re.I)
 
 

--- a/scripts/extract-candidates.py
+++ b/scripts/extract-candidates.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""
+extract-candidates — Stage B of the ingestion pipeline.
+
+Reads a Stage-A artefact (`structure.json` + `sections/*.md` from
+pdf-structure.py) and proposes what the document *offers*, writing
+`candidates.json` next to it.
+
+    uploads/<doc-id>/candidates.json     ingest-candidates/v1
+
+**These are proposals, never content.** A theorem extracted from someone
+else's paper is a claim attributed to a source, not a folio claim — it
+reaches `content/` only when an agent or the author promotes it, per
+`document-intake.md §Stage 4`. Nothing here writes to `content/`, and
+nothing here creates Lean. See docs/proposals/rag-document-ingestion.md
+§7-bis for why that boundary is load-bearing.
+
+Two extractor classes share the machinery and differ only in what they
+look for and which skill they route to:
+
+    math   theorem/definition/lemma environments  → formalizer
+    who-l1 boxed recommendations, GRADE tables    → l2-dak-authoring
+
+Class is auto-detected from the Stage-A metadata unless forced with
+`--class`. The `who-l1` extractor is structurally complete but has not
+been run against a real WHO L1 guideline — there is none in the corpus —
+so it reports `"validated": false` in its output and should be treated
+as untested until one is available.
+
+Usage:
+    extract-candidates.py uploads/<doc-id>/ [...]
+    extract-candidates.py --corpus uploads/ --class math
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from typing import Any
+
+SCHEMA = "ingest-candidates/v1"
+
+# ---------------------------------------------------------------- math
+
+# "Theorem 3.1 (Name). Statement..." at the head of a paragraph.
+RE_MATH_ENV = re.compile(
+    r"^\s*(?P<kind>Theorem|Proposition|Lemma|Corollary|Definition|Conjecture"
+    r"|Claim|Remark|Example)\s*"
+    r"(?P<num>\d+(?:\.\d+)*)?\s*"
+    r"(?:\((?P<name>[^)]{2,80})\))?\s*[.:—-]?\s*"
+    r"(?P<body>\S.*)$",
+    re.M,
+)
+# Block kinds the folio actually has (schemas/types.ts).
+KIND_MAP = {
+    "theorem": "theorem", "proposition": "proposition", "lemma": "lemma",
+    "corollary": "corollary", "definition": "definition",
+    "conjecture": "conjecture", "claim": "proposition",
+    "remark": "remark", "example": "example",
+}
+# A result the folio would plausibly want to *use* rather than merely cite.
+FORMALIZABLE = {"theorem", "proposition", "lemma", "corollary", "definition"}
+
+# ---------------------------------------------------------------- who-l1
+
+RE_WHO_REC = re.compile(
+    r"^\s*RECOMMENDATION\s*(?P<num>\d+[a-z]?(?:\.\d+)*)?\s*[.:—-]?\s*(?P<body>.*)$",
+    re.M | re.I,
+)
+RE_WHO_GPS = re.compile(r"^\s*Good\s+practice\s+statement\s*[.:—-]?\s*(?P<body>.*)$", re.M | re.I)
+RE_WHO_REMARK = re.compile(r"^\s*Remarks?\s*[.:—-]\s*(?P<body>.*)$", re.M | re.I)
+RE_WHO_RESEARCH = re.compile(r"^\s*Research\s+(?:priority|priorities|gap)\w*\s*[.:—-]?\s*(?P<body>.*)$", re.M | re.I)
+RE_GRADE = re.compile(r"(⊕|\bGRADE\b|\bcertainty of (?:the )?evidence\b|\bhigh|moderate|low|very low\b\s+certainty)", re.I)
+RE_STRENGTH = re.compile(r"\b(strong|conditional|context[- ]specific)\b\s+recommendation", re.I)
+
+
+def clean(s: str, limit: int = 600) -> str:
+    s = re.sub(r"\s+", " ", s).strip()
+    return s[:limit]
+
+
+def read_sections(docdir: str) -> list[tuple[str, dict[str, str], str]]:
+    """Return (filename, front-matter, body) per section .md."""
+    sdir = os.path.join(docdir, "sections")
+    if not os.path.isdir(sdir):
+        return []
+    out = []
+    for fn in sorted(os.listdir(sdir)):
+        if not fn.endswith(".md"):
+            continue
+        raw = open(os.path.join(sdir, fn), encoding="utf-8", errors="replace").read()
+        fm: dict[str, str] = {}
+        body = raw
+        if raw.startswith("---\n"):
+            end = raw.find("\n---\n", 4)
+            if end != -1:
+                for line in raw[4:end].splitlines():
+                    if ":" in line:
+                        k, v = line.split(":", 1)
+                        fm[k.strip()] = v.strip().strip('"')
+                body = raw[end + 5:]
+        out.append((fn, fm, body))
+    return out
+
+
+def extract_math(sections, meta) -> list[dict[str, Any]]:
+    cands: list[dict[str, Any]] = []
+    for fn, fm, body in sections:
+        # References sections are citations, not claims.
+        if re.search(r"reference|bibliograph", fm.get("section_title", ""), re.I):
+            continue
+        for m in RE_MATH_ENV.finditer(body):
+            kind_raw = m.group("kind").lower()
+            kind = KIND_MAP.get(kind_raw)
+            if not kind:
+                continue
+            stmt = clean(m.group("body"))
+            if len(stmt) < 25:          # a bare cross-reference, not a statement
+                continue
+            if re.match(r"^\d+(\.\d+)*\s*$", stmt):
+                continue
+            cands.append({
+                "kind": kind,
+                "source_kind": kind_raw,
+                "number": m.group("num"),
+                "name": m.group("name"),
+                "statement": stmt,
+                "section_file": f"sections/{fn}",
+                "section_title": fm.get("section_title"),
+                "pages": fm.get("pages"),
+                "formalization_candidate": kind in FORMALIZABLE,
+                "formalization_note": (
+                    "Imported result — attribute to the source. If the folio uses it, "
+                    "state it in Lean with `sorry` + `-- Ref:` to this document, or "
+                    "prove it. Ingestion creates no Lean."
+                ) if kind in FORMALIZABLE else None,
+                "route_to": "formalizer" if kind in FORMALIZABLE else None,
+            })
+    return cands
+
+
+def extract_who_l1(sections, meta) -> list[dict[str, Any]]:
+    cands: list[dict[str, Any]] = []
+    rules = (
+        (RE_WHO_REC, "definition", "recommendation", "def:who"),
+        (RE_WHO_GPS, "proposition", "good-practice-statement", "prop:who"),
+        (RE_WHO_REMARK, "remark", "remark", "rem:who"),
+        (RE_WHO_RESEARCH, "conjecture", "research-priority", "conj:who"),
+    )
+    for fn, fm, body in sections:
+        for rx, kind, source_kind, prefix in rules:
+            for m in rx.finditer(body):
+                stmt = clean(m.group("body"), 900)
+                if len(stmt) < 20:
+                    continue
+                window = body[m.start(): m.start() + 1800]
+                strength = RE_STRENGTH.search(window)
+                cands.append({
+                    "kind": kind,
+                    "source_kind": source_kind,
+                    "number": (m.groupdict().get("num") if "num" in m.groupdict() else None),
+                    "name": None,
+                    "statement": stmt,
+                    "section_file": f"sections/{fn}",
+                    "section_title": fm.get("section_title"),
+                    "pages": fm.get("pages"),
+                    "label_prefix": prefix,
+                    "grade_nearby": bool(RE_GRADE.search(window)),
+                    "strength": strength.group(1).lower() if strength else None,
+                    "formalization_candidate": False,
+                    "route_to": "l2-dak-authoring",
+                })
+    return cands
+
+
+def detect_class(meta: dict[str, Any], sections) -> str:
+    if meta.get("arxiv"):
+        return "math"
+    blob = " ".join((fm.get("section_title") or "") for _, fm, _ in sections[:40])
+    blob += " " + (meta.get("title") or "")
+    if re.search(r"\bWHO\b|World Health Organization|guideline|recommendation", blob, re.I):
+        return "who-l1"
+    return "math"
+
+
+def process(docdir: str, forced: str | None) -> dict[str, Any] | None:
+    spath = os.path.join(docdir, "structure.json")
+    if not os.path.exists(spath):
+        return None
+    art = json.load(open(spath))
+    meta = art.get("metadata", {})
+    sections = read_sections(docdir)
+    cls = forced or detect_class(meta, sections)
+
+    if cls == "who-l1":
+        cands = extract_who_l1(sections, meta)
+    else:
+        cands = extract_math(sections, meta)
+
+    by_kind: dict[str, int] = {}
+    for c in cands:
+        by_kind[c["kind"]] = by_kind.get(c["kind"], 0) + 1
+
+    return {
+        "_schema": SCHEMA,
+        "doc_id": art.get("doc_id"),
+        "document_class": cls,
+        "validated": cls != "who-l1",   # who-l1 path is untested — no L1 PDF in corpus
+        "source": {
+            "structure_sha256": art.get("source", {}).get("sha256"),
+            "file": art.get("source", {}).get("file"),
+        },
+        "provenance": {
+            "title": meta.get("title"),
+            "authors": meta.get("authors_raw"),
+            "arxiv": meta.get("arxiv"),
+            "doi": meta.get("doi"),
+        },
+        "disposition": "proposals only — promote via document-intake Stage 4; "
+                       "nothing here is folio content and nothing here creates Lean",
+        "summary": {
+            "candidates": len(cands),
+            "by_kind": by_kind,
+            "formalization_candidates": sum(1 for c in cands if c["formalization_candidate"]),
+        },
+        "candidates": cands,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Stage B — propose content candidates from a Stage-A artefact")
+    ap.add_argument("docdirs", nargs="*")
+    ap.add_argument("--corpus", help="root containing <doc-id>/ directories")
+    ap.add_argument("--class", dest="cls", choices=["math", "who-l1"], help="force document class")
+    ap.add_argument("--json", action="store_true", help="print to stdout, write nothing")
+    args = ap.parse_args()
+
+    dirs = list(args.docdirs)
+    if args.corpus:
+        dirs += sorted(
+            os.path.join(args.corpus, d) for d in os.listdir(args.corpus)
+            if os.path.isdir(os.path.join(args.corpus, d))
+            and os.path.exists(os.path.join(args.corpus, d, "structure.json"))
+        )
+    if not dirs:
+        ap.error("no document directories given")
+
+    tot = fml = docs = 0
+    for d in dirs:
+        res = process(d, args.cls)
+        if res is None:
+            continue
+        docs += 1
+        tot += res["summary"]["candidates"]
+        fml += res["summary"]["formalization_candidates"]
+        if args.json:
+            print(json.dumps(res, indent=2))
+        else:
+            with open(os.path.join(d, "candidates.json"), "w") as fh:
+                json.dump(res, fh, indent=1)
+            s = res["summary"]
+            if s["candidates"]:
+                kinds = " ".join(f"{k}={v}" for k, v in sorted(s["by_kind"].items()))
+                print(f"{res['doc_id']:<34} {s['candidates']:>4}  {kinds}")
+
+    if not args.json:
+        print(f"\n{docs} documents, {tot} candidates, "
+              f"{fml} flagged as formalization candidates", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pdf-ocr.py
+++ b/scripts/pdf-ocr.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""
+pdf-ocr — recover text from PDFs that `pdf-structure` cannot read.
+
+Two kinds of document defeat text extraction entirely, and both are common
+in an ingested corpus:
+
+  * **A scan with no text layer.** `pypdf` returns 0 characters. The
+    document is invisible to grep, has no title, and cannot be registered.
+  * **A scan whose text layer is mojibake.** Older Japanese typesetting
+    embeds a JIS-encoded font with no ToUnicode map, so extraction yields
+    `Fs=E2=7k$SL\\$Ncolored Jones` — worse than nothing, because it looks
+    like text and passes any "did we get characters" test.
+
+This rasterises such documents and runs Tesseract over the images, caching
+one text file per page beside the PDF. `pdf-structure.py --ocr` then reads
+that cache instead of the embedded text.
+
+## Why Tesseract and not a model-based OCR
+
+Measured against this environment, not against benchmarks. Every
+model-based option — PaddleOCR, docTR, Surya, EasyOCR — fetches weights
+from Hugging Face on first run, and `huggingface.co` returns **403** here
+(organisation policy). Tesseract's language data ships in Ubuntu packages,
+so it installs from apt and runs entirely offline:
+
+    apt-get install -y --no-install-recommends \\
+        tesseract-ocr tesseract-ocr-eng tesseract-ocr-jpn \\
+        poppler-utils poppler-data
+
+`poppler-data` is not optional for CJK. Without it `pdftoppm` fails with
+"Missing language pack for 'Adobe-Japan1' mapping" and produces no image
+at all, so the OCR silently has nothing to read.
+
+`rapidocr-onnxruntime` is the one model-based option that does work
+offline — it ships its ONNX weights inside the wheel — and is the natural
+second string if Tesseract's accuracy proves insufficient on a given
+document class.
+
+## Language
+
+Passing the wrong language is not a small penalty: a Japanese page read as
+English returns near-nothing. The language is guessed from Tesseract's own
+orientation-and-script detection, which is cheap and does not need the
+language pack for the script it detects. Override with `--lang`.
+
+Usage:
+    pdf-ocr.py <pdf> [-o OUTDIR] [--lang jpn+eng] [--dpi 200] [--force]
+    pdf-ocr.py --check            # report whether the tools are present
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+# A page below this many characters is treated as having no usable text.
+MIN_CHARS_PER_PAGE = 120
+# Below this fraction of letters, the "text" is mojibake rather than prose.
+MIN_ALPHA_RATIO = 0.55
+
+SCRIPT_TO_LANG = {
+    "Japanese": "jpn+eng",
+    "HanS": "chi_sim+eng",
+    "HanT": "chi_tra+eng",
+    "Korean": "kor+eng",
+    "Cyrillic": "rus+eng",
+    "Greek": "ell+eng",
+}
+
+
+def tools_present() -> dict[str, str | None]:
+    return {t: shutil.which(t) for t in ("tesseract", "pdftoppm")}
+
+
+def langs_present() -> set[str]:
+    try:
+        out = subprocess.run(["tesseract", "--list-langs"], capture_output=True,
+                             text=True, timeout=30).stdout
+    except Exception:
+        return set()
+    return {l.strip() for l in out.splitlines()[1:] if l.strip()}
+
+
+def is_mojibake(text: str) -> bool:
+    """Text that decoded through the wrong codec.
+
+    Distinct from "no text": the string is long, so a length test passes,
+    but it is mostly punctuation and digits rather than letters.
+    """
+    if not text:
+        return True
+    letters = sum(c.isalpha() for c in text)
+    return letters < MIN_ALPHA_RATIO * len(text)
+
+
+def needs_ocr(pages: list[str]) -> tuple[bool, str]:
+    """Decide from the embedded text alone, and say why."""
+    if not pages:
+        return True, "no pages could be read"
+    total = sum(len(p or "") for p in pages)
+    mean = total / len(pages)
+    if mean < MIN_CHARS_PER_PAGE:
+        return True, f"{int(mean)} chars/page — no text layer"
+    head = " ".join((p or "") for p in pages[:3])
+    if is_mojibake(head):
+        return True, "text layer is mojibake — wrong codec"
+    return False, f"{int(mean)} chars/page of readable text"
+
+
+def detect_lang(png: str) -> str:
+    """Guess the language from Tesseract's script detection."""
+    try:
+        out = subprocess.run(["tesseract", png, "stdout", "--psm", "0"],
+                             capture_output=True, text=True, timeout=90).stdout
+    except Exception:
+        return "eng"
+    m = re.search(r"Script:\s*(\S+)", out)
+    script = m.group(1) if m else ""
+    lang = SCRIPT_TO_LANG.get(script, "eng")
+    have = langs_present()
+    # Fall back rather than fail: asking for a pack that is not installed
+    # makes Tesseract exit non-zero and return nothing at all.
+    kept = "+".join(p for p in lang.split("+") if p in have)
+    return kept or "eng"
+
+
+def ocr_pdf(pdf: str, outdir: str, lang: str | None, dpi: int,
+            force: bool) -> tuple[int, str]:
+    """Rasterise and OCR, caching one text file per page. Returns (pages, lang)."""
+    cache = os.path.join(outdir, "ocr")
+    os.makedirs(cache, exist_ok=True)
+    done = sorted(glob.glob(os.path.join(cache, "page-*.txt")))
+    if done and not force:
+        return len(done), "cached"
+
+    with tempfile.TemporaryDirectory() as tmp:
+        stem = os.path.join(tmp, "pg")
+        r = subprocess.run(["pdftoppm", "-r", str(dpi), "-png", pdf, stem],
+                           capture_output=True, text=True)
+        pngs = sorted(glob.glob(stem + "*.png"))
+        if not pngs:
+            # The usual cause is a missing CMap pack, and the message goes
+            # to stderr while the exit code stays 0 — so report it rather
+            # than returning a silent zero.
+            raise RuntimeError(
+                f"pdftoppm produced no images: {(r.stderr or '').strip()[:200] or 'no output'}")
+        use = lang or detect_lang(pngs[0])
+        for i, png in enumerate(pngs, 1):
+            txt = subprocess.run(["tesseract", png, "stdout", "-l", use],
+                                 capture_output=True, text=True).stdout
+            open(os.path.join(cache, f"page-{i:03d}.txt"), "w",
+                 encoding="utf-8").write(txt)
+        return len(pngs), use
+
+
+def read_cache(outdir: str) -> list[str]:
+    """The cached OCR text, one entry per page, or [] if there is none."""
+    files = sorted(glob.glob(os.path.join(outdir, "ocr", "page-*.txt")))
+    return [open(f, encoding="utf-8", errors="replace").read() for f in files]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="OCR a PDF that has no usable text layer")
+    ap.add_argument("pdfs", nargs="*")
+    ap.add_argument("-o", "--outdir", help="where to write ocr/ (default: beside the PDF)")
+    ap.add_argument("--lang", help="tesseract language, e.g. jpn+eng (default: detect)")
+    ap.add_argument("--dpi", type=int, default=200)
+    ap.add_argument("--force", action="store_true", help="re-OCR even if cached")
+    ap.add_argument("--check", action="store_true", help="report tool availability and exit")
+    args = ap.parse_args()
+
+    tools = tools_present()
+    if args.check:
+        for t, p in tools.items():
+            print(f"  {t:<10} {p or 'MISSING'}")
+        have = sorted(langs_present())
+        print(f"  languages  {', '.join(have) if have else 'none'}")
+        return 0 if all(tools.values()) else 1
+
+    missing = [t for t, p in tools.items() if not p]
+    if missing:
+        sys.exit(f"pdf-ocr: needs {', '.join(missing)} — "
+                 "apt-get install -y --no-install-recommends "
+                 "tesseract-ocr tesseract-ocr-eng poppler-utils poppler-data")
+
+    for pdf in args.pdfs:
+        out = args.outdir or os.path.dirname(os.path.abspath(pdf))
+        try:
+            n, lang = ocr_pdf(pdf, out, args.lang, args.dpi, args.force)
+            print(f"  {os.path.basename(pdf)}: {n} pages ({lang})")
+        except Exception as e:
+            print(f"  {os.path.basename(pdf)}: FAILED — {e}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pdf-structure.py
+++ b/scripts/pdf-structure.py
@@ -46,6 +46,7 @@ import json
 import os
 import re
 import unicodedata
+from collections import Counter
 import sys
 import warnings
 from dataclasses import dataclass, field, asdict
@@ -174,21 +175,31 @@ def repair_text(s: str) -> str:
     return re.sub(r"\s{2,}", " ", s)
 
 
-def rejoin_caps(s: str, vocab: set[str]) -> str:
+def rejoin_caps(s: str, vocab) -> str:
     """Vocabulary-gated half: undo arbitrary splits in all-caps runs.
 
     All-caps words get broken at arbitrary points by kerning — "STA VROS
     GAROUF ALIDIS" — and nothing about the *shape* of two capitalised
-    fragments says whether they are one word or two. So a join is made
-    only when the joined form actually occurs elsewhere in this same
-    document, which separates "GAROUF ALIDIS" (attested) from "THREE
-    MANIFOLDS" (never attested as one token).
+    fragments says whether they are one word or two. The document's own
+    text decides.
 
-    `vocab` must be built from text that has already been through
-    `repair_text`, or an accented name will fail to attest its own join.
+    `vocab` is a Counter of lower-cased tokens, and the counts are load
+    bearing: mere presence is not enough in either direction, because a
+    document that carries this damage attests its own artefacts. "BASES
+    FOR" was welded into one token because "basesfor" appeared elsewhere,
+    and "NON-CRYST ALLOGRAPHIC" was left broken because the same damaged
+    header repeats on every page, so "cryst" and "allographic" are both
+    "words" too.
+
+    Frequency separates them. A real word beats the fragments it was
+    broken into (`crystallographic` 30 vs `cryst` 5), while a damage
+    artefact loses to the real words it welded (`basesfor` 1 vs `for` 200).
     """
     if not vocab:
         return s
+
+    def freq(w):
+        return vocab.get(re.sub(r"[^\w]", "", w).lower(), 0)
 
     # A capital kerned away from the rest of its word: "V olume". Gated on
     # attestation, because the same shape is also a symbol followed by an
@@ -196,7 +207,7 @@ def rejoin_caps(s: str, vocab: set[str]) -> str:
     # into "Soit Kun corps".
     s = RE_SPLIT_CAP.sub(
         lambda m: m.group(1) + m.group(2)
-        if (m.group(1) + m.group(2)).lower() in vocab else m.group(0), s)
+        if freq(m.group(1) + m.group(2)) else m.group(0), s)
 
     # Whole runs, longest first. A name can be broken more than once —
     # "J ÉR ÔME" — and joining pairwise never fires there, because the
@@ -216,35 +227,23 @@ def rejoin_caps(s: str, vocab: set[str]) -> str:
             cand = "".join(run[:k])
             words = [(m.start(), m.end(), m.group(0))
                      for m in re.finditer(r"[^\W\d_]+", cand)]
-            # Test the word formed at *every* seam, not the whole
-            # concatenation and not just the first seam. Joining "GR" to
-            # "ÖBNER-SHIRSHOV" makes the word "GRÖBNER", so asking whether
-            # "gröbnershirshov" is a word answers a question nobody posed;
-            # and checking only the first seam once swallowed an entire
-            # title into one token because its first seam happened to be
-            # a real join.
             seams, ok = [], True
             for f in run[:k - 1]:
                 seams.append((seams[-1] if seams else 0) + len(f))
             for idx, seam in enumerate(seams):
+                # The word formed AT THE SEAM, not the whole concatenation:
+                # "GR" + "ÖBNER-SHIRSHOV" makes "GRÖBNER", and asking
+                # whether "gröbnershirshov" is a word answers a question
+                # nobody posed. Every seam is checked, because checking
+                # only the first once swallowed a whole title into one
+                # token on a run whose first seam was a real join.
                 w = next((t for a, b, t in words if a < seam <= b), "")
-                if len(w) < 4 or w.lower() not in vocab:
+                if len(w) < 4 or not freq(w):
                     ok = False
                     break
-                # The two words actually being welded — the last word of
-                # the left fragment and the first of the right. If BOTH
-                # are real words on their own, they are two real words,
-                # whatever the document says about the welded form: a
-                # document containing its own damage attests the
-                # artefact, which is how "BASES FOR" became "BASESFOR"
-                # and "L'INSTITUT FOURIER" became "L'INSTITUTFOURIER".
-                # Comparing whole fragments missed the second, because
-                # "L'INSTITUT" is not a word while "INSTITUT" is.
                 left = re.findall(r"[^\W\d_]+", run[idx])
                 right = re.findall(r"[^\W\d_]+", run[idx + 1])
-                if (left and right
-                        and left[-1].lower() in vocab
-                        and right[0].lower() in vocab):
+                if left and right and freq(w) < min(freq(left[-1]), freq(right[0])):
                     ok = False
                     break
             if ok:
@@ -466,8 +465,8 @@ def parse_front_matter(pages: list[str]) -> dict[str, Any]:
     # letter-spaced — so a two-page sample often fails to attest the very
     # names it needs. An author surname reappears unbroken in the running
     # heads and the bibliography, which is what makes the join decidable.
-    vocab = {w.lower() for w in
-             re.findall(r"[^\W\d_]{3,}", repair_text("\n".join(pages)))}
+    vocab = Counter(w.lower() for w in
+                    re.findall(r"[^\W\d_]{3,}", repair_text("\n".join(pages))))
 
     title = rejoin_caps(repair_text(" ".join(title_lines)), vocab).strip(" .,")
     meta["title"] = title or None

--- a/scripts/pdf-structure.py
+++ b/scripts/pdf-structure.py
@@ -130,7 +130,19 @@ RE_REPORT_NO = re.compile(
     # — "Symmetry, Integrability and Geometry: Methods and Applications
     # SIGMA 7 (2011), 115" went unrecognised and became a paper's title.
     r"|[A-Za-z][A-Za-z\s&.,:\-]{5,}\s+\d{1,4}\s*[:(]\s*\d"
-    r"|Vol(?:ume)?\.?\s*\d+\s*[,.]"
+    r"|Vol(?:ume)?\.?\s*\d+\s*[,.(]"
+    # An ISSN banner and a publication-date line, both printed above the
+    # title on society offprints. Neither was recognised, and once the
+    # start index stopped at the first non-furniture line rather than the
+    # last furniture line, an unrecognised banner became the title itself.
+    #
+    #   0| ISSN 1472-2739 (on-line) 1472-2747 (printed) 537
+    #   1| Algebraic & Geometric Topology
+    #   3| Volume 3 (2003) 537-556
+    #   4| Published: 16 June 2003
+    #   5| Skein-theoretical derivation          <- the title starts here
+    r"|ISSN\b|e-ISSN\b"
+    r"|(?:Published|Received|Accepted|Revised)\s*:?\s*\d{1,2}\s+\w+\s+\d{4}"
     # Publisher furniture that prints ABOVE the title and was being taken
     # as the title: a submission banner, a download stamp, an
     # article-listing masthead, and the society banner that opens an AMS
@@ -459,12 +471,32 @@ def parse_front_matter(pages: list[str]) -> dict[str, Any]:
     #   9| http://dx.doi.org/10.3842/SIGMA.2011.115   <- furniture, below it
     #
     # The old rule started at line 10.
+    def furniture(l: str) -> bool:
+        return bool(re.search(r"ar\s*X\s*iv", l, re.I) or RE_REPORT_NO.match(l))
+
     start = 0
+    skipped = False
     for i, l in enumerate(lines[:16]):
         if not l:
             start = i + 1
             continue
-        if re.search(r"ar\s*X\s*iv", l, re.I) or RE_REPORT_NO.match(l):
+        if furniture(l):
+            start, skipped = i + 1, True
+            continue
+        # A bare journal name carries no volume or year to match on, so it
+        # is unrecognisable on its own — but it sits INSIDE the furniture
+        # run, with more furniture under it:
+        #
+        #   ISSN 1472-2739 (on-line) ...      furniture
+        #   Algebraic & Geometric Topology    <- this line
+        #   ATG                               furniture
+        #   Volume 3 (2003) 537-556           furniture
+        #   Published: 16 June 2003           furniture
+        #   Skein-theoretical derivation      the title
+        #
+        # Only once something above it was already skipped, so a title
+        # sitting on line 0 above a date line is never mistaken for one.
+        if skipped and any(furniture(x) for x in lines[i + 1:i + 3] if x):
             start = i + 1
             continue
         break

--- a/scripts/pdf-structure.py
+++ b/scripts/pdf-structure.py
@@ -116,7 +116,15 @@ RE_AUTHOR_HINT = re.compile(r"(,\s|\band\b|\&)", re.I)
 # Report numbers / preprint stamps that precede the title.
 RE_REPORT_NO = re.compile(
     r"^\s*(?:[A-Z]{2,}[-–—/]{1,2}[\w\-–/.]*\d|[a-z\-]+(?:\.[A-Z]{2})?/\d{7}"
-    r"|preprint\b|submitted\b|\d{1,2}\s+(?:" + MONTHS + r")\s+\d{4})",
+    r"|preprint\b|submitted\b|\d{1,2}\s+(?:" + MONTHS + r")\s+\d{4}"
+    # Journal front matter, in the order a published paper prints it:
+    # a publisher mark ("msp"), the masthead ("ALGEBRA AND NUMBER THEORY
+    # 14:7 (2020)"), then the DOI. Without these three a split journal
+    # paper takes the publisher mark as its title — all ten papers of a
+    # bound issue came out titled "msp".
+    r"|\S{1,4}\s*$"
+    r"|[A-Za-z][A-Za-z\s&.\-]{5,}\s+\d+\s*[:(]\s*\d"
+    r"|https?://|doi\s*:|\bdoi\.org\b)",
     re.I,
 )
 

--- a/scripts/pdf-structure.py
+++ b/scripts/pdf-structure.py
@@ -1,0 +1,519 @@
+#!/usr/bin/env python3
+"""
+pdf-structure — turn an opaque upload into greppable, structured text.
+
+Reads a PDF and emits a domain-neutral structure artefact:
+
+    uploads/<doc-id>/
+      structure.json          pdf-structure/v1 — metadata + TOC + section index
+      sections/NN-slug.md     one file per section, YAML front-matter + text
+
+The `sections/` tree is the point. Agents in this project find things by
+grepping (`AGENTS.md` §"Before declaring open ... corpus-grep checklist"),
+and `uploads/` is the one part of the corpus that grep cannot see, because
+it is 339 PDFs. Extracting sections to plain Markdown makes uploads a
+first-class grep path, with the front-matter naming the document and page
+so a hit is immediately citable.
+
+This script is deliberately **domain-neutral**: no math logic, no WHO
+logic. It produces structure. Class-specific extractors (formalization
+candidates, L1 recommendation blocks) consume `structure.json` and are
+separate — see docs/proposals/rag-document-ingestion.md §7.
+
+Metadata is derived from the *text*, not from the PDF DocInfo dictionary:
+measured over the qou corpus only 126 of 339 documents (37%) carry a
+plausible `/Title`, while the arXiv stamp is reliably present in page-1
+text for arXiv papers, both new-style (`arXiv:0706.2213v3 [math.GT]`) and
+old-style (`arXiv:hep-th/0001202v2`). DocInfo is recorded as a
+cross-check, never as the source of truth.
+
+Table of contents comes from the PDF outline when there is one (194 of
+339, 57%) and is otherwise inferred from heading patterns in the text.
+Which route was used is recorded per entry, so a consumer can weight it.
+
+Usage:
+    pdf-structure.py <pdf> [<pdf>...] [-o OUTDIR] [--no-sections] [--json]
+    pdf-structure.py --corpus uploads/ -o uploads/
+
+Dependencies: pypdf (BSD-3-Clause). Install: pip install pypdf
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+import warnings
+from dataclasses import dataclass, field, asdict
+from typing import Any
+
+warnings.filterwarnings("ignore")
+
+try:
+    from pypdf import PdfReader
+except ImportError:  # pragma: no cover
+    sys.exit("pdf-structure: needs pypdf — pip install pypdf")
+
+SCHEMA = "pdf-structure/v1"
+
+# ---------------------------------------------------------------- patterns
+
+# arXiv stamp printed down the left margin of page 1 by arXiv itself.
+# Two eras: 0706.2213v3 (2007-04 onward) and hep-th/0001202v2 (before).
+RE_ARXIV_NEW = re.compile(
+    r"ar\s*X\s*iv\s*[:.]?\s*(?P<id>\d{4}\.\d{4,5})\s*(?P<ver>v\d+)?"
+    r"(?:\s*\[(?P<cls>[a-zA-Z\-]+(?:\.[A-Za-z\-]{2,})?)\])?",
+    re.I,
+)
+RE_ARXIV_OLD = re.compile(
+    r"ar\s*X\s*iv\s*[:.]?\s*(?P<id>[a-zA-Z\-]+(?:\.[A-Z]{2})?/\d{7})\s*(?P<ver>v\d+)?",
+    re.I,
+)
+RE_DOI = re.compile(r"\b(10\.\d{4,9}/[-._;()/:A-Za-z0-9]+?)(?=[\s,;)\]]|$)")
+RE_DATE = re.compile(
+    r"\b(\d{1,2}\s+"
+    r"(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\s+\d{4})\b"
+)
+
+# A heading, for the 43% of documents with no PDF outline.
+RE_NUMBERED = re.compile(r"^\s{0,6}(\d{1,2}(?:\.\d{1,2}){0,3})\.?\s+(\S.{1,86})$")
+RE_ROMAN = re.compile(r"^\s{0,6}([IVXLC]{1,6})\.\s+([A-Z]\S.{1,86})$")
+NAMED = (
+    "abstract", "introduction", "preliminaries", "background", "notation",
+    "conclusion", "conclusions", "discussion", "references", "bibliography",
+    "acknowledgements", "acknowledgments", "appendix",
+)
+RE_NAMED = re.compile(
+    r"^\s{0,6}((?:appendix\s+[a-z0-9]{1,3}[.:]?\s*)?(?:" + "|".join(NAMED) + r"))\s*$",
+    re.I,
+)
+MONTHS = (
+    "January|February|March|April|May|June|July|August|September|October|"
+    "November|December|Jan|Feb|Mar|Apr|Jun|Jul|Aug|Sep|Oct|Nov|Dec"
+)
+# Lines that look like headings but are not.
+RE_NOT_HEADING = re.compile(
+    r"(?:"
+    r"\.\s*$"            # ends in a full stop — a sentence
+    r"|^\s*\(\d+\)"      # numbered equation
+    r"|^\s*\[\d+\]"      # bibliography entry
+    r"|\bet\s+al\b"
+    r"|\d{4}\)\s*$"      # trailing citation year
+    r"|\b(?:" + MONTHS + r")\b\s*\d{0,4}\s*$"   # a date line
+    r"|\b(?:19|20)\d{2}\b"                       # any year — dates, citations
+    r"|^\s*\S+\s*\(\d+\)\s*$"                    # "1 (9)" equation reference
+    r")",
+    re.I,
+)
+# An author line: "A. Smith, B. Jones and C. Lee" / "SMITH, JONES, AND LEE".
+# Periods must be allowed — initials are near-universal — so a sentence is
+# excluded by looking for ". " followed by a lower-case word instead.
+RE_AUTHORS = re.compile(r"^[A-ZÀ-ʯ](?![^\n]*[.!?]\s+[a-z])[^!?]{2,120}$")
+RE_AUTHOR_HINT = re.compile(r"(,\s|\band\b|\&)", re.I)
+# Report numbers / preprint stamps that precede the title.
+RE_REPORT_NO = re.compile(
+    r"^\s*(?:[A-Z]{2,}[-–—/]{1,2}[\w\-–/.]*\d|[a-z\-]+(?:\.[A-Z]{2})?/\d{7}"
+    r"|preprint\b|submitted\b|\d{1,2}\s+(?:" + MONTHS + r")\s+\d{4})",
+    re.I,
+)
+
+
+# ---------------------------------------------------------------- structures
+
+@dataclass
+class TocEntry:
+    level: int
+    title: str
+    page: int | None
+    source: str            # "outline" | "inferred"
+    number: str | None = None
+
+
+@dataclass
+class Section:
+    id: str
+    number: str | None
+    title: str
+    level: int
+    page_start: int | None
+    page_end: int | None
+    n_chars: int
+    n_words: int
+    text: str = field(repr=False, default="")
+
+
+def sha256_of(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def slugify(s: str, maxlen: int = 48) -> str:
+    s = re.sub(r"[^\w\s-]", "", s.lower()).strip()
+    s = re.sub(r"[\s_]+", "-", s)
+    return (s[:maxlen].rstrip("-")) or "section"
+
+
+# ---------------------------------------------------------------- extraction
+
+def page_texts(reader: PdfReader) -> list[str]:
+    out = []
+    for p in reader.pages:
+        try:
+            out.append(p.extract_text() or "")
+        except Exception:
+            out.append("")
+    return out
+
+
+def read_outline(reader: PdfReader) -> list[TocEntry]:
+    """PDF bookmarks, flattened with nesting depth preserved."""
+    try:
+        raw = reader.outline
+    except Exception:
+        return []
+    if not raw:
+        return []
+
+    entries: list[TocEntry] = []
+
+    def page_of(item: Any) -> int | None:
+        try:
+            return reader.get_destination_page_number(item) + 1
+        except Exception:
+            return None
+
+    def walk(node: Any, level: int) -> None:
+        for item in node:
+            if isinstance(item, list):
+                walk(item, level + 1)
+                continue
+            try:
+                title = str(item.get("/Title", "")).strip()
+            except Exception:
+                continue
+            if not title:
+                continue
+            num = None
+            m = re.match(r"^\s*(\d+(?:\.\d+)*)\.?\s+(.*)$", title)
+            if m:
+                num, title = m.group(1), m.group(2).strip()
+            entries.append(TocEntry(level, title, page_of(item), "outline", num))
+
+    walk(raw, 1)
+    return entries
+
+
+def infer_headings(pages: list[str]) -> list[TocEntry]:
+    """Heading detection for documents with no outline (43% of the corpus)."""
+    entries: list[TocEntry] = []
+    seen: set[str] = set()
+
+    for pageno, text in enumerate(pages, start=1):
+        for line in text.splitlines():
+            line = line.rstrip()
+            if not (3 <= len(line.strip()) <= 92) or RE_NOT_HEADING.search(line):
+                continue
+
+            num, title, level = None, None, 1
+
+            m = RE_NUMBERED.match(line)
+            if m and not re.match(r"^\d{4}$", m.group(1)):
+                num, title = m.group(1), m.group(2).strip()
+                level = num.count(".") + 1
+                # Section numbers are small; "28 January 2000" is not §28.
+                if int(num.split(".")[0]) > 30:
+                    continue
+                # A real heading starts with a capital and is not mostly digits.
+                if not re.match(r"^[A-Z(]", title) or sum(c.isdigit() for c in title) > len(title) / 3:
+                    continue
+            if title is None:
+                m = RE_ROMAN.match(line)
+                if m:
+                    num, title, level = m.group(1), m.group(2).strip(), 1
+            if title is None:
+                m = RE_NAMED.match(line)
+                if m:
+                    title, level = m.group(1).strip().title(), 1
+            if title is None:
+                continue
+
+            title = re.sub(r"\s{2,}", " ", title).strip(" .")
+            key = f"{num or ''}|{title.lower()}"
+            if key in seen:
+                continue
+            seen.add(key)
+            entries.append(TocEntry(level, title, pageno, "inferred", num))
+
+    return entries
+
+
+def parse_front_matter(pages: list[str]) -> dict[str, Any]:
+    """Title, authors, abstract, arXiv id, DOI — from page-1 text."""
+    p1 = pages[0] if pages else ""
+    head = "\n".join(("\n".join(pages[:2])).splitlines()[:120])
+    meta: dict[str, Any] = {}
+
+    arxiv = None
+    for rx in (RE_ARXIV_NEW, RE_ARXIV_OLD):
+        m = rx.search(p1)
+        if m:
+            arxiv = {
+                "id": m.group("id"),
+                "version": (m.groupdict().get("ver") or "").lstrip("v") or None,
+                "primary_class": m.groupdict().get("cls"),
+            }
+            d = RE_DATE.search(p1[m.end(): m.end() + 90])
+            arxiv["stamp_date"] = d.group(1) if d else None
+            break
+    meta["arxiv"] = arxiv
+
+    m = RE_DOI.search(head)
+    meta["doi"] = m.group(1).rstrip(".") if m else None
+
+    # Title and authors sit between the arXiv stamp / report numbers and the
+    # abstract. Walk down, skipping stamp lines, collecting title lines until
+    # something that reads like an author list or the abstract marker.
+    lines = [l.strip() for l in p1.splitlines()]
+    start = 0
+    for i, l in enumerate(lines[:16]):
+        if re.search(r"ar\s*X\s*iv", l, re.I) or RE_REPORT_NO.match(l):
+            start = i + 1
+
+    title_lines: list[str] = []
+    author_lines: list[str] = []
+    for l in lines[start:start + 20]:
+        if re.match(r"^abstract\b", l, re.I):
+            break
+        if not l or len(l) < 3 or re.match(r"^\d+$", l) or RE_REPORT_NO.match(l):
+            if title_lines and not l:
+                # blank line after a title usually precedes the authors
+                continue
+            continue
+        # An author line: capitalised, comma/and-separated, no trailing colon,
+        # and we already have some title text.
+        if title_lines and RE_AUTHORS.match(l) and RE_AUTHOR_HINT.search(l) \
+                and not l.endswith(":") and len(l) < 120:
+            author_lines.append(l)
+            break
+        title_lines.append(l)
+        if len(" ".join(title_lines)) > 180:
+            break
+
+    title = re.sub(r"\s{2,}", " ", " ".join(title_lines)).strip(" .,")
+    meta["title"] = title or None
+    authors = re.sub(r"\s{2,}", " ", " ".join(author_lines)).strip(" .,")
+    meta["authors_raw"] = authors or None
+
+    # Abstract: everything after the marker, cut at the first section heading.
+    meta["abstract"] = None
+    m = re.search(r"\babstract\b\s*[.:—–-]?\s*", p1, re.I)
+    if m:
+        tail = p1[m.end(): m.end() + 2600]
+        cut = re.search(
+            r"\n\s*(?:1\s*\.?\s+Introduction\b|Introduction\b|Contents\b"
+            r"|Keywords?\b|Key words\b|MSC\b|AMS\b|\d{4}\s+Mathematics)",
+            tail, re.I,
+        )
+        if cut:
+            tail = tail[: cut.start()]
+        tail = re.sub(r"\s+", " ", tail).strip()
+        if len(tail) >= 40:
+            meta["abstract"] = tail[:2000]
+    return meta
+
+
+def split_sections(pages: list[str], toc: list[TocEntry]) -> list[Section]:
+    """Slice the document text at heading boundaries."""
+    marks: list[tuple[int, int, TocEntry]] = []  # (page_idx, line_idx, entry)
+    used: set[int] = set()
+
+    for e in toc:
+        needle = e.title.lower()[:44]
+        if not needle:
+            continue
+        lo = max(0, (e.page or 1) - 2)
+        hi = min(len(pages), (e.page or 1) + 2)
+        found = None
+        for pi in range(lo, hi):
+            for li, line in enumerate(pages[pi].splitlines()):
+                cand = re.sub(r"\s+", " ", line).strip().lower()
+                if needle in cand and len(cand) < 120:
+                    found = (pi, li)
+                    break
+            if found:
+                break
+        if found and found not in used:
+            used.add(found)  # type: ignore[arg-type]
+            marks.append((found[0], found[1], e))
+
+    marks.sort(key=lambda t: (t[0], t[1]))
+    if not marks:
+        whole = "\n".join(pages).strip()
+        return [Section("sec-000-document", None, "Document", 1, 1, len(pages),
+                        len(whole), len(whole.split()), whole)]
+
+    page_lines = [p.splitlines() for p in pages]
+    sections: list[Section] = []
+    for i, (pi, li, e) in enumerate(marks):
+        if i + 1 < len(marks):
+            epi, eli, _ = marks[i + 1]
+        else:
+            epi, eli = len(pages) - 1, len(page_lines[-1])
+
+        buf: list[str] = []
+        for p in range(pi, min(epi + 1, len(pages))):
+            src = page_lines[p]
+            s = li + 1 if p == pi else 0
+            t = eli if p == epi else len(src)
+            buf.extend(src[s:t])
+        body = re.sub(r"\n{3,}", "\n\n", "\n".join(buf)).strip()
+
+        num = e.number
+        sid = f"sec-{i:03d}-" + slugify(f"{num + ' ' if num else ''}{e.title}")
+        sections.append(Section(sid, num, e.title, e.level, pi + 1, epi + 1,
+                                len(body), len(body.split()), body))
+    return sections
+
+
+# ---------------------------------------------------------------- doc id
+
+def derive_doc_id(path: str, meta: dict[str, Any]) -> str:
+    ax = meta.get("arxiv")
+    if ax and ax.get("id"):
+        base = "arxiv-" + ax["id"].replace("/", "-")
+        return base + (f"v{ax['version']}" if ax.get("version") else "")
+    return slugify(os.path.splitext(os.path.basename(path))[0], 60)
+
+
+def process(path: str) -> tuple[dict[str, Any], list[Section]]:
+    reader = PdfReader(path)
+    pages = page_texts(reader)
+
+    outline = read_outline(reader)
+    toc = outline or infer_headings(pages)
+    meta = parse_front_matter(pages)
+    sections = split_sections(pages, toc)
+
+    try:
+        info = reader.metadata or {}
+        docinfo = {k.lstrip("/"): str(v) for k, v in info.items()
+                   if k in ("/Title", "/Author", "/Producer", "/Creator", "/CreationDate")}
+    except Exception:
+        docinfo = {}
+
+    empty = sum(1 for p in pages if len(p.strip()) < 20)
+    doc_id = derive_doc_id(path, meta)
+
+    artefact: dict[str, Any] = {
+        "_schema": SCHEMA,
+        "doc_id": doc_id,
+        "source": {
+            "file": os.path.basename(path),
+            "sha256": sha256_of(path),
+            "bytes": os.path.getsize(path),
+            "pages": len(pages),
+        },
+        "metadata": meta | {"docinfo": docinfo},
+        "toc": [asdict(e) for e in toc],
+        "toc_source": "outline" if outline else ("inferred" if toc else "none"),
+        "sections": [
+            {k: v for k, v in asdict(s).items() if k != "text"} for s in sections
+        ],
+        "diagnostics": {
+            "pages_without_text": empty,
+            "likely_scanned": empty > len(pages) * 0.5,
+            "toc_entries": len(toc),
+            "sections": len(sections),
+            "chars_total": sum(s.n_chars for s in sections),
+        },
+    }
+    return artefact, sections
+
+
+def write_sections(outdir: str, artefact: dict[str, Any], sections: list[Section]) -> None:
+    sdir = os.path.join(outdir, "sections")
+    os.makedirs(sdir, exist_ok=True)
+    for old in os.listdir(sdir):
+        if old.endswith(".md"):
+            os.remove(os.path.join(sdir, old))
+
+    doc_id = artefact["doc_id"]
+    title = (artefact["metadata"].get("title") or "").replace('"', "'")
+    for s in sections:
+        fm = [
+            "---",
+            f"doc_id: {doc_id}",
+            f'doc_title: "{title[:180]}"',
+            f"section_id: {s.id}",
+            f'section_title: "{s.title.replace(chr(34), chr(39))[:180]}"',
+            f"section_number: {s.number or 'null'}",
+            f"pages: {s.page_start}-{s.page_end}",
+            f"source_pdf: {artefact['source']['file']}",
+            f"source_sha256: {artefact['source']['sha256'][:16]}",
+            "---",
+            "",
+        ]
+        with open(os.path.join(sdir, f"{s.id}.md"), "w") as fh:
+            fh.write("\n".join(fm) + s.text + "\n")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="PDF → metadata + TOC + greppable sections")
+    ap.add_argument("pdfs", nargs="*")
+    ap.add_argument("--corpus", help="directory of PDFs to process")
+    ap.add_argument("-o", "--outdir", default=None,
+                    help="root for <doc-id>/ output dirs (default: alongside the PDF)")
+    ap.add_argument("--no-sections", action="store_true", help="structure.json only")
+    ap.add_argument("--json", action="store_true", help="print artefact to stdout, write nothing")
+    args = ap.parse_args()
+
+    targets = list(args.pdfs)
+    if args.corpus:
+        targets += sorted(
+            os.path.join(args.corpus, f)
+            for f in os.listdir(args.corpus) if f.lower().endswith(".pdf")
+        )
+    if not targets:
+        ap.error("no PDFs given")
+
+    ok = failed = 0
+    for path in targets:
+        try:
+            artefact, sections = process(path)
+        except Exception as exc:
+            failed += 1
+            print(f"FAIL  {os.path.basename(path)}: {type(exc).__name__}: {exc}",
+                  file=sys.stderr)
+            continue
+
+        if args.json:
+            print(json.dumps(artefact, indent=2))
+        else:
+            root = args.outdir or os.path.dirname(os.path.abspath(path))
+            outdir = os.path.join(root, artefact["doc_id"])
+            os.makedirs(outdir, exist_ok=True)
+            with open(os.path.join(outdir, "structure.json"), "w") as fh:
+                json.dump(artefact, fh, indent=1)
+            if not args.no_sections:
+                write_sections(outdir, artefact, sections)
+            d = artefact["diagnostics"]
+            flag = " SCANNED?" if d["likely_scanned"] else ""
+            print(f"ok  {artefact['doc_id']:<34} "
+                  f"{artefact['source']['pages']:>4}pp  "
+                  f"toc={d['toc_entries']:<3}({artefact['toc_source'][:3]})  "
+                  f"sec={d['sections']:<3}  {d['chars_total']//1000:>4}kc{flag}")
+        ok += 1
+
+    if not args.json:
+        print(f"\n{ok} ok, {failed} failed", file=sys.stderr)
+    return 1 if failed and not ok else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pdf-structure.py
+++ b/scripts/pdf-structure.py
@@ -45,6 +45,7 @@ import hashlib
 import json
 import os
 import re
+import unicodedata
 import sys
 import warnings
 from dataclasses import dataclass, field, asdict
@@ -124,9 +125,137 @@ RE_REPORT_NO = re.compile(
     # bound issue came out titled "msp".
     r"|\S{1,4}\s*$"
     r"|[A-Za-z][A-Za-z\s&.\-]{5,}\s+\d+\s*[:(]\s*\d"
+    # Publisher furniture that prints ABOVE the title and was being taken
+    # as the title: a submission banner, a download stamp, an
+    # article-listing masthead, and the society banner that opens an AMS
+    # or Springer offprint.
+    r"|prepared\s+for\s+submission\b|downloaded\s+from\b"
+    r"|contents\s+lists\s+available\b|journal\s+homepage\b"
+    r"|(?:transactions|proceedings|communications|annals|bulletin|journal)\s+"
+    r"(?:of|in)\b[^\n]{0,60}$"
     r"|https?://|doi\s*:|\bdoi\.org\b)",
     re.I,
 )
+
+# PDF text extraction damages words in two systematic ways. Both corrupt
+# every downstream consumer at once — the title, the index brief, and the
+# section text that corpus-grep runs over — so they are repaired here at
+# the producer rather than in each reader.
+LIGATURES = str.maketrans({
+    "ﬀ": "ff", "ﬁ": "fi", "ﬂ": "fl", "ﬃ": "ffi",
+    "ﬄ": "ffl", "ﬅ": "st", "ﬆ": "st",
+})
+# A floating accent emitted before its letter: "Gr¨ obner" -> "Gröbner",
+# "J ´ER ˆOME" -> "JÉRÔME".
+ACCENTS = {"¨": "̈", "´": "́", "`": "̀", "ˆ": "̂", "˜": "̃"}
+RE_FLOAT_ACCENT = re.compile("([" + "".join(ACCENTS) + r"])\s*([A-Za-z])")
+# A capital separated from the rest of its word by kerning: "V olume".
+RE_SPLIT_CAP = re.compile(r"\b([A-Z])\s+([a-z]{2,})\b")
+
+
+# Two adjacent all-caps runs, Unicode-aware. `[A-Z]` is ASCII-only in
+# Python's re, which left "GR ÖBNER" and "J ÉR ÔME" split precisely for
+# the accented names the accent repair had just fixed.
+RE_CAPS_PAIR = re.compile(r"(?<![^\W\d_])([^\W\d_]+)\s+([^\W\d_]+)(?![^\W\d_])")
+
+
+def repair_text(s: str) -> str:
+    """Deterministic half: ligatures and floating accents only.
+
+    Safe to apply anywhere — neither needs to know the document, and both
+    are unambiguous. Anything that has to guess belongs in `rejoin_caps`,
+    which can consult the document's own vocabulary.
+    """
+    if not s:
+        return s
+    s = s.translate(LIGATURES)
+    s = unicodedata.normalize(
+        "NFC", RE_FLOAT_ACCENT.sub(lambda m: m.group(2) + ACCENTS[m.group(1)], s))
+    return re.sub(r"\s{2,}", " ", s)
+
+
+def rejoin_caps(s: str, vocab: set[str]) -> str:
+    """Vocabulary-gated half: undo arbitrary splits in all-caps runs.
+
+    All-caps words get broken at arbitrary points by kerning — "STA VROS
+    GAROUF ALIDIS" — and nothing about the *shape* of two capitalised
+    fragments says whether they are one word or two. So a join is made
+    only when the joined form actually occurs elsewhere in this same
+    document, which separates "GAROUF ALIDIS" (attested) from "THREE
+    MANIFOLDS" (never attested as one token).
+
+    `vocab` must be built from text that has already been through
+    `repair_text`, or an accented name will fail to attest its own join.
+    """
+    if not vocab:
+        return s
+
+    # A capital kerned away from the rest of its word: "V olume". Gated on
+    # attestation, because the same shape is also a symbol followed by an
+    # ordinary word — ungated, this turned the French "Soit K un corps"
+    # into "Soit Kun corps".
+    s = RE_SPLIT_CAP.sub(
+        lambda m: m.group(1) + m.group(2)
+        if (m.group(1) + m.group(2)).lower() in vocab else m.group(0), s)
+
+    # Whole runs, longest first. A name can be broken more than once —
+    # "J ÉR ÔME" — and joining pairwise never fires there, because the
+    # intermediate "JÉR" is not a word and so is not attested. Only the
+    # full run is.
+    toks = re.split(r"(\s+)", s)
+    out: list[str] = []
+    i = 0
+    while i < len(toks):
+        run = []
+        j = i
+        while j < len(toks) and toks[j].strip() and toks[j].isupper():
+            run.append(toks[j])
+            j += 2                      # skip the separator between tokens
+        joined = None
+        for k in range(len(run), 1, -1):
+            cand = "".join(run[:k])
+            words = [(m.start(), m.end(), m.group(0))
+                     for m in re.finditer(r"[^\W\d_]+", cand)]
+            # Test the word formed at *every* seam, not the whole
+            # concatenation and not just the first seam. Joining "GR" to
+            # "ÖBNER-SHIRSHOV" makes the word "GRÖBNER", so asking whether
+            # "gröbnershirshov" is a word answers a question nobody posed;
+            # and checking only the first seam once swallowed an entire
+            # title into one token because its first seam happened to be
+            # a real join.
+            seams, ok = [], True
+            for f in run[:k - 1]:
+                seams.append((seams[-1] if seams else 0) + len(f))
+            for idx, seam in enumerate(seams):
+                w = next((t for a, b, t in words if a < seam <= b), "")
+                if len(w) < 4 or w.lower() not in vocab:
+                    ok = False
+                    break
+                # The two words actually being welded — the last word of
+                # the left fragment and the first of the right. If BOTH
+                # are real words on their own, they are two real words,
+                # whatever the document says about the welded form: a
+                # document containing its own damage attests the
+                # artefact, which is how "BASES FOR" became "BASESFOR"
+                # and "L'INSTITUT FOURIER" became "L'INSTITUTFOURIER".
+                # Comparing whole fragments missed the second, because
+                # "L'INSTITUT" is not a word while "INSTITUT" is.
+                left = re.findall(r"[^\W\d_]+", run[idx])
+                right = re.findall(r"[^\W\d_]+", run[idx + 1])
+                if (left and right
+                        and left[-1].lower() in vocab
+                        and right[0].lower() in vocab):
+                    ok = False
+                    break
+            if ok:
+                joined, i = cand, i + 2 * k - 1
+                break
+        if joined:
+            out.append(joined)
+        else:
+            out.append(toks[i])
+            i += 1
+    return "".join(out)
 
 
 # ---------------------------------------------------------------- structures
@@ -328,9 +457,21 @@ def parse_front_matter(pages: list[str]) -> dict[str, Any]:
         if len(" ".join(title_lines)) > 180:
             break
 
-    title = re.sub(r"\s{2,}", " ", " ".join(title_lines)).strip(" .,")
+    # The document's own token set, used to decide whether an all-caps
+    # split is real, and built from *repaired* text so an accented name
+    # can attest its own join.
+    #
+    # Drawn from the whole document, not from `head`. Front matter is
+    # exactly where the damage is — it is the part set in caps and
+    # letter-spaced — so a two-page sample often fails to attest the very
+    # names it needs. An author surname reappears unbroken in the running
+    # heads and the bibliography, which is what makes the join decidable.
+    vocab = {w.lower() for w in
+             re.findall(r"[^\W\d_]{3,}", repair_text("\n".join(pages)))}
+
+    title = rejoin_caps(repair_text(" ".join(title_lines)), vocab).strip(" .,")
     meta["title"] = title or None
-    authors = re.sub(r"\s{2,}", " ", " ".join(author_lines)).strip(" .,")
+    authors = rejoin_caps(repair_text(" ".join(author_lines)), vocab).strip(" .,")
     meta["authors_raw"] = authors or None
 
     # Abstract: everything after the marker, cut at the first section heading.

--- a/scripts/pdf-structure.py
+++ b/scripts/pdf-structure.py
@@ -468,10 +468,22 @@ def parse_front_matter(pages: list[str]) -> dict[str, Any]:
     vocab = Counter(w.lower() for w in
                     re.findall(r"[^\W\d_]{3,}", repair_text("\n".join(pages))))
 
-    title = rejoin_caps(repair_text(" ".join(title_lines)), vocab).strip(" .,")
+    fix = lambda s: rejoin_caps(repair_text(s), vocab).strip(" .,")
+    title = fix(" ".join(title_lines))
     meta["title"] = title or None
-    authors = rejoin_caps(repair_text(" ".join(author_lines)), vocab).strip(" .,")
+    authors = fix(" ".join(author_lines))
     meta["authors_raw"] = authors or None
+    # The lines the title was assembled from, kept separately.
+    #
+    # Joining them destroys the one boundary that reliably separates a
+    # title from its byline: the line break. When the author-line test
+    # above misses — it needs a comma or an "and", so a single-author
+    # byline slips through — the byline is appended to the title and no
+    # downstream heuristic can recover it, because in an all-caps title
+    # "THEORY TOM BRIDGELAND" is indistinguishable from "TORUS KNOT" by
+    # shape alone. With the lines kept, a consumer can test the last one
+    # on its own.
+    meta["title_lines"] = [fix(l) for l in title_lines] or None
 
     # Abstract: everything after the marker, cut at the first section heading.
     meta["abstract"] = None

--- a/scripts/pdf-structure.py
+++ b/scripts/pdf-structure.py
@@ -243,7 +243,15 @@ def rejoin_caps(s: str, vocab) -> str:
                     break
                 left = re.findall(r"[^\W\d_]+", run[idx])
                 right = re.findall(r"[^\W\d_]+", run[idx + 1])
-                if left and right and freq(w) < min(freq(left[-1]), freq(right[0])):
+                # The join has to actually make a word. When a fragment
+                # ends in a non-letter the seam word is just that fragment
+                # unchanged — "HYPERBOLIC" + "3-MANIFOLDS" seams on
+                # "HYPERBOLIC" — and every frequency test then compares the
+                # word with itself and passes, welding two real words.
+                if not left or not right or w in (left[-1], right[0]):
+                    ok = False
+                    break
+                if freq(w) < min(freq(left[-1]), freq(right[0])):
                     ok = False
                     break
             if ok:

--- a/scripts/pdf-structure.py
+++ b/scripts/pdf-structure.py
@@ -223,7 +223,22 @@ def infer_headings(pages: list[str]) -> list[TocEntry]:
     seen: set[str] = set()
 
     for pageno, text in enumerate(pages, start=1):
-        for line in text.splitlines():
+        # A table-of-contents page is itself a dense list of heading-shaped
+        # lines, each ending in the page number it points at. Scraping it
+        # yields a whole document's headings all claiming to start on the
+        # TOC page — 3 corpus documents had over half their sections on one
+        # page for this reason. Detect and skip the page, not the document:
+        # its real headings are still found in the body.
+        lines_ = text.splitlines()
+        heading_ish = [l for l in lines_ if RE_NUMBERED.match(l) or RE_NAMED.match(l)]
+        if len(heading_ish) >= 8:
+            trailing_page_no = sum(
+                1 for l in heading_ish if re.search(r"(?:\.\s*){2,}\d{1,4}\s*$|\s\d{1,4}\s*$", l)
+            )
+            if trailing_page_no >= 0.6 * len(heading_ish):
+                continue
+
+        for line in lines_:
             line = line.rstrip()
             if not (3 <= len(line.strip()) <= 92) or RE_NOT_HEADING.search(line):
                 continue

--- a/scripts/pdf-structure.py
+++ b/scripts/pdf-structure.py
@@ -41,6 +41,7 @@ Dependencies: pypdf (BSD-3-Clause). Install: pip install pypdf
 from __future__ import annotations
 
 import argparse
+import glob
 import hashlib
 import json
 import os
@@ -631,9 +632,49 @@ def derive_doc_id(path: str, meta: dict[str, Any]) -> str:
     return slugify(os.path.splitext(os.path.basename(path))[0], 60)
 
 
-def process(path: str) -> tuple[dict[str, Any], list[Section]]:
+def ocr_pages(path: str, outdir: str | None) -> list[str]:
+    """Cached OCR text for this PDF, if `pdf-ocr.py` has been run on it.
+
+    Read rather than generated: OCR costs seconds per page and needs
+    binaries this script deliberately does not depend on, so producing it
+    is a separate, explicit step.
+    """
+    base = outdir or os.path.dirname(os.path.abspath(path))
+    for d in (os.path.join(base, "ocr"),
+              os.path.join(base, slugify(os.path.splitext(os.path.basename(path))[0], 60), "ocr")):
+        files = sorted(glob.glob(os.path.join(d, "page-*.txt")))
+        if files:
+            return [open(f, encoding="utf-8", errors="replace").read() for f in files]
+    return []
+
+
+def text_is_unusable(pages: list[str]) -> bool:
+    """No text layer, or one that decoded through the wrong codec.
+
+    The second case is why a length test is not enough: a JIS-encoded
+    Japanese scan yields ~1,100 characters per page of
+    `Fs=E2=7k$SL\\$Ncolored Jones`, which passes every "did we get text"
+    check and is worth less than nothing downstream.
+    """
+    if not pages:
+        return True
+    mean = sum(len(p or "") for p in pages) / len(pages)
+    if mean < 120:
+        return True
+    head = " ".join((p or "") for p in pages[:3])
+    letters = sum(c.isalpha() for c in head)
+    return bool(head) and letters < 0.55 * len(head)
+
+
+def process(path: str, outdir: str | None = None, use_ocr: bool = False,
+            ) -> tuple[dict[str, Any], list[Section]]:
     reader = PdfReader(path)
     pages = page_texts(reader)
+    ocr_used = False
+    if use_ocr and text_is_unusable(pages):
+        cached = ocr_pages(path, outdir)
+        if cached:
+            pages, ocr_used = cached, True
 
     outline = read_outline(reader)
     toc = outline or infer_headings(pages)
@@ -658,6 +699,10 @@ def process(path: str) -> tuple[dict[str, Any], list[Section]]:
             "sha256": sha256_of(path),
             "bytes": os.path.getsize(path),
             "pages": len(pages),
+            # Whether this artefact was built from OCR rather than from the
+            # PDF's own text. A consumer that ranks or cites this document
+            # should know the text is a transcription.
+            "text_source": "ocr" if ocr_used else "embedded",
         },
         "metadata": meta | {"docinfo": docinfo},
         "toc": [asdict(e) for e in toc],
@@ -711,6 +756,9 @@ def main() -> int:
                     help="root for <doc-id>/ output dirs (default: alongside the PDF)")
     ap.add_argument("--no-sections", action="store_true", help="structure.json only")
     ap.add_argument("--json", action="store_true", help="print artefact to stdout, write nothing")
+    ap.add_argument("--ocr", action="store_true",
+                    help="for a PDF whose text layer is absent or mojibake, use the "
+                         "cached OCR text written by pdf-ocr.py (which must be run first)")
     args = ap.parse_args()
 
     targets = list(args.pdfs)
@@ -725,7 +773,7 @@ def main() -> int:
     ok = failed = 0
     for path in targets:
         try:
-            artefact, sections = process(path)
+            artefact, sections = process(path, args.outdir, args.ocr)
         except Exception as exc:
             failed += 1
             print(f"FAIL  {os.path.basename(path)}: {type(exc).__name__}: {exc}",

--- a/scripts/pdf-structure.py
+++ b/scripts/pdf-structure.py
@@ -125,7 +125,12 @@ RE_REPORT_NO = re.compile(
     # paper takes the publisher mark as its title — all ten papers of a
     # bound issue came out titled "msp".
     r"|\S{1,4}\s*$"
-    r"|[A-Za-z][A-Za-z\s&.\-]{5,}\s+\d+\s*[:(]\s*\d"
+    # A journal name then "vol (year)" or "vol:issue". Commas and colons
+    # have to be allowed inside the name or the pattern cannot cross them
+    # — "Symmetry, Integrability and Geometry: Methods and Applications
+    # SIGMA 7 (2011), 115" went unrecognised and became a paper's title.
+    r"|[A-Za-z][A-Za-z\s&.,:\-]{5,}\s+\d{1,4}\s*[:(]\s*\d"
+    r"|Vol(?:ume)?\.?\s*\d+\s*[,.]"
     # Publisher furniture that prints ABOVE the title and was being taken
     # as the title: a submission banner, a download stamp, an
     # article-listing masthead, and the society banner that opens an AMS
@@ -439,10 +444,30 @@ def parse_front_matter(pages: list[str]) -> dict[str, Any]:
     # abstract. Walk down, skipping stamp lines, collecting title lines until
     # something that reads like an author list or the abstract marker.
     lines = [l.strip() for l in p1.splitlines()]
+    # Skip the CONTIGUOUS run of furniture at the top, and stop at the
+    # first line that is not furniture. Taking the last furniture line
+    # anywhere in the window instead — which this did — walks straight past
+    # the title whenever any furniture is printed *below* it, and plenty
+    # is: a DOI URL under the byline, a "Received ... Published online"
+    # line, or an arXiv margin stamp that pypdf emits last because it is
+    # rotated. Both cost the title outright.
+    #
+    #   0| arXiv:1105.1998v3 [math.CA] 16 Dec 2011
+    #   1| ... SIGMA 7 (2011), 115, 11 pages          <- furniture
+    #   2| A Connection Formula                       <- the title
+    #   ...
+    #   9| http://dx.doi.org/10.3842/SIGMA.2011.115   <- furniture, below it
+    #
+    # The old rule started at line 10.
     start = 0
     for i, l in enumerate(lines[:16]):
+        if not l:
+            start = i + 1
+            continue
         if re.search(r"ar\s*X\s*iv", l, re.I) or RE_REPORT_NO.match(l):
             start = i + 1
+            continue
+        break
 
     title_lines: list[str] = []
     author_lines: list[str] = []

--- a/scripts/tests/pdf-text-repair.test.py
+++ b/scripts/tests/pdf-text-repair.test.py
@@ -60,6 +60,7 @@ institut fourier institut fourier institut fourier corps valué hauteur soit
 bases for bases for bases for bases for the bases for
 crystallographic crystallographic crystallographic crystallographic
 cryst allographic
+hyperbolic hyperbolic hyperbolic manifolds manifolds manifolds bloch group
 """
 # The repeated words above are deliberate, and so are the odd ones.
 # `basesfor`, `institutfourier` and the lone `cryst allographic` are damage
@@ -117,6 +118,11 @@ CASES = [
      "Soit K un corps val\u00e9 de hauteur",
      "a lone symbol before a word is not a kerning split: ungated, the "
      "split-capital rule turned \"K un\" into \"Kun\""),
+    ("HYPERBOLIC 3-MANIFOLDS, THE BLOCH GROUP",
+     "HYPERBOLIC 3-MANIFOLDS, THE BLOCH GROUP",
+     "a join must create a word: a fragment ending in a non-letter seams "
+     "on itself, so every frequency test compares a word with itself and "
+     "passes - which welded HYPERBOLIC to 3-MANIFOLDS"),
     ("NON-CRYST ALLOGRAPHIC COXETER GROUPS AND BASES",
      "NON-CRYSTALLOGRAPHIC COXETER GROUPS AND BASES",
      "a real word still wins when the document attests BOTH fragments too: "

--- a/scripts/tests/pdf-text-repair.test.py
+++ b/scripts/tests/pdf-text-repair.test.py
@@ -31,6 +31,7 @@ import os
 import re
 import sys
 import unicodedata
+from collections import Counter
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 SCRIPT = os.path.join(os.path.dirname(HERE), "pdf-structure.py")
@@ -41,7 +42,7 @@ def load():
     start = src.index("LIGATURES = str.maketrans")
     end = src.index("# ------------------------------------------------"
                     "---------------- structures")
-    ns: dict = {"re": re, "unicodedata": unicodedata}
+    ns: dict = {"re": re, "unicodedata": unicodedata, "Counter": Counter}
     exec(src[start:end], ns)
     return ns["repair_text"], ns["rejoin_caps"]
 
@@ -54,12 +55,19 @@ stavros garoufalidis rinat kashaev volume mathematical transactions coxeter
 non-crystallographic groups gröbner shirshov jérôme dubois vu huynh yoshikazu
 yamaguchi invariant refined categorified three manifolds physics topology
 algebras bases for non abelian reidemeister torsion twist knots
-basesfor institutfourier institut fourier corps valué hauteur soit
+basesfor institutfourier
+institut fourier institut fourier institut fourier corps valué hauteur soit
+bases for bases for bases for bases for the bases for
+crystallographic crystallographic crystallographic crystallographic
+cryst allographic
 """
-# `basesfor` above is deliberate. It is not a typo: the real document
-# carried that same kerning damage in its body, so attestation attested
-# the *artefact*, and an earlier version of the repair used it as licence
-# to weld "BASES FOR" into one token in the title.
+# The repeated words above are deliberate, and so are the odd ones.
+# `basesfor`, `institutfourier` and the lone `cryst allographic` are damage
+# artefacts the real documents carried in their own bodies — mere presence
+# therefore attests them, which is why the gate counts occurrences instead.
+# A real word outnumbers the fragments it was broken into
+# (`crystallographic` 4 vs `cryst` 1); an artefact is outnumbered by the
+# real words it welded (`basesfor` 1 vs `for` 5).
 
 CASES = [
     # (damaged, expected, what it exercises)
@@ -109,12 +117,17 @@ CASES = [
      "Soit K un corps val\u00e9 de hauteur",
      "a lone symbol before a word is not a kerning split: ungated, the "
      "split-capital rule turned \"K un\" into \"Kun\""),
+    ("NON-CRYST ALLOGRAPHIC COXETER GROUPS AND BASES",
+     "NON-CRYSTALLOGRAPHIC COXETER GROUPS AND BASES",
+     "a real word still wins when the document attests BOTH fragments too: "
+     "the same damaged header repeats on every page, so presence alone "
+     "cannot separate them and frequency has to"),
 ]
 
 
 def main() -> int:
     repair_text, rejoin_caps = load()
-    vocab = {w.lower() for w in re.findall(r"[^\W\d_]{3,}", repair_text(BODY))}
+    vocab = Counter(w.lower() for w in re.findall(r"[^\W\d_]{3,}", repair_text(BODY)))
     failed = 0
     for damaged, expected, what in CASES:
         got = rejoin_caps(repair_text(damaged), vocab)

--- a/scripts/tests/pdf-text-repair.test.py
+++ b/scripts/tests/pdf-text-repair.test.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""
+Regression test for `pdf-structure.py`'s text repair.
+
+PDF text extraction damages words in ways that look cosmetic and are not:
+the damaged form is what lands in `structure.json`'s title, in the library
+index brief, and in the section text that corpus-grep runs over. A search
+for "Garoufalidis" does not match "GAROUF ALIDIS".
+
+Every case below is real damage taken from the qou library, and each one
+broke a *previous* version of the repair — which is the reason this file
+exists rather than a one-off check:
+
+  * pairwise joining could not fix "J ÉR ÔME", because the intermediate
+    "JÉR" is not a word and so is never attested;
+  * whole-concatenation lookup could not fix "GR ÖBNER-SHIRSHOV", because
+    the word formed at the seam is "GRÖBNER", not "GRÖBNERSHIRSHOV";
+  * first-seam-only lookup swallowed an entire title into one token, on a
+    run whose first seam happened to be a real join.
+
+Run: python3 scripts/tests/pdf-text-repair.test.py
+
+Standalone by design — it loads the two functions out of the script's
+source rather than importing it, so it runs in environments where pypdf
+is unavailable.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+import unicodedata
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCRIPT = os.path.join(os.path.dirname(HERE), "pdf-structure.py")
+
+
+def load():
+    src = open(SCRIPT, encoding="utf-8").read()
+    start = src.index("LIGATURES = str.maketrans")
+    end = src.index("# ------------------------------------------------"
+                    "---------------- structures")
+    ns: dict = {"re": re, "unicodedata": unicodedata}
+    exec(src[start:end], ns)
+    return ns["repair_text"], ns["rejoin_caps"]
+
+
+# Stands in for the document body the real code harvests its vocabulary
+# from. The gate is attestation *in this document*, so a join is only
+# made when the joined form genuinely occurs elsewhere in the same paper.
+BODY = """
+stavros garoufalidis rinat kashaev volume mathematical transactions coxeter
+non-crystallographic groups gröbner shirshov jérôme dubois vu huynh yoshikazu
+yamaguchi invariant refined categorified three manifolds physics topology
+algebras bases for non abelian reidemeister torsion twist knots
+basesfor institutfourier institut fourier corps valué hauteur soit
+"""
+# `basesfor` above is deliberate. It is not a typo: the real document
+# carried that same kerning damage in its body, so attestation attested
+# the *artefact*, and an earlier version of the repair used it as licence
+# to weld "BASES FOR" into one token in the title.
+
+CASES = [
+    # (damaged, expected, what it exercises)
+    ("STA VROS GAROUF ALIDIS AND RINAT KASHAEV",
+     "STAVROS GAROUFALIDIS AND RINAT KASHAEV",
+     "all-caps kerning split, two independent joins in one line"),
+    ("V olume 00, Number 0",
+     "Volume 00, Number 0",
+     "single capital split from a lower-case remainder"),
+    ("Volume Conjecture: Reﬁned and Categoriﬁed",
+     "Volume Conjecture: Refined and Categorified",
+     "fi ligature"),
+    ("Gr¨ obner-Shirshov bases for categories",
+     "Gröbner-Shirshov bases for categories",
+     "floating umlaut before its letter"),
+    ("J ´ER ˆOME DUBOIS, VU HUYNH, AND YOSHIKAZU Y AMAGUCHI",
+     "JÉRÔME DUBOIS, VU HUYNH, AND YOSHIKAZU YAMAGUCHI",
+     "three-fragment name; no intermediate fragment is a word"),
+    ("GR ¨OBNER-SHIRSHOV BASES FOR NON-CRYST ALLOGRAPHIC COXETER GROUPS",
+     "GRÖBNER-SHIRSHOV BASES FOR NON-CRYSTALLOGRAPHIC COXETER GROUPS",
+     "joins across a hyphen; word at the seam, not the concatenation"),
+    # Negatives — these must be left exactly alone.
+    ("NON–ABELIAN REIDEMEISTER TORSION FOR TWIST KNOTS",
+     "NON–ABELIAN REIDEMEISTER TORSION FOR TWIST KNOTS",
+     "an undamaged all-caps title survives untouched"),
+    ("ON THE NUMBER OF THREE MANIFOLDS",
+     "ON THE NUMBER OF THREE MANIFOLDS",
+     "adjacent real words are not welded together"),
+    ("MATHEMATICAL PHYSICS AND TOPOLOGY",
+     "MATHEMATICAL PHYSICS AND TOPOLOGY",
+     "long real words are not welded together"),
+    ("COXETER GROUPS AND ALGEBRAS",
+     "COXETER GROUPS AND ALGEBRAS",
+     "every token attested individually, none jointly"),
+    ("mixed Case Text unaffected",
+     "mixed Case Text unaffected",
+     "mixed-case text is out of scope for the caps rejoin"),
+    ("GRÖBNER-SHIRSHOV BASES FOR NON-CRYSTALLOGRAPHIC COXETER GROUPS",
+     "GRÖBNER-SHIRSHOV BASES FOR NON-CRYSTALLOGRAPHIC COXETER GROUPS",
+     "two real words are not welded even when the document attests the "
+     "welded form as its own damage artefact"),
+    ("L\u2019INSTITUT FOURIER",
+     "L\u2019INSTITUT FOURIER",
+     "an apostrophe must not hide a real word from the seam guard: "
+     "\"L\u2019INSTITUT\" is not a word but \"INSTITUT\" is"),
+    ("Soit K un corps val\u00e9 de hauteur",
+     "Soit K un corps val\u00e9 de hauteur",
+     "a lone symbol before a word is not a kerning split: ungated, the "
+     "split-capital rule turned \"K un\" into \"Kun\""),
+]
+
+
+def main() -> int:
+    repair_text, rejoin_caps = load()
+    vocab = {w.lower() for w in re.findall(r"[^\W\d_]{3,}", repair_text(BODY))}
+    failed = 0
+    for damaged, expected, what in CASES:
+        got = rejoin_caps(repair_text(damaged), vocab)
+        if got == expected:
+            print(f"  ok   {what}")
+        else:
+            failed += 1
+            print(f"  FAIL {what}")
+            print(f"         in:   {damaged}")
+            print(f"         got:  {got}")
+            print(f"         want: {expected}")
+    print(f"\n  {len(CASES) - failed}/{len(CASES)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/who-l1-extractor.test.py
+++ b/scripts/tests/who-l1-extractor.test.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""
+Exercise the WHO L1 extractor in `scripts/extract-candidates.py`.
+
+## What this does and does not establish
+
+It builds a **synthetic** L1 fixture from the structure documented in
+`local/document-intake` §"WHO-Specific Processing" and asserts the
+extractor finds each normative element and maps it to the right block
+kind. That is a logic test.
+
+It is **not** validation against a real WHO guideline. No L1 PDF exists
+in the corpus and `who.int` / `iris.who.int` are 403-blocked by the egress
+policy (measured 2026-08-15), so the real-layout question — do
+recommendations survive Stage A's text extraction as recognisable lines
+once they have been through a *ruled box*, does a GRADE table survive as
+anything parseable — is untouched by this file and remains open.
+
+Read a pass here as "the regexes do what they claim on well-formed
+input", not "the L1 path works". `candidates.json` reports
+`"validated": false` for this class for exactly that reason, and should
+keep doing so until a real guideline has been run.
+
+Run: python3 scripts/tests/who-l1-extractor.test.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+EXTRACT = os.path.join(HERE, "..", "extract-candidates.py")
+
+# Shaped after document-intake's worked example: a boxed numbered
+# recommendation, its strength/certainty line, remarks, a good-practice
+# statement, and a research priority.
+SECTION = """---
+doc_id: who-test-guideline
+doc_title: "WHO Recommendations on Synthetic Test Care"
+section_id: sec-003-recommendations
+section_title: "3 Recommendations"
+section_number: 3
+pages: 12-19
+source_pdf: who-test-guideline.pdf
+source_sha256: 0000000000000000
+---
+
+RECOMMENDATION 1: Daily oral iron and folic acid supplementation is
+recommended for pregnant women to prevent maternal anaemia.
+
+(Strong recommendation, moderate certainty of the evidence)
+
+GRADE: ⊕⊕⊕◯ moderate
+
+Remarks: Implementation should account for local anaemia prevalence and
+existing supplementation programmes.
+
+Good practice statement: Counselling on side-effects should accompany
+every supplementation contact.
+
+Research priority: The optimal dosing interval in settings with high
+malaria burden has not been established.
+
+RECOMMENDATION 2: Ultrasound scan before 24 weeks of gestation is
+recommended for pregnant women to estimate gestational age.
+
+(Conditional recommendation, low certainty of the evidence)
+"""
+
+EXPECT = {
+    "definition": 2,     # two RECOMMENDATIONs
+    "proposition": 1,    # good practice statement
+    "remark": 1,
+    "conjecture": 1,     # research priority
+}
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    with tempfile.TemporaryDirectory() as tmp:
+        docdir = os.path.join(tmp, "who-test-guideline")
+        os.makedirs(os.path.join(docdir, "sections"))
+        with open(os.path.join(docdir, "structure.json"), "w") as fh:
+            json.dump({
+                "_schema": "pdf-structure/v1",
+                "doc_id": "who-test-guideline",
+                "source": {"file": "who-test-guideline.pdf", "sha256": "0" * 64, "pages": 40},
+                "metadata": {"title": "WHO Recommendations on Synthetic Test Care",
+                             "arxiv": None, "doi": None},
+                "sections": [], "toc": [], "diagnostics": {},
+            }, fh)
+        with open(os.path.join(docdir, "sections", "sec-003-recommendations.md"), "w") as fh:
+            fh.write(SECTION)
+
+        r = subprocess.run(
+            [sys.executable, EXTRACT, docdir, "--class", "who-l1", "--json"],
+            capture_output=True, text=True,
+        )
+        if r.returncode != 0:
+            print(r.stderr, file=sys.stderr)
+            return 1
+        res = json.loads(r.stdout)
+
+    got = res["summary"]["by_kind"]
+    for kind, n in EXPECT.items():
+        if got.get(kind, 0) != n:
+            failures.append(f"{kind}: expected {n}, got {got.get(kind, 0)}")
+
+    if res["document_class"] != "who-l1":
+        failures.append(f"document_class: {res['document_class']}")
+
+    # The class must declare itself unvalidated — this is the honesty flag
+    # the whole file exists to protect.
+    if res.get("validated") is not False:
+        failures.append("validated should be False for the who-l1 class")
+
+    # Nothing in a guideline is a formalization candidate; that routing
+    # belongs to the math class alone.
+    if res["summary"]["formalization_candidates"] != 0:
+        failures.append("who-l1 must not emit formalization candidates")
+
+    recs = [c for c in res["candidates"] if c["source_kind"] == "recommendation"]
+    if [c["number"] for c in recs] != ["1", "2"]:
+        failures.append(f"recommendation numbers: {[c['number'] for c in recs]}")
+    if not recs or not recs[0]["grade_nearby"]:
+        failures.append("GRADE marker not detected next to recommendation 1")
+    strengths = [c.get("strength") for c in recs]
+    if strengths != ["strong", "conditional"]:
+        failures.append(f"strength: {strengths}")
+    for c in res["candidates"]:
+        if c["route_to"] != "l2-dak-authoring":
+            failures.append(f"route_to: {c['route_to']}")
+            break
+
+    # Negative case: with the GRADE line and the strength parentheticals
+    # removed, neither signal may survive. This is what caught the original
+    # `\bhigh|moderate|low` alternation — the phrase "high malaria burden"
+    # in a nearby research priority kept grade_nearby true.
+    import re as _re
+    stripped = _re.sub(r"\(Strong recommendation.*?\)|GRADE:.*|\(Conditional recommendation.*?\)",
+                       "", SECTION)
+    with tempfile.TemporaryDirectory() as tmp:
+        docdir = os.path.join(tmp, "who-test-guideline")
+        os.makedirs(os.path.join(docdir, "sections"))
+        with open(os.path.join(docdir, "structure.json"), "w") as fh:
+            json.dump({"_schema": "pdf-structure/v1", "doc_id": "who-test-guideline",
+                       "source": {"file": "x.pdf", "sha256": "0" * 64, "pages": 40},
+                       "metadata": {"title": "t", "arxiv": None, "doi": None},
+                       "sections": [], "toc": [], "diagnostics": {}}, fh)
+        with open(os.path.join(docdir, "sections", "s.md"), "w") as fh:
+            fh.write(stripped)
+        r2 = subprocess.run([sys.executable, EXTRACT, docdir, "--class", "who-l1", "--json"],
+                            capture_output=True, text=True)
+        neg = json.loads(r2.stdout)
+    nrecs = [c for c in neg["candidates"] if c["source_kind"] == "recommendation"]
+    if any(c["grade_nearby"] for c in nrecs):
+        failures.append("grade_nearby true with no GRADE marker present "
+                        "(regex matching a bare certainty word)")
+    if any(c.get("strength") for c in nrecs):
+        failures.append("strength detected with no strength parenthetical present")
+
+    if failures:
+        print("FAIL")
+        for f in failures:
+            print("  -", f)
+        return 1
+
+    print(f"ok — {res['summary']['candidates']} candidates, kinds {got}")
+    print("NOTE: synthetic fixture only; the real-layout question is untested "
+          "(no L1 PDF in corpus, who.int egress 403).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The platform half of document ingestion: two domain-neutral producers and the assessment behind them. The content half is [litlfred/qou#5134](https://github.com/litlfred/qou/pull/5134).

## `scripts/pdf-structure.py`

PDF → `structure.json` + `sections/*.md`, pure `pypdf`, no network, no GPU, no service. Metadata comes from the *text*, not DocInfo — only 37% of these PDFs carry a plausible `/Title`.

Most of the work went into repairing damage that looks cosmetic and is not, because the damaged string is what the index and corpus-grep both see — a search for "Garoufalidis" does not match "GAROUF ALIDIS":

- **Ligatures and floating accents** — `Reﬁned`, `Gr¨ obner`, `J ´ER ˆOME`. Unambiguous, repaired outright.
- **Kerning splits** — `STA VROS GAROUF ALIDIS`, `V olume`. Nothing about the *shape* of two capitalised fragments says whether they are one word or two, so a join is made only when the joined form is attested elsewhere in the same document, **and outnumbers the fragments it was broken into**. Frequency, not presence: a document carrying this damage attests its own artefacts, which is how `BASES FOR` became `BASESFOR` while `NON-CRYST ALLOGRAPHIC` stayed broken. Presence cannot separate those two cases.
- **Furniture above the title** — the scan now stops at the first *contiguous* non-furniture line. Taking the last furniture line anywhere in the window, which it did, walks past the title whenever furniture is printed *below* it: a DOI URL under a byline, or a rotated arXiv margin stamp that pypdf emits after the abstract.
- **`title_lines`** is preserved, because the line break is the only reliable title/byline boundary — in an all-caps title, `THEORY TOM BRIDGELAND` has the same shape as `TORUS KNOT`.

`scripts/tests/pdf-text-repair.test.py` — 16 cases, every one real damage from the qou library, **including five negatives**. Each guard exists because an earlier version fixed one case and broke another, so the negatives carry as much weight as the positives.

## `scripts/pdf-ocr.py`

For the documents no parser reaches: scans with no text layer, and JIS-encoded scans whose text layer is mojibake — ~1,100 chars/page of `Fs=E2=7k$SL\$Ncolored Jones`, which passes every "did we get text" check.

**The engine choice is made by egress, not by benchmark scores.** Every model-based OCR — PaddleOCR, docTR, Surya, EasyOCR — fetches weights from Hugging Face on first run, and `huggingface.co` returns 403 under organisation policy. Tesseract's language data ships as apt packages and runs offline; `rapidocr-onnxruntime` is the one model-based option that also works offline (weights inside the wheel) and is the natural second string. Full table in `docs/proposals/rag-document-ingestion.md` §9-bis.

Two traps recorded because both fail *silently*:

- **`poppler-data` is a hard requirement for CJK.** Without it `pdftoppm` reports the missing Adobe-Japan1 CMap on stderr, produces no image, and **exits 0** — so the pipeline reads nothing and reports success. That is now raised rather than returned as a quiet zero.
- **Language must be detected, not assumed.** A Japanese page read as `-l eng` returns near-nothing; a requested pack that is not installed makes Tesseract exit non-zero and return nothing at all.

OCR is explicit and cached per page; `pdf-structure.py --ocr` reads that cache and records `source.text_source: "ocr"` so a consumer knows the text is a transcription.

## Gates

| Gate | Result |
|---|---|
| `bun test` | 631 pass, 46 skip, **0 fail** |
| `eslint .` | exit 0 |
| `gen-schema-docs` + `gen-skill-docs` | no uncommitted diff |
| `pdf-text-repair.test.py` | 16/16 |
| `who-l1-extractor.test.py` | passes — **synthetic fixture only** |

## Honest limits

- OCR recovers *text*, not *judgement*. An OCR'd masthead is still a masthead; the title/byline problems apply unchanged to the transcription, and several OCR'd documents still needed a hand-verified override downstream.
- The WHO L1 extractor is logic-tested against a synthetic fixture. No L1 PDF exists in the corpus and `who.int` returns 403, so the real-layout question is **untested** — the test file says so in its own header.
- `pdf-structure` remains deliberately `pypdf`-only; OCR is a separate step precisely so the producer does not acquire binary dependencies.