### PR TITLE
The editorial cycle count is a snapshot, so stop quoting one

### DIFF
--- a/.beans/folio-assistant-i8ad--count-interprets-as-an-editorial-edge-in-the-conte.md
+++ b/.beans/folio-assistant-i8ad--count-interprets-as-an-editorial-edge-in-the-conte.md
@@ -111,3 +111,27 @@ Prune damage on the union: **658 → 581**. More than the 37 directly-declared,
 because the new edges restore transitive reachability for others.
 
 tsc 0 · 702 tests / 0 fail · eslint clean.
+
+
+## 2026-08-15 — the cycle count was a snapshot, not a property
+
+Recorded here as "exactly one" cycle. A few hours later, after `main` moved
+3792 files, the same check reports **four**:
+
+```
+rem:frobenius-packing-density   -> conj:mass-volume-factorization -> …
+thm:ns-singularity-descartes    -> prop:ns-kummer-specialisation  -> …
+rem:skein-filtration-trichotomy -> conj:q-collatz -> …
+prop:ns-kummer-specialisation   -> rem:skein-filtration-trichotomy -> conj:q-collatz -> …
+```
+
+All four are pre-existing content cycles that counting `interprets` makes
+visible; three arrived with merged content after this bean was measured. Nothing
+here caused them, and the framing — *revealed, not introduced* — survives.
+
+What does not survive is the number. `AGENTS.md` now says so explicitly rather
+than carrying a figure that goes stale whenever content lands. Same class of
+error this bean's own arc kept finding: a measurement quoted as a property.
+
+The forward-reference gate moved the same way, 195 -> 196, from the same merged
+content and likewise not from this change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,8 +135,11 @@ a background subagent, not the foreground.
   `detangler-no-forward-ref` builds its own `uses`-only adjacency in
   `loadChapterGraph` and does **not** consume `content-graph`, so it is
   unaffected and ten forward-pointing `interprets` edges are outside what it
-  counts; and the graph is no longer acyclic — one genuine editorial cycle is
-  revealed rather than introduced (see `i8ad`).
+  counts; and the graph is no longer acyclic — genuine editorial cycles are
+  revealed rather than introduced (see `i8ad`). **Do not quote a count from
+  here**: it was 1 when `i8ad` was measured and 4 a few hours later on merged
+  content, none of it caused by the change. Run the check against the corpus
+  in front of you.
   It is **not** the formal dependency graph; that is machine-derived from
   `lean.ref`. The two diverge legitimately in both directions (a proof invokes
   `simp` lemmas nobody reads about; a theorem is motivated by an example it


### PR DESCRIPTION
Follow-up to #117, on a branch restarted from the new `main` since that PR is merged.

`AGENTS.md` says counting `interprets` reveals "**one** genuine editorial cycle". That was true when `i8ad` measured it, and **four** a few hours later after `main` moved 3792 files:

```
rem:frobenius-packing-density   -> conj:mass-volume-factorization -> …
thm:ns-singularity-descartes    -> prop:ns-kummer-specialisation  -> …
rem:skein-filtration-trichotomy -> conj:q-collatz -> …
prop:ns-kummer-specialisation   -> rem:skein-filtration-trichotomy -> conj:q-collatz -> …
```

None of it caused by that change — all four are pre-existing content cycles the relation makes visible, and three arrived with merged content afterwards. The framing *revealed, not introduced* survives. The number doesn't.

Replaced with an instruction to run the check against the corpus in front of you. Carrying a figure that goes stale whenever content lands is the same error this whole arc kept finding elsewhere: **a measurement quoted as a property.**

The forward-reference gate moved the same way, 195 → 196, from the same merged content.

tsc 0 · 702 tests / 0 fail · eslint clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_016hQePZH4xA7gxL5eLTP5av)_