### PR TITLE
qa(registry): da-arity-conflation precision is 0%, not ~10% — correcting my own figure

### DIFF
--- a/content/pipeline/qa-criteria-registry.ts
+++ b/content/pipeline/qa-criteria-registry.ts
@@ -1786,8 +1786,22 @@ const DEVILS_ADVOCATE: QaCriterionDefinition[] = [
   // CORRECTED text — it detects the topic, not the defect, because the
   // discriminating fact (does the index bind across the equivalence? is the
   // symbol level-indexed in its Lean type? are the two legs the same instance?)
-  // is semantic, not lexical. ~10% actionable precision over 6395 files. The
-  // candidate lister is print-only; only an agent verdict writes a sidecar.
+  // is semantic, not lexical.
+  //
+  // ADJUDICATED PRECISION IS 0% — 0 defects in 29 candidates over 6395 files,
+  // on the first real agent pass (2026-08-16). An earlier revision of this
+  // comment said "~10%"; that was a TRIAGE estimate (three hits that looked
+  // worth opening) reported as if it were an adjudication. All three were then
+  // adjudicated legit — one of them, "at Kummer level n, kappa_0 mod n vanishes
+  // iff n | chi(A)", is in fact a MODEL of the correct form, since the index
+  // binds on both sides. Per-candidate verdicts: qou PR #5191.
+  //
+  // That strengthens this `automated: false` rather than weakening it: a
+  // checker with 0% adjudicated precision must not write sidecars. The
+  // criterion itself stands — the four historical instances were real, and it
+  // is the DISCIPLINE (the four questions) that catches them, not the regex.
+  //
+  // Candidate lister is print-only; only an agent verdict writes a sidecar.
   // Four questions + full measurement: qou `local/devils-advocate-watcher`.
   { id: "da-arity-conflation", domain: "devils-advocate", description: "A predicate that VARIES (over states, levels, or instances) conflated with the single truth value of its universal closure: a level-indexed family read as one Prop; a pointwise claim (forall P, v <-> Pred P) refuted where the corpus asserts the universal closure (v <-> forall P, Pred P, which is trivially inhabited); a one-instance theorem read as a cross-instance identification; a set-level fact (undecidable / not cut out by an ideal / cofinite locus) used to deny a truth-value equivalence.", default_severity: "major", depends_on: ["md", "ts", "lean"], automated: false },
   { id: "da-lean-narrative-divergence", domain: "devils-advocate", description: "Lean proves something weaker/different/vacuously-implied vs the .md claim (proof-statement-integrity).", default_severity: "major", depends_on: ["md", "ts", "lean"], automated: false },


### PR DESCRIPTION
The comment above the `da-arity-conflation` entry, added in #124, claimed **"~10 % actionable precision over 6395 files"**. That was wrong. It was a **triage** estimate — three hits that looked worth *opening* — reported as though it were an adjudication.

The pass has since been run. **All three candidates are legit:**

| candidate | why it's fine |
|---|---|
| `q-gl-obstruction-calc.md:13` | *"at Kummer level `n`, `κ₀ mod n` vanishes iff `n ∣ χ(A)`"* — the index **binds on both sides**. Not a violation: a **model** of the correct form, and the exact contrast with the historical error the criterion exists to catch, which collapsed a level-indexed family to a single `Prop`. |
| `HeckeTauAssignmentGaugeGate.lean:80` | the Lean is `(∀ v u, …) ↔ (∀ u, … ↔ …)`. Both sides universal closures; the docstring's "pointwise" faithfully names the RHS. |
| `LevelMixingBridge.lean:77` | `DiagonalScalar` is `∀ n, mas n = r * blk (n+k)`; the docstring names two shapes *searched*, not a collapsed family. |

**Adjudicated precision: 0 defects in 29 candidates.**

## This strengthens `automated: false`

A checker with 0 % adjudicated precision must not write sidecars. The decision was right for a better reason than was known when #124 merged.

The **criterion itself stands** — the four historical instances were real and reached durable artifacts, and it is the *discipline* (the four questions) that catches them, not the regex.

## Why fix it here

This is the copy that gets read **at the code**, by whoever's next instinct is to flip `automated: false`. The qou skill doc ([qou#5191](https://github.com/litlfred/qou/pull/5191)) carries the per-candidate verdicts, and merged [qou#5169](https://github.com/litlfred/qou/pull/5169)'s body has been amended with the same correction.

## Verification

`bunx tsc --noEmit -p tsconfig.json` — **exit 0**. Comment-only change; no entry fields or checker code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Km78DthtvM8vywoTX7Eeb9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Km78DthtvM8vywoTX7Eeb9)_