### PR TITLE
qa(registry): da-arity-conflation — agent-adjudicated by measurement, not convenience

### DIFF
--- a/content/pipeline/qa-criteria-registry.ts
+++ b/content/pipeline/qa-criteria-registry.ts
@@ -1781,6 +1781,15 @@ const DEVILS_ADVOCATE: QaCriterionDefinition[] = [
   { id: "da-overclaim", domain: "devils-advocate", description: "Conclusion stronger than the argument supports: scope-limited negative as structural, fitted-as-derived, conditional-as-proved, approximate-as-absolute.", default_severity: "major", depends_on: ["md", "ts", "lean"], automated: false },
   { id: "da-hidden-dof", domain: "devils-advocate", description: "Undisclosed free parameter: 4th calibration, off-menu coefficient, constant with no canonical-chain origin.", default_severity: "major", depends_on: ["md", "ts", "lean"], automated: false },
   { id: "da-non-sequitur", domain: "devils-advocate", description: "Logical gap: step B does not follow from step A; 'therefore' with a missing lemma.", default_severity: "major", depends_on: ["md", "ts", "lean"], automated: false },
+  // `automated: false` here is a MEASURED necessity, not a convenience. A
+  // prototype scanner flags all 4 known instances but fires IDENTICALLY on the
+  // CORRECTED text — it detects the topic, not the defect, because the
+  // discriminating fact (does the index bind across the equivalence? is the
+  // symbol level-indexed in its Lean type? are the two legs the same instance?)
+  // is semantic, not lexical. ~10% actionable precision over 6395 files. The
+  // candidate lister is print-only; only an agent verdict writes a sidecar.
+  // Four questions + full measurement: qou `local/devils-advocate-watcher`.
+  { id: "da-arity-conflation", domain: "devils-advocate", description: "A predicate that VARIES (over states, levels, or instances) conflated with the single truth value of its universal closure: a level-indexed family read as one Prop; a pointwise claim (forall P, v <-> Pred P) refuted where the corpus asserts the universal closure (v <-> forall P, Pred P, which is trivially inhabited); a one-instance theorem read as a cross-instance identification; a set-level fact (undecidable / not cut out by an ideal / cofinite locus) used to deny a truth-value equivalence.", default_severity: "major", depends_on: ["md", "ts", "lean"], automated: false },
   { id: "da-lean-narrative-divergence", domain: "devils-advocate", description: "Lean proves something weaker/different/vacuously-implied vs the .md claim (proof-statement-integrity).", default_severity: "major", depends_on: ["md", "ts", "lean"], automated: false },
   { id: "da-citation-misuse", domain: "devils-advocate", description: "Cited reference (cites[] or -- Ref:) does not contain / is mis-attributed for the invoked result.", default_severity: "minor", depends_on: ["md", "ts", "lean"], automated: false },
   { id: "da-definitional-ambiguity", domain: "devils-advocate", description: "Key term undefined / multiple incompatible readings / 'the unique X' without uniqueness / implicit regime or base ring.", default_severity: "minor", depends_on: ["md", "ts", "lean"], automated: false },


### PR DESCRIPTION
Registers the criterion specified in qou's `local/devils-advocate-watcher`. Companion to **litlfred/qou#5169**, which carries the skill-doc spec, the AGENTS.md discipline, and the candidate lister.

## What it names

An error class that produced **four separate durable-artifact errors in a single qou session** (2026-08-15), none of which any existing `da-*` criterion flagged:

1. A level-indexed family `kappa_vanishes : ℕ → Prop` collapsed to one `Prop`.
2. A **pointwise** claim `∀ P, v ↔ Pred P` refuted where the corpus asserts the universal closure `v ↔ ∀ P, Pred P` — which is *trivially inhabited*, so the refutation says nothing.
3. A one-instance theorem read as a cross-instance identification, where the corpus instantiates the two legs separately.
4. A set-level fact ("not cut out by any ideal") used to deny a truth-value equivalence.

Root cause: **conflating a predicate that varies (over states, levels, instances) with the single truth value of its universal closure.**

## Why `automated: false` — measured, not assumed

A prototype scanner was built and evaluated against the four known instances:

| | result |
|---|---|
| Recall | 4/4 files, but only 2/4 at the exact offending sentence |
| Volume | 29 candidates / 6395 files |
| Actionable precision | ~3 of 29 ≈ **10 %** |

**Decisive:** it fires **identically on the corrected text** — the fixed prose, which explicitly warns against the inference, matches the same signature as the version that committed it.

It detects the *topic*, not the *defect*, because the discriminating fact (does the index bind across the equivalence? is the symbol level-indexed in its Lean type? are the two legs the same instance?) is semantic and not lexically visible. That's structural, not a tuning failure — which is why the candidate lister stays print-only and only an agent verdict writes a sidecar. Writing sidecars from it would put 26 false positives into the `needs-agent` backlog for ~3 findings.

The rationale is recorded as a comment above the entry so the next reader doesn't retry the automation.

## Verification

`bunx tsc --noEmit -p tsconfig.json` — **exit 0**. Registry-entry-only change; no checker code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Km78DthtvM8vywoTX7Eeb9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Km78DthtvM8vywoTX7Eeb9)_