### PR TITLE
`parseLeanRef` returned a simulator id as a Lean declaration

### DIFF
--- a/content/pipeline/content-graph.ts
+++ b/content/pipeline/content-graph.ts
@@ -77,7 +77,7 @@ import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { walkBlocks } from "./qa-utils";
 import { findContentRepoRoot } from "./repo-root";
-import { findUsesField, parseStringField } from "./uses-field";
+import { findUsesField, parseNestedStringField, parseStringField } from "./uses-field";
 
 /** Provenance of a dependency edge. */
 export type EdgeKind = "editorial" | "formal";
@@ -227,9 +227,19 @@ export function parseUses(tsSrc: string): string[] {
   return [...new Set(extractUses(tsSrc)?.entries ?? [])];
 }
 
-/** Parse a block manifest's `lean: { ref: "..." }` URI, if present. */
+/**
+ * Parse a block manifest's `lean: { ref: "..." }` URI, if present.
+ *
+ * **Scoped to the `lean` object.** A manifest may carry several `ref:` keys —
+ * `lean.ref`, `simulator.ref`, `computation.ref` — and the unscoped
+ * `/\bref\s*:\s*["']([^"']+)["']/` this replaced returned whichever came first
+ * in the file. Three blocks in the `qou` corpus have `simulator: { ref: … }`
+ * and **no `lean:` block at all**, and were reported as owning a Lean
+ * declaration named `sim:…`, which put them in `declOwners` and gave them
+ * formal edges they cannot have.
+ */
 export function parseLeanRef(tsSrc: string): string | undefined {
-  return tsSrc.match(/\bref\s*:\s*["']([^"']+)["']/)?.[1];
+  return parseNestedStringField(tsSrc, "lean", "ref");
 }
 
 /**

--- a/content/pipeline/uses-field.ts
+++ b/content/pipeline/uses-field.ts
@@ -245,6 +245,65 @@ export function findUsesField(text: string): UsesField | undefined {
 }
 
 /**
+ * A string field nested inside an object field: `lean: { ref: "qou:X" }`.
+ *
+ * Scoped to `outer`'s braces, so a `ref:` belonging to a *different* field
+ * cannot answer. Manifests carry several: `lean.ref`, `simulator.ref`,
+ * `computation.ref`. An unscoped `/\bref\s*:\s*"([^"]+)"/` returns whichever
+ * appears first in the file, which for a block with `simulator: { ref: … }` and
+ * no `lean:` block at all is a simulator id reported as a Lean declaration.
+ *
+ * Returns `undefined` when `outer` is absent, is not an object, or holds no
+ * such key — never a value from elsewhere in the file.
+ */
+export function parseNestedStringField(
+  text: string,
+  outer: string,
+  inner: string,
+): string | undefined {
+  const scan = maskStringsAndComments(text);
+  let from = 0;
+  for (;;) {
+    const start = findFieldStart(scan, outer, from);
+    if (start < 0) return undefined;
+    let i = start + outer.length;
+    while (i < scan.length && scan[i] !== ":") i++;
+    i++;
+    while (i < scan.length && /\s/.test(scan[i])) i++;
+    if (scan[i] !== "{") {
+      from = start + outer.length;
+      continue;
+    }
+    // Depth-scan the object so a nested `{}` cannot end it early.
+    let depth = 0;
+    let end = -1;
+    for (let k = i; k < scan.length; k++) {
+      if (scan[k] === "{") depth++;
+      else if (scan[k] === "}") {
+        depth--;
+        if (depth === 0) { end = k; break; }
+      }
+    }
+    if (end < 0) return undefined;
+    // Search only within the object, and slice the value from the original.
+    const innerStart = findFieldStart(scan.slice(i, end), inner, 0);
+    if (innerStart < 0) {
+      from = start + outer.length;
+      continue;
+    }
+    let j = i + innerStart + inner.length;
+    while (j < scan.length && scan[j] !== ":") j++;
+    j++;
+    while (j < scan.length && /\s/.test(scan[j])) j++;
+    const q = scan[j];
+    if (q !== '"' && q !== "'") return undefined;
+    const close = scan.indexOf(q, j + 1);
+    if (close < 0) return undefined;
+    return text.slice(j + 1, close);
+  }
+}
+
+/**
  * A scalar string field's value — `interprets: "def:x"` — or `undefined`.
  *
  * Same masked locate as `findArrayField`, for the same reasons: a `//` note

--- a/scripts/tests/lean-ref-scoping.test.ts
+++ b/scripts/tests/lean-ref-scoping.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { parseNestedStringField } from "../../content/pipeline/uses-field";
+import { parseLeanRef } from "../../content/pipeline/content-graph";
+
+/**
+ * A block manifest carries several `ref:` keys — `lean.ref`, `simulator.ref`,
+ * `computation.ref`. `parseLeanRef` matched `/\bref\s*:\s*["']([^"']+)["']/`
+ * against the whole file and returned whichever came first.
+ *
+ * Three blocks in the `qou` corpus have `simulator: { ref: … }` and **no
+ * `lean:` block at all**. They were reported as owning a Lean declaration
+ * called `sim:…` — which put them in `declOwners` and gave them formal edges
+ * they cannot have. A block that declares no Lean must read as declaring none.
+ */
+describe("parseLeanRef is scoped to the lean object", () => {
+  test("a simulator ref is not a lean ref", () => {
+    const src = `export default remark({
+  label: "rem:x",
+  simulator: { ref: "sim:q-double-slit" },
+});`;
+    expect(parseLeanRef(src)).toBeUndefined();
+  });
+
+  test("the lean ref wins even when another ref: comes first", () => {
+    const src = `export default proposition({
+  simulator: { ref: "sim:decoy" },
+  lean: { ref: "qou:QOU.Real.decl", validation: "not_checked" },
+});`;
+    expect(parseLeanRef(src)).toBe("qou:QOU.Real.decl");
+  });
+
+  test("a lean ref is found when it comes first too", () => {
+    const src = `lean: { ref: "qou:QOU.A.b" }, computation: { ref: "probe:x" },`;
+    expect(parseLeanRef(src)).toBe("qou:QOU.A.b");
+  });
+
+  test("a lean block with no ref yields undefined, not a neighbour's", () => {
+    const src = `lean: { validation: "stub" }, simulator: { ref: "sim:y" },`;
+    expect(parseLeanRef(src)).toBeUndefined();
+  });
+
+  test("no lean block at all yields undefined", () => {
+    expect(parseLeanRef(`label: "rem:x", computation: { ref: "probe:z" },`)).toBeUndefined();
+  });
+});
+
+describe("parseNestedStringField", () => {
+  test("a nested object does not end the scan early", () => {
+    const src = `lean: { meta: { note: "x" }, ref: "qou:QOU.After.nested" },`;
+    expect(parseNestedStringField(src, "lean", "ref")).toBe("qou:QOU.After.nested");
+  });
+
+  test("a comment before the outer field does not hide it", () => {
+    const src = `title: "T",\n  // the lean decl moved in July\n  lean: { ref: "qou:QOU.A.b" },`;
+    expect(parseNestedStringField(src, "lean", "ref")).toBe("qou:QOU.A.b");
+  });
+
+  test("the key quoted in prose does not win", () => {
+    const src = `body: "set lean: { ref: \\"qou:GHOST\\" } on it", lean: { ref: "qou:REAL" },`;
+    expect(parseNestedStringField(src, "lean", "ref")).toBe("qou:REAL");
+  });
+
+  test("an outer field that is not an object is skipped, not mis-read", () => {
+    const src = `lean: someVar, lean: { ref: "qou:QOU.Second.form" },`;
+    expect(parseNestedStringField(src, "lean", "ref")).toBe("qou:QOU.Second.form");
+  });
+
+  test("an absent outer field yields undefined", () => {
+    expect(parseNestedStringField(`ref: "loose"`, "lean", "ref")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
A block manifest carries several `ref:` keys — `lean.ref`, `simulator.ref`, `computation.ref`. `parseLeanRef` matched `/\bref\s*:\s*["']([^"']+)["']/` against the whole file and returned **whichever came first**.

Three blocks in the `qou` corpus have `simulator: { ref: … }` and **no `lean:` block at all**:

- `rem:spectral-dynamics` → reported `sim:quantum-brings-surface`
- `rem:double-slit-two-modes` → reported `sim:double-slit-analytical`
- `rem:q-deformed-double-slit` → reported `sim:q-double-slit`

They were reported as owning a Lean declaration named `sim:…`, which put them into `declOwners` and gave them formal edges they cannot have. **1259 blocks reported a `lean.ref`; 1256 actually have one.** A block that declares no Lean must read as declaring none.

## The fix

`parseNestedStringField(text, outer, inner)` — scoped to the outer object's braces, depth-scanned so a nested `{}` can't end it early, masked like its siblings so the key quoted in prose or a comment before the field can't answer.

## How it was found, and the joke on me

I went looking for dangling `lean.ref`s and found five that resolve to no file. Three of the five turned out **not to be Lean refs at all** — my detector had the *same* unscoped-`ref:` bug as the function it was auditing.

The two genuine dangling refs are left for a content decision:
- `qou:QOU.BraidsAndKnots.figure_eight_classical_reeb`
- `qou:QOU.Braiding.pair_cancellation`

## Note on the test suite

Run from `folio-assistant`: **729 tests / 0 fail**. Run from the folio's working directory it reports 10 failures — Lean project discovery, lakefile paths, `.gitignore` — which I verified are **pre-existing** by stashing this change and reproducing them. They only appear in the folio-attached path, which resolves Lean project roots differently. Not addressed here, but worth knowing they're red.

tsc 0 · 729 tests / 0 fail · eslint clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_016hQePZH4xA7gxL5eLTP5av)_