### PR TITLE
Cycle detection could not see an `interprets` leg

### DIFF
--- a/.beans/folio-assistant-wesu--cycle-detection-cannot-see-an-interprets-leg.md
+++ b/.beans/folio-assistant-wesu--cycle-detection-cannot-see-an-interprets-leg.md
@@ -1,0 +1,80 @@
+---
+# folio-assistant-wesu
+title: Cycle detection cannot see an interprets leg
+status: completed
+type: bug
+created_at: 2026-08-15T23:40:00Z
+updated_at: 2026-08-15T23:40:00Z
+---
+
+Asked how the four editorial cycles could be **prevented at author time**. The
+answer turned out to be mostly reassuring, with one precise hole.
+
+## The mechanical check already exists, and mostly works
+
+`detangler-no-dependency-cycle` is a real QA criterion with a real
+implementation. Run against the six blocks in the four cycles:
+
+| block | before this fix |
+|---|---|
+| `conj:q-collatz` | **fail** |
+| `thm:ns-singularity-descartes` | **fail** |
+| `prop:ns-kummer-specialisation` | **fail** |
+| `rem:skein-filtration-trichotomy` | **fail** |
+| `rem:frobenius-packing-density` | pass |
+| `conj:mass-volume-factorization` | pass |
+
+So three of the four cycles are **already flagged** — they are known findings
+sitting in the corpus, not undetected ones. Author-time prevention for the
+`uses[]`-only case is in place and needs nothing.
+
+## The hole: one cycle it cannot see
+
+`loadChapterGraph` builds `usesGraph` from `uses[]` alone, and `inCyclePath` is
+computed from that. So a cycle whose return leg is an `interprets` edge is
+invisible:
+
+```
+rem:frobenius-packing-density --interprets--> conj:mass-volume-factorization
+conj:mass-volume-factorization --uses-------> rem:frobenius-packing-density
+```
+
+"Read A before B and B before A" is exactly as circular whichever field carries
+the leg. `interprets` became an editorial edge in `i8ad`; the cycle scan did not
+follow.
+
+## The fix, and what it deliberately does not touch
+
+A separate `editorialGraph` (`uses[]` + `interprets`) inside `loadChapterGraph`,
+used **only** for cycle detection. `usesGraph` is untouched, so
+`detangler-no-forward-ref` keeps counting `uses[]` alone.
+
+That separation is the whole design. Merging them would also make the
+forward-reference gate count the ten forward-pointing `interprets` edges,
+moving it 196 → ~206 — a number five merged PRs were measured against. That is
+a **separate** decision and is not smuggled in here.
+
+Verified: cycle-flagged blocks **4 → 6** (all six members now caught), forward
+references **196 → 196**.
+
+## Tests
+
+`scripts/tests/editorial-cycle-detection.test.ts`, three of them, asserted
+generically against whatever folio is attached rather than against specific
+labels — a test that hardcodes content breaks when the content is fixed.
+
+- the checker flags every block the union graph puts on a cycle (**fails**
+  against the pre-fix checker — this is the regression)
+- it invents none the union graph does not have
+- forward-reference hits all name a `uses[]` target, so the gate cannot have
+  been widened as a side effect
+
+The last two pass either way by design: they are the guards that keep the fix
+from over-reaching, not evidence of the bug.
+
+## What this does not do
+
+It does not resolve the four cycles. Those are editorial: each says a reader
+must read A before B and B before A, and choosing which leg to cut is a claim
+about what a block is *about*. The checker's job is to stop the fifth one being
+written, and now it can.

--- a/content/pipeline/qa-checkers-extended.ts
+++ b/content/pipeline/qa-checkers-extended.ts
@@ -28,7 +28,7 @@ import { fileURLToPath } from "url";
 import { Q_USAGE_AUTOMATED_CHECKERS } from "./qa-checkers-q-usage";
 import { hashFile } from "./qa-utils";
 import { findContentRepoRoot, findPapers } from "./repo-root";
-import { maskStringsAndComments, stripArrayField } from "./uses-field";
+import { maskStringsAndComments, parseStringField, stripArrayField } from "./uses-field";
 
 const __filename = fileURLToPath(import.meta.url);
 // Resolve content-repo paths (witnesses under <repo>/computations, Lean
@@ -1916,6 +1916,9 @@ function loadChapterGraph(): void {
   const chapterOrder = new Map<string, number>();
   const labelToChapter = new Map<string, string>();
   const usesGraph = new Map<string, string[]>();
+  // `uses[]` PLUS `interprets` — the full editorial relation. Cycle detection
+  // runs on this; the ordering measures stay on `usesGraph`.
+  const editorialGraph = new Map<string, string[]>();
   // Deliberate forward references, per block. A separate adjacency (rather
   // than a per-file re-parse) so the RECEIVE side of the tanglement metric
   // can ask "did the citing block declare this?" without reading that
@@ -1975,8 +1978,7 @@ function loadChapterGraph(): void {
             labelToChapter.set(m[1], `${paper}/${dir}`);
             slugToLabel.set(f.slice(0, -3), m[1]);
             // Record the block's `uses:[...]` dependency edges (only the
-            // uses array — NOT cites/interprets/own-label) for cycle
-            // detection.
+            // uses array — NOT cites/own-label) for ordering measures.
             // De-duplicate: a block listing the same `uses:` label twice
             // must not inflate out-degree / in-degree / cone size — count
             // unique dependency edges only.
@@ -1984,6 +1986,19 @@ function loadChapterGraph(): void {
               ...new Set(parseManifestStringArray(content, "uses")),
             ];
             usesGraph.set(m[1], useLabels);
+            // The EDITORIAL adjacency additionally carries `interprets`, which
+            // is an editorial dependency too (bean `i8ad`). Kept separate from
+            // `usesGraph` on purpose: cycle detection must see the whole
+            // relation, while the forward-reference count stays on `uses[]`
+            // alone. Merging them would move a gate five merged PRs were
+            // measured against, and that is a separate decision.
+            const interpretsTarget = parseStringField(content, "interprets");
+            editorialGraph.set(
+              m[1],
+              interpretsTarget && !useLabels.includes(interpretsTarget)
+                ? [...useLabels, interpretsTarget]
+                : useLabels,
+            );
             foreshadowGraph.set(m[1], parseForeshadows(content));
             // Collect the narrative's raw block references now; the
             // forward/backward split needs positions, which are built in the
@@ -2045,15 +2060,21 @@ function loadChapterGraph(): void {
     }
   }
 
-  // Precompute uses[]-cycle membership ONCE: for each label on a
+  // Precompute EDITORIAL cycle membership ONCE: for each label on a
   // dependency cycle, store an example back-to-self path. Per-block
   // checks then become an O(1) lookup.
+  //
+  // Runs on `editorialGraph`, not `usesGraph`. A cycle through an `interprets`
+  // edge is just as circular for a reader — "read A before B and B before A" —
+  // and one such cycle sat undetected in the corpus because this scan could
+  // not see that leg (`rem:frobenius-packing-density` interprets
+  // `conj:mass-volume-factorization`, which `uses` it back).
   const inCyclePath = new Map<string, string[]>();
-  for (const start of usesGraph.keys()) {
+  for (const start of editorialGraph.keys()) {
     const visited = new Set<string>([start]);
     const path: string[] = [start];
     const dfs = (node: string): string[] | null => {
-      for (const next of usesGraph.get(node) ?? []) {
+      for (const next of editorialGraph.get(node) ?? []) {
         if (next === start) return [...path, start];
         if (!visited.has(next)) {
           visited.add(next);
@@ -2569,7 +2590,9 @@ export function checkDetanglerNoDependencyCycle(
         {
           file: tsPath,
           line: 0,
-          text: `uses[] dependency cycle: ${cyclePath.join(" -> ")}`,
+          text:
+            `editorial dependency cycle (uses[] + interprets): ` +
+            `${cyclePath.join(" -> ")}`,
         },
       ],
     };

--- a/scripts/tests/editorial-cycle-detection.test.ts
+++ b/scripts/tests/editorial-cycle-detection.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import {
+  checkDetanglerNoDependencyCycle,
+  checkDetanglerNoForwardRef,
+} from "../../content/pipeline/qa-checkers-extended";
+import { buildContentGraph } from "../../content/pipeline/content-graph";
+import { walkBlocks } from "../../content/pipeline/qa-utils";
+import { FOLIO_ROOT, hasFolio } from "./helpers";
+import { join } from "path";
+
+/**
+ * `detangler-no-dependency-cycle` scanned `uses[]` alone, so a cycle running
+ * through an `interprets` edge was invisible — and one sat in the corpus
+ * undetected: a remark interpreting a conjecture that `uses` the remark back.
+ * "Read A before B and B before A" is just as circular whichever field carries
+ * the leg.
+ *
+ * The fix runs cycle detection on the full editorial relation while leaving
+ * `detangler-no-forward-ref` on `uses[]`. That separation is the point, and
+ * these tests pin both halves of it: the checker must agree with the union
+ * graph, and the forward-reference count must not have been widened as a side
+ * effect — widening it moves a number several merged PRs were measured against.
+ *
+ * Asserted generically against whatever folio is attached, never against
+ * specific labels: a test that hardcodes content is a test that breaks when the
+ * content is right.
+ */
+describe.skipIf(!hasFolio())("editorial cycle detection", () => {
+  // Lazy: `describe.skipIf` still evaluates this body, and FOLIO_ROOT is
+  // undefined when the platform repo is tested on its own.
+  const contentDir = (): string => join(FOLIO_ROOT!, "content");
+
+  /** Labels the checker says sit on a cycle. */
+  function flaggedByChecker(): Set<string> {
+    const out = new Set<string>();
+    for (const b of walkBlocks(contentDir())) {
+      if (checkDetanglerNoDependencyCycle(b.ts).result === "fail") out.add(b.label);
+    }
+    return out;
+  }
+
+  /** Labels that genuinely sit on a cycle in the union editorial graph. */
+  function onCycleInUnionGraph(): Set<string> {
+    const g = buildContentGraph(contentDir(), FOLIO_ROOT!);
+    const WHITE = 0, GREY = 1, BLACK = 2;
+    const colour = new Map<string, number>();
+    const onCycle = new Set<string>();
+    const dfs = (n: string, stack: string[]): void => {
+      colour.set(n, GREY);
+      stack.push(n);
+      for (const m of g.out(n, "editorial")) {
+        const c = colour.get(m) ?? WHITE;
+        if (c === GREY) for (const l of stack.slice(stack.indexOf(m))) onCycle.add(l);
+        else if (c === WHITE) dfs(m, stack);
+      }
+      stack.pop();
+      colour.set(n, BLACK);
+    };
+    for (const n of g.nodes.keys()) if ((colour.get(n) ?? WHITE) === WHITE) dfs(n, []);
+    return onCycle;
+  }
+
+  test("the checker flags every block the union graph puts on a cycle", () => {
+    // The regression: an `interprets` leg made a real cycle invisible here, so
+    // the axis reported clean on material it could not see.
+    const flagged = flaggedByChecker();
+    for (const label of onCycleInUnionGraph()) {
+      expect(flagged.has(label)).toBe(true);
+    }
+  });
+
+  test("the checker does not invent cycles the union graph does not have", () => {
+    const onCycle = onCycleInUnionGraph();
+    for (const label of flaggedByChecker()) {
+      expect(onCycle.has(label)).toBe(true);
+    }
+  });
+
+  test("forward-reference counting was NOT widened to interprets", () => {
+    // Every hit must name a `uses[]` target. If `interprets` had leaked into
+    // the ordering adjacency, hits would appear for edges no `uses[]` carries,
+    // and the gate's number would move under everyone measuring against it.
+    const g = buildContentGraph(contentDir(), FOLIO_ROOT!);
+    for (const b of walkBlocks(contentDir())) {
+      const r = checkDetanglerNoForwardRef(b.ts);
+      if (!r.hits.length) continue;
+      const usesTargets = new Set(
+        g.outEdges(b.label, "editorial")
+          .filter((e) => e.editorialField === "uses")
+          .map((e) => e.to),
+      );
+      for (const hit of r.hits) {
+        const named = [...usesTargets].some((t) => hit.text.includes(t));
+        expect(named).toBe(true);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Bean `fa/wesu`. Answering "how do we prevent this at author time?" — and the answer is mostly reassuring.

## The mechanical check already exists

`detangler-no-dependency-cycle` is a real criterion with a real implementation. Against the six blocks in the four cycles:

| block | before |
|---|---|
| `conj:q-collatz` | **fail** |
| `thm:ns-singularity-descartes` | **fail** |
| `prop:ns-kummer-specialisation` | **fail** |
| `rem:skein-filtration-trichotomy` | **fail** |
| `rem:frobenius-packing-density` | pass |
| `conj:mass-volume-factorization` | pass |

**Three of the four cycles are already flagged** — known findings sitting in the corpus, not undetected ones. Author-time prevention for the `uses[]` case needs nothing.

## The hole: one cycle it cannot see

`loadChapterGraph` builds `usesGraph` from `uses[]` alone and `inCyclePath` from that, so a cycle whose return leg is an `interprets` edge is invisible:

```
rem:frobenius-packing-density  --interprets-->  conj:mass-volume-factorization
conj:mass-volume-factorization --uses-------->  rem:frobenius-packing-density
```

"Read A before B and B before A" is exactly as circular whichever field carries the leg. `interprets` became an editorial edge in `i8ad`; the cycle scan didn't follow.

## The fix, and what it deliberately leaves alone

A separate `editorialGraph` (`uses[]` + `interprets`) used **only** for cycle detection. `usesGraph` is untouched, so `detangler-no-forward-ref` keeps counting `uses[]` alone.

That separation is the design. Merging them would also make the forward-reference gate count the ten forward-pointing `interprets` edges, moving it **196 → ~206** — a number five merged PRs were measured against. That's a separate decision and isn't smuggled in here.

Verified: cycle-flagged blocks **4 → 6** (all six members caught), forward references **196 → 196**.

## Tests

Three, asserted generically against whatever folio is attached rather than against specific labels — a test that hardcodes content breaks when the content is *fixed*.

- flags every block the union graph puts on a cycle — **fails against the pre-fix checker**, so it can catch the regression
- invents none the union graph doesn't have
- forward-reference hits all name a `uses[]` target, so the gate can't have been widened as a side effect

The last two pass either way by design: guards against over-reach, not evidence of the bug.

## What this does not do

Resolve the four cycles. Each says a reader must read A before B and B before A, and choosing which leg to cut is a claim about what a block is *about* — editorial, and being handled separately in `qou`. This stops the fifth one being written.

tsc 0 · 705 tests / 0 fail · eslint clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_016hQePZH4xA7gxL5eLTP5av)_