### PR TITLE
`readBlockManifest` admitted a source file as a content block

### DIFF
--- a/.beans/folio-assistant-fsl7--repoint-remaining-hand-rolled-block-scanners-at-th.md
+++ b/.beans/folio-assistant-fsl7--repoint-remaining-hand-rolled-block-scanners-at-th.md
@@ -193,3 +193,40 @@ Verified behaviour-preserving: forward references on qou read **194 before and
 by owner decision, bullet 2 fine as filed. The bean's remaining subject is the
 sync loader, unchanged: worth doing when someone is already in loader work, not
 worth opening on its own account.
+
+## 2026-08-16 — bullet 2 closed: readBlockManifest was admitting a non-block
+
+Bullet 2 said `readBlockManifest` "is regex-based but builds its kind
+alternation from BLOCK_KINDS, so it cannot drift. Fine as is unless a sync
+loader appears."
+
+The alternation cannot drift. The **matching** could, and did — in the
+permissive direction, which is the worse one. Both regexes ran against raw
+source, so a builder call or a `label:` inside a string literal or comment made
+an ordinary file look like a manifest.
+
+`content/pipeline/witness-substitution-audit.ts` carries a self-test:
+
+```ts
+parseWitnessList(`export default proposition({ label: "prop:x" });`)
+```
+
+`walkBlocks` yielded that audit script as a content block labelled `prop:x`.
+Every per-block checker ran on it and filed results under a label no block
+holds. Blocks walked: **3521 → 3520**.
+
+Fixed by matching against a string- and comment-masked copy and reading the
+label through `parseStringField`. Both primitives already live in
+`uses-field.ts` after this session's consolidation, so this is a repoint rather
+than a fifth parser — which is what this bean has been asking for throughout.
+
+Seven tests, including the exact corpus shape (a manifest's source passed as a
+template literal to the function under test) and the guard that a real manifest
+still reads.
+
+**Bullet 2 is closed**, and not by the sync loader. The remaining subject is
+unchanged: bullet 1 was closed by owner decision, bullet 3 by `#116`, and a true
+sync loader is still absent — but the class this bean was filed to track,
+"scanners that read source text and can be fooled by what source text may
+legitimately contain", is now materially smaller. Every manifest read in the
+pipeline goes through the masked scanner.

--- a/content/pipeline/qa-utils.ts
+++ b/content/pipeline/qa-utils.ts
@@ -15,6 +15,7 @@ import {
 import { join, resolve } from "path";
 import { execFileSync } from "child_process";
 import { criterionSourceHash } from "./qa-criterion-hash";
+import { maskStringsAndComments, parseStringField } from "./uses-field";
 import {
   parseLeanRef,
   leanPackageByName,
@@ -559,19 +560,33 @@ const BLOCK_BUILDER_RE = new RegExp(
  * manifest. Returns the block's kind + label, or `undefined` if the
  * file is not a single-block manifest (chapter, paper, etc.).
  *
- * Robust to surrounding fields; uses naive regex (no TypeScript
- * loader needed for this scan).
+ * **Matched against a string- and comment-masked copy**, so a builder call or
+ * a `label:` written inside a string literal or a comment cannot make an
+ * ordinary source file look like a block manifest. Offsets are preserved by
+ * masking, so the values still come from the original text.
+ *
+ * That is not a hypothetical: `content/pipeline/witness-substitution-audit.ts`
+ * contains a self-test reading
+ *
+ * ```ts
+ * parseWitnessList(`export default proposition({ label: "prop:x" });`)
+ * ```
+ *
+ * and the raw scan yielded that audit script as a content block labelled
+ * `prop:x`. Every per-block checker then ran on it and attributed the results
+ * to a block that does not exist.
  */
 export function readBlockManifest(
   tsPath: string,
 ): { kind: string; label: string } | undefined {
   if (!existsSync(tsPath)) return undefined;
   const src = readFileSync(tsPath, "utf-8");
-  const kindMatch = src.match(BLOCK_BUILDER_RE);
+  const masked = maskStringsAndComments(src);
+  const kindMatch = masked.match(BLOCK_BUILDER_RE);
   if (!kindMatch) return undefined;
-  const labelMatch = src.match(/\blabel\s*:\s*"([^"]+)"/);
-  if (!labelMatch) return undefined;
-  return { kind: kindMatch[1], label: labelMatch[1] };
+  const label = parseStringField(src, "label");
+  if (!label) return undefined;
+  return { kind: kindMatch[1], label };
 }
 
 /**

--- a/scripts/tests/read-block-manifest-masking.test.ts
+++ b/scripts/tests/read-block-manifest-masking.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { readBlockManifest } from "../../content/pipeline/qa-utils";
+
+/**
+ * `readBlockManifest` decides what counts as a content block. Getting it wrong
+ * in the permissive direction is worse than missing a block: an ordinary source
+ * file becomes a "block", every per-block checker runs on it, and the results
+ * are filed under a label that does not exist.
+ *
+ * That happened. `content/pipeline/witness-substitution-audit.ts` carries a
+ * self-test containing the literal text of a manifest, and the raw scan yielded
+ * that audit script as a block labelled `prop:x`.
+ */
+describe("readBlockManifest ignores builders and labels inside strings", () => {
+  const dir = mkdtempSync(join(tmpdir(), "read-block-manifest-"));
+  const write = (name: string, body: string): string => {
+    const p = join(dir, name);
+    writeFileSync(p, body);
+    return p;
+  };
+
+  test("a builder call inside a template literal is not a manifest", () => {
+    // The exact shape from the corpus: a self-test passing manifest source as
+    // a string to the function under test.
+    const p = write(
+      "audit.ts",
+      "import { parseWitnessList } from './x';\n" +
+        "const ok = parseWitnessList(`export default proposition({ label: \"prop:x\" });`).length === 0;\n" +
+        "console.log(ok);\n",
+    );
+    expect(readBlockManifest(p)).toBeUndefined();
+  });
+
+  test("a builder call inside a comment is not a manifest", () => {
+    const p = write(
+      "commented.ts",
+      "// Usage: export default theorem({ label: \"thm:example\" })\n" +
+        "export const helper = 1;\n",
+    );
+    expect(readBlockManifest(p)).toBeUndefined();
+  });
+
+  test("a real manifest still reads, with kind and label", () => {
+    const p = write(
+      "real.ts",
+      'import { proposition } from "../../schema/builders";\n\n' +
+        "export default proposition({\n" +
+        '  label: "prop:real-one",\n' +
+        '  title: "T",\n' +
+        "});\n",
+    );
+    expect(readBlockManifest(p)).toEqual({ kind: "proposition", label: "prop:real-one" });
+  });
+
+  test("a decoy label in a comment does not win over the real field", () => {
+    const p = write(
+      "decoy.ts",
+      'import { remark } from "../../schema/builders";\n\n' +
+        "export default remark({\n" +
+        '  // label: "rem:ghost" was the old id, retired in July\n' +
+        '  label: "rem:actual",\n' +
+        "});\n",
+    );
+    expect(readBlockManifest(p)?.label).toBe("rem:actual");
+  });
+
+  test("a manifest with no label is not a block", () => {
+    const p = write(
+      "nolabel.ts",
+      'import { remark } from "../../schema/builders";\n' +
+        "export default remark({ title: \"T\" });\n",
+    );
+    expect(readBlockManifest(p)).toBeUndefined();
+  });
+
+  test("a missing file is undefined, not a throw", () => {
+    expect(readBlockManifest(join(dir, "nope.ts"))).toBeUndefined();
+  });
+
+  // Cleanup is best-effort; the temp dir is small and per-run.
+  test("cleanup", () => {
+    rmSync(dir, { recursive: true, force: true });
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
Bean `fa/fsl7`, bullet 2 — which had been judged safe.

Bullet 2 read: *"`readBlockManifest` is regex-based but builds its kind alternation from `BLOCK_KINDS`, so it cannot drift. Fine as is unless a sync loader appears."*

The alternation cannot drift. The **matching** could, and did — in the permissive direction, which is the worse one. Both regexes ran against raw source, so a builder call or a `label:` inside a string literal or a comment made an ordinary file look like a manifest.

## The live case

`content/pipeline/witness-substitution-audit.ts` carries a self-test that passes manifest source as a template literal to the function under test:

```ts
parseWitnessList(`export default proposition({ label: "prop:x" });`)
```

`walkBlocks` yielded **that audit script as a content block labelled `prop:x`**. Every per-block checker ran on it and filed results under a label no block holds.

Blocks walked: **3521 → 3520.**

Missing a block would be bad. Inventing one is worse — the results look like findings about content.

## The fix is a repoint, not a fifth parser

Matched against a string- and comment-masked copy, label read through `parseStringField`. Both primitives already live in `uses-field.ts` after this session's consolidation, so nothing new was written — which is precisely what `fsl7` has been asking for throughout.

Seven tests, including the exact corpus shape and the guards that a real manifest still reads with kind and label, and that a decoy `label:` in a comment doesn't win.

## Where that leaves the bean

**Bullet 2 is closed** — not by the sync loader it was waiting on. Bullet 1 was closed by owner decision, bullet 3 by #116. A true sync loader is still absent, but the class `fsl7` exists to track — *scanners that read source text and can be fooled by what source text may legitimately contain* — is now materially smaller: every manifest read in the pipeline goes through the masked scanner.

tsc 0 · 712 tests / 0 fail · eslint clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_016hQePZH4xA7gxL5eLTP5av)_