### PR TITLE
fix(qa-utils): don't fall back to an import-only aggregator — it makes checkers pass vacuously

### DIFF
--- a/content/pipeline/qa-utils.ts
+++ b/content/pipeline/qa-utils.ts
@@ -324,6 +324,32 @@ function lakeBasenameMap(
  * purpose: it only *gates* candidate (a), and a false positive there is no
  * worse than the pre-fix behaviour.
  */
+/** Regex fragment listing every Lean top-level declaration keyword. */
+const _DECL_KW =
+  "theorem|lemma|def|abbrev|instance|structure|class|inductive|opaque|axiom";
+
+/**
+ * Does `file` declare **anything at all**, or is it an import-only aggregator?
+ *
+ * Used to keep the safe fallback from handing back a file that declares
+ * nothing. A ref naming a decl that does not exist (e.g. `qou:QOU.Foo` when no
+ * `Foo` was ever written) parses with module `QOU`, whose module-path file is
+ * the library root — a list of `import` lines. Returning that made every
+ * checker audit the import list and **pass**, which is strictly worse than the
+ * honest `n/a` an unresolved ref produces. Measured on the qou corpus
+ * 2026-08-15: 65 of 1220 blocks resolved this way (bean `qou-cu0a`).
+ */
+function fileDeclaresAnything(file: string): boolean {
+  let body: string;
+  try {
+    body = readFileSync(file, "utf-8");
+  } catch {
+    return false;
+  }
+  return new RegExp(`^\\s*(?:noncomputable\\s+|private\\s+|protected\\s+)*(?:${_DECL_KW})\\s`, "mu")
+    .test(body);
+}
+
 function fileDeclaresName(file: string, name: string): boolean {
   let body: string;
   try {
@@ -488,7 +514,15 @@ export function resolveCanonicalLean(
   // (safe fallback) preserve legacy behaviour: a ref that resolved to the
   //   direct module-path before the (a)-gate still resolves to it, so no
   //   previously-resolving ref regresses to `undefined`.
-  if (directExists) return direct;
+  //
+  //   EXCEPT when that file declares nothing at all. An import-only aggregator
+  //   carries no statement to audit, so returning it makes every checker pass
+  //   vacuously on a list of `import` lines — strictly worse than the honest
+  //   `n/a` that `undefined` produces, because a false green is indistinguishable
+  //   from a real one. Refs naming a decl that exists nowhere land here (module
+  //   `QOU` → the library root); 65 of 1220 qou blocks did, bean `qou-cu0a`.
+  //   Real single-module files still fall back exactly as before.
+  if (directExists && fileDeclaresAnything(direct)) return direct;
   return undefined;
 }
 

--- a/scripts/tests/lean-ref-coverage.test.ts
+++ b/scripts/tests/lean-ref-coverage.test.ts
@@ -229,6 +229,29 @@ describe("lean.ref candidate-2 (library tree) resolution", () => {
     }
   });
 
+  test("ref naming a nonexistent decl does NOT fall back to an import-only root", () => {
+    const { tmp, lake } = makeWorkspace();
+    try {
+      // The library root is an import-only aggregator, exactly like qou's
+      // 954-line `QOU.lean`. A ref whose decl exists nowhere parses with
+      // module `QOU`, so its module-path IS this file.
+      writeLake(lake, "QOU.lean", "import QOU.Some.Module\nimport QOU.Other\n");
+      writeLake(lake, "QOU/Some/Module.lean", GENERIC_R_BODY);
+
+      // Must be undefined (-> honest n/a), never the aggregator: returning it
+      // makes every checker pass vacuously on a list of imports (qou-cu0a).
+      expect(resolveCanonicalLean("qou:QOU.NoSuchDeclAnywhere", REPO_ROOT)).toBeUndefined();
+
+      // But a module-path file that DOES declare something still resolves —
+      // the fallback is narrowed, not removed.
+      const real = resolveCanonicalLean("qou:QOU.Some.Module.genId", REPO_ROOT);
+      expect(real).toBeDefined();
+      expect(real!.replace(/\\/g, "/")).toContain("/QOU/Some/Module.lean");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   test("unknown package / malformed ref resolves to undefined", () => {
     makeWorkspace();
     expect(resolveCanonicalLean("nope:QOU.X", REPO_ROOT)).toBeUndefined();


### PR DESCRIPTION
## The defect

`resolveCanonicalLean` ends with a safe fallback that returns the direct module-path file when candidates (a)/(b)/(c) all miss, so no previously-resolving ref regresses to `undefined`. But when that file **declares nothing** — an import-only aggregator — returning it is worse than returning nothing: every checker then audits a list of `import` lines and **passes**.

`wall-side-correct` sees no archimedean markers → pass. `proof-no-bare-sorries` sees no `sorry` → pass. The block reads as formalised and green while nothing of the kind was checked. **A false green is indistinguishable from a real one**, whereas `undefined` yields an honest `n/a`.

Refs naming a declaration that exists nowhere land here: `qou:QOU.Foo` parses with module `QOU`, whose module-path file is the 954-line library root.

## The fix

Narrowed, **not removed**. The fallback still fires for any file that declares something; a new `fileDeclaresAnything()` gates it. Genuinely-resolving refs are unaffected.

## Measured impact — small and safe

An earlier revision of this PR claimed ~304 affected blocks. **That was wrong and is corrected here.** Those scans called `resolveCanonicalLean` directly, which resolves candidates 2–3 only and does **not** check for a co-located sibling `.lean`. The pipeline never calls it that way: `walkBlocks` checks the **sibling first** (candidate 1) and only falls through to the resolver when there is none. So 880 sibling-owning blocks were miscounted as affected.

Measured the way `walkBlocks` actually resolves, over the qou corpus:

| | count |
|---|---|
| blocks carrying a `qou:` ref | 1220 |
| resolved by **sibling** (candidate 1) | **880** — untouched by this change |
| resolved via library tree (candidates 2/3) | 336 |
| **truly unresolved after the fix** | **4** |
| sidecar verdicts flipping `pass` → `n/a` | **12** |

The four blocks: `figure-eight-reeb-theta-value`, `crossing-energy-pair-cancellation`, `channel-rotation-askey-lit`, `complex-volume-character-variety-path` — each naming a declaration that exists nowhere in the tree.

## Verification

- Five spot-checked decl-bearing refs still resolve: `TauQuantumIntegerForm`, `QChebyshevFunction`, `CosimplicialCrossedGroupoid.YekutieliTriple`, `QJucysMurphy`, `Torsion.YekutieliTriple`.
- An aggregator ref now returns `undefined`.
- Regression test in `scripts/tests/lean-ref-coverage.test.ts` asserts **both** directions — the aggregator is refused *and* a decl-bearing module-path file still resolves, so the fallback cannot be silently gutted later.
- Full suite: **706 tests, 0 fail**; eslint clean; generated docs in sync.

## Adoption

The earlier "expect coverage to drop, re-sweep before adopting" warning was written against the wrong number and is **withdrawn**. Twelve verdicts across four blocks move from a false `pass` to an honest `n/a`; a normal sweep picks that up. Recorded on the qou side in `qou-cu0a`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUnKeZE2YcdjGmTEcKA2Ng