### PR TITLE
Separate "what is in the graph" from "what prose ships"

### DIFF
--- a/.beans/folio-assistant-fsl7--repoint-remaining-hand-rolled-block-scanners-at-th.md
+++ b/.beans/folio-assistant-fsl7--repoint-remaining-hand-rolled-block-scanners-at-th.md
@@ -230,3 +230,39 @@ sync loader is still absent — but the class this bean was filed to track,
 "scanners that read source text and can be fooled by what source text may
 legitimately contain", is now materially smaller. Every manifest read in the
 pipeline goes through the masked scanner.
+
+## 2026-08-16 — the walk was wrong in BOTH directions
+
+`#125` fixed `walkBlocks` **admitting** a non-block. Asking the complement —
+does it **miss** real ones? — found 63 that it did.
+
+Chapter manifests list 3571 slugs; the walk yielded 63 fewer. All 63 are
+`prose()` connective tissue with no `label:` (chapter intros and outros, the
+notation register, the author's note), all render into the paper, and all carry
+27,390 words of narrative plus `.qa.json` sidecars that `qa-sweep` — which
+iterates `walkBlocks` — could never refresh.
+
+Fixed by separating the two questions the one enumeration was answering.
+`walkBlocks(root, { includeUnlabelled })` defaults to **false**, which is right
+for the dependency graph: a block with no label cannot be a node. `qa-sweep`
+opts in, because its question is "what prose ships?" not "what is in the
+graph?". Unlabelled blocks are yielded under their **slug**, which is the
+identity their existing sidecars already use.
+
+`readUnlabelledBlockManifest` is masked like `readBlockManifest`, and a test
+pins that neither mode readmits the `#125` shape — a looser path added beside a
+fix is how the fix gets undone.
+
+**Measured before landing, and the measurement changed the recommendation.** I
+had argued this option was "the smallest change and the loudest", on the
+assumption that 27,390 unchecked words would produce a large batch of findings.
+Across the 63 blocks: **1286 applicable criterion runs, 0 failures** (819 runs
+skipped by `applies_to`, correctly — a chapter outro is not a proposition).
+
+An earlier count of 126 failures was my own error: I invoked the checkers
+directly and bypassed the `applies_to` filter that `qa-sweep` applies at line
+367, so `compute-prop-has-probe` and `-has-consumer` fired on prose. Caught
+before it was reported as a risk.
+
+So the change is cheap AND quiet. The prose was clean; it simply could not be
+seen to be.

--- a/content/pipeline/qa-sweep.ts
+++ b/content/pipeline/qa-sweep.ts
@@ -287,7 +287,12 @@ function run(): void {
   let totalMinor = 0;
   let totalNeedsAgent = 0;
 
-  for (const block of walkBlocks(walkRoot)) {
+  // `includeUnlabelled`: the sweep's question is "what prose ships?", not "what
+  // is in the dependency graph". Unlabelled `prose()` blocks — chapter intros
+  // and outros, the notation register — render into the paper and were outside
+  // every criterion, while already carrying sidecars nothing could refresh.
+  // See `qou/3fui`.
+  for (const block of walkBlocks(walkRoot, { includeUnlabelled: true })) {
     if (blockRootFilter && block.root !== blockRootFilter) continue;
     totalBlocks++;
     const paths = { md: block.md, ts: block.ts, lean: block.lean };

--- a/content/pipeline/qa-utils.ts
+++ b/content/pipeline/qa-utils.ts
@@ -594,7 +594,57 @@ export function readBlockManifest(
  * triple. Skips chapter manifests, paper manifests, and any .ts
  * file that is not a single-block manifest.
  */
-export function* walkBlocks(rootDir: string): Generator<BlockPaths> {
+/**
+ * A block manifest that declares a builder but **no `label:`** — `prose()`
+ * connective tissue. Returns its kind plus the file's slug standing in for the
+ * label; `undefined` when the file is not a block manifest at all, or when it
+ * does have a label (use `readBlockManifest` for those).
+ *
+ * The slug is what the corpus's existing sidecars for these blocks already key
+ * on, so this adopts the convention rather than minting a second one.
+ *
+ * Masked like `readBlockManifest`, so a builder call inside a string or comment
+ * still does not qualify — the fix in `#125` must not be undone by the looser
+ * path being added beside it.
+ */
+export function readUnlabelledBlockManifest(
+  tsPath: string,
+): { kind: string; label: string } | undefined {
+  if (!existsSync(tsPath)) return undefined;
+  const src = readFileSync(tsPath, "utf-8");
+  if (parseStringField(src, "label")) return undefined; // labelled: not ours
+  const kindMatch = maskStringsAndComments(src).match(BLOCK_BUILDER_RE);
+  if (!kindMatch) return undefined;
+  const slug = tsPath.split("/").pop()!.replace(/\.ts$/, "");
+  return { kind: kindMatch[1], label: slug };
+}
+
+export interface WalkBlocksOptions {
+  /**
+   * Also yield blocks that declare **no `label:`** — `prose()` connective
+   * tissue (chapter intros and outros, author's notes, the notation register).
+   *
+   * Default `false`, which is right for the **dependency graph**: a block with
+   * no label cannot be a node, and nothing can reference it.
+   *
+   * It is wrong for **QA**. `walkBlocks` is not only the graph's enumeration,
+   * it is every checker's, and 63 such blocks in the `qou` corpus render into
+   * the paper carrying 27,390 words that no criterion could reach. They already
+   * hold `.qa.json` sidecars — written by a one-off bulk pass that enumerated
+   * differently — which `qa-sweep` could never refresh, so a stale sidecar and
+   * a current one were indistinguishable. See `qou/3fui`.
+   *
+   * Unlabelled blocks are yielded with their **slug** as `label`, which is the
+   * identity the existing sidecars already use; this adopts a convention rather
+   * than inventing one.
+   */
+  includeUnlabelled?: boolean;
+}
+
+export function* walkBlocks(
+  rootDir: string,
+  opts: WalkBlocksOptions = {},
+): Generator<BlockPaths> {
   // When a block's sibling `<root>.lean` is missing but its `lean.ref`
   // URI points at a file in the package's Lake tree (the cluster-
   // migration pattern, e.g. lean/QOU/BraidKnot/MarkovAxiomsPrimitive.lean),
@@ -622,7 +672,10 @@ export function* walkBlocks(rootDir: string): Generator<BlockPaths> {
         yield* recurse(full);
       } else if (entry.endsWith(".ts")) {
         // Skip chapter / paper manifests by checking the export shape.
-        const manifest = readBlockManifest(full);
+        let manifest = readBlockManifest(full);
+        if (!manifest && opts.includeUnlabelled) {
+          manifest = readUnlabelledBlockManifest(full);
+        }
         if (!manifest) continue;
         const root = full.slice(0, -3); // strip ".ts"
         const md = root + ".md";

--- a/scripts/tests/walk-unlabelled-blocks.test.ts
+++ b/scripts/tests/walk-unlabelled-blocks.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { readUnlabelledBlockManifest, walkBlocks } from "../../content/pipeline/qa-utils";
+
+/**
+ * `walkBlocks` answers two different questions with one enumeration: "what is
+ * in the dependency graph?" and "what prose ships?". Those diverge for
+ * `prose()` blocks with no `label:` — chapter intros and outros, the notation
+ * register. A block with no label cannot be a graph node, so the graph is right
+ * to skip it; but 63 such blocks in the `qou` corpus carried 27,390 words that
+ * no criterion could reach, while already holding `.qa.json` sidecars the sweep
+ * could never refresh. See `qou/3fui`.
+ *
+ * The option separates the two questions. These tests pin that it stays
+ * separated — the default must not start yielding unlabelled blocks into the
+ * graph — and that the looser path did not reopen the hole `#125` closed.
+ */
+describe("walkBlocks: unlabelled prose", () => {
+  const root = mkdtempSync(join(tmpdir(), "walk-unlabelled-"));
+  const ch = join(root, "chapter-one");
+  mkdirSync(ch, { recursive: true });
+
+  writeFileSync(
+    join(ch, "labelled.ts"),
+    'import { proposition } from "x";\nexport default proposition({ label: "prop:a", title: "A" });\n',
+  );
+  writeFileSync(
+    join(ch, "outro.ts"),
+    'import { prose } from "x";\nexport default prose({ title: "Chapter close" });\n',
+  );
+  writeFileSync(join(ch, "outro.md"), "Some closing narrative.\n");
+  // The `#125` shape: manifest source inside a template literal.
+  writeFileSync(
+    join(ch, "audit-script.ts"),
+    "const ok = parse(`export default proposition({ label: \"prop:x\" });`);\nconsole.log(ok);\n",
+  );
+
+  const labels = (opts?: { includeUnlabelled?: boolean }): string[] =>
+    [...walkBlocks(root, opts)].map((b) => b.label).sort();
+
+  test("by default an unlabelled prose block is not yielded", () => {
+    expect(labels()).toEqual(["prop:a"]);
+  });
+
+  test("with includeUnlabelled it is yielded under its slug", () => {
+    expect(labels({ includeUnlabelled: true })).toEqual(["outro", "prop:a"]);
+  });
+
+  test("the unlabelled block still carries its .md, so criteria can read it", () => {
+    const outro = [...walkBlocks(root, { includeUnlabelled: true })].find(
+      (b) => b.label === "outro",
+    );
+    expect(outro?.md?.endsWith("outro.md")).toBe(true);
+    expect(outro?.kind).toBe("prose");
+  });
+
+  test("the looser path does NOT readmit a builder inside a string literal", () => {
+    // The regression #125 fixed. Neither mode may yield the audit script.
+    expect(labels()).not.toContain("audit-script");
+    expect(labels({ includeUnlabelled: true })).not.toContain("audit-script");
+  });
+
+  test("readUnlabelledBlockManifest declines a block that HAS a label", () => {
+    // Labelled blocks belong to readBlockManifest; two paths claiming one file
+    // is how the identity would drift.
+    expect(readUnlabelledBlockManifest(join(ch, "labelled.ts"))).toBeUndefined();
+  });
+
+  test("readUnlabelledBlockManifest declines a non-manifest", () => {
+    expect(readUnlabelledBlockManifest(join(ch, "audit-script.ts"))).toBeUndefined();
+    expect(readUnlabelledBlockManifest(join(ch, "nope.ts"))).toBeUndefined();
+  });
+
+  test("cleanup", () => {
+    rmSync(root, { recursive: true, force: true });
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
Bean `fa/fsl7`. Fixes `qou/3fui`.

#125 fixed `walkBlocks` **admitting** a non-block. Asking the complement — does it **miss** real ones? — found 63 that it did.

Chapter manifests list **3571** slugs; the walk yielded **63 fewer**. All 63 are `prose()` connective tissue with no `label:` — chapter intros and outros, the notation register, the author's note. All render into the paper, carry **27,390 words**, and hold `.qa.json` sidecars that `qa-sweep` (which iterates `walkBlocks`) could never refresh — so a stale sidecar and a current one were indistinguishable.

## The fix

One enumeration was answering two different questions. `walkBlocks(root, { includeUnlabelled })` defaults to **false**, which is right for the dependency graph: a block with no label cannot be a node, and nothing can reference it. `qa-sweep` opts in, because its question is *what prose ships*, not *what is in the graph*.

Unlabelled blocks are yielded under their **slug** — the identity their existing sidecars already use, so this adopts a convention rather than minting one.

`readUnlabelledBlockManifest` is masked exactly like `readBlockManifest`, and a test pins that **neither** mode readmits the #125 shape. A looser path added beside a fix is how the fix gets undone.

## Measured before landing — and the measurement changed the recommendation

In `qou/3fui` I argued this option was "the smallest change and the loudest", assuming 27,390 unchecked words would produce a large batch of findings. Measured across the 63 blocks:

| | |
|---|---|
| applicable criterion runs | **1286** |
| skipped by `applies_to` | 819 (correctly — a chapter outro is not a proposition) |
| **failures** | **0** |

So it's cheap *and* quiet. The prose was clean; it simply could not be seen to be.

**An earlier count of 126 failures was my own error.** I invoked the checkers directly and bypassed the `applies_to` filter `qa-sweep` applies at line 367, so `compute-prop-has-probe` and `-has-consumer` fired on prose. Caught before it was reported as a risk — but worth recording, because a bypassed filter producing 126 phantom findings is the same shape as everything else this arc has been fixing.

tsc 0 · **719 tests / 0 fail** · eslint clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_016hQePZH4xA7gxL5eLTP5av)_