### PR TITLE
main has been red since 29b03f7b — one impossible cast in validate.ts

### DIFF
--- a/content/pipeline/validate.ts
+++ b/content/pipeline/validate.ts
@@ -166,7 +166,7 @@ async function loadBlocksFromDir(
       // dependency graph entirely. Three more carry `is_mathematics`. The same
       // class bit this schema once before — `of` itself was declared on the TS
       // type and missing from the Zod object, and was stripped until noticed.
-      for (const key of Object.keys(block as Record<string, unknown>)) {
+      for (const key of Object.keys(block)) {
         if (key in (result.data as Record<string, unknown>)) continue;
         issues.push({
           level: "warning",


### PR DESCRIPTION
`Code-quality gates` fails on **every push to `main`** since `29b03f7b` (2026-08-15 12:38 Z). Last green: `1690d08d`, 2026-08-11. Every PR opened since inherits the red — I found it because #118 did.

## The entire failure is one line

```
content/pipeline/validate.ts(169,37): error TS2352: Conversion of type 'Block'
to type 'Record<string, unknown>' may be a mistake because neither type
sufficiently overlaps with the other.
  Type 'TableBlock' is not comparable to type 'Record<string, unknown>'.
    Index signature for type 'string' is missing in type 'TableBlock'.
```

`Block` is a discriminated union and `TableBlock` has no index signature, so the assertion isn't a legal widening.

## The cast was never needed

`Object.keys` is typed `(o: object) => string[]`, and `Block` already satisfies `object` — the argument type-checks on its own. So this drops the assertion rather than laundering it:

```diff
-      for (const key of Object.keys(block as Record<string, unknown>)) {
+      for (const key of Object.keys(block)) {
```

I deliberately did **not** take the fix the compiler suggests (`as unknown as Record<string, unknown>`). That silences the checker by discarding the type; this passes by being correct. Runtime behaviour is identical either way — the loop enumerates the raw object's own keys, which is exactly the intent documented in the comment above it (compare the raw manifest's keys against the parsed result's, to catch fields Zod silently drops).

The sibling cast on the next line (`result.data as Record<string, unknown>`) is untouched — it compiles, because `result.data` isn't the union.

## Verification

- `bunx tsc --noEmit -p tsconfig.json`: **no error in `validate.ts`** (previously the one above). Confirmed the same error reproduces on pristine `main` at `b987547` with no changes of mine, so this is base breakage, not #118's.
- `bun run lint`: clean.
- `bun test`: **identical before and after** — 635 pass / 35 skip / 7 fail. Those 7 are pre-existing in my sandbox (dev deps absent locally, e.g. `csl-json`) and byte-identically present on pristine `main`; CI itself reported 638 pass / 0 fail with full deps, and the only CI-red step was `tsc`.

Unblocks #118 and anything else opened since Friday midday.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7UaMoA5dvHUrvAAsNFdor)_