### PR TITLE
pdf-structure: the furniture look-ahead was eating titles; run the Python tests

### DIFF
--- a/.github/workflows/code-quality-gates.yml
+++ b/.github/workflows/code-quality-gates.yml
@@ -22,6 +22,9 @@
 #      paths and exited 0, so the step reported a clean baseline it had never
 #      computed. Repointed at the trees that hold the 44 real files, which
 #      surfaced 24 live F401s; those were drained, so the rule is an error.
+#      This job also RUNS `scripts/tests/*.test.py`, which previously ran
+#      nowhere: run-tests.sh delegates to `bun test` and that collects only
+#      `*.test.ts`, so the Python tests were green by never executing.
 #
 #   3. TypeScript gate — HARD FAIL on `bun test`, `bun run lint`, and
 #      `tsc --noEmit`. Each is a real regression gate rather than a baseline
@@ -140,6 +143,30 @@ jobs:
           ruff check --select F401,F403 --output-format=github \
             --exclude '**/_deprecated/**' \
             $targets
+
+      # The Python tests under scripts/tests/ ran nowhere. run-tests.sh
+      # delegates to `bun test`, which only collects `*.test.ts`, and no
+      # workflow named them — so pdf-text-repair.test.py and
+      # who-l1-extractor.test.py were green by never being executed. They
+      # are self-contained (no pypdf, no network) and take under a second.
+      #
+      # Discovered rather than listed, so a new one is picked up by
+      # existing; a listed set is a set that goes stale.
+      - name: Python tests (scripts/tests/*.test.py)
+        run: |
+          set -uo pipefail
+          shopt -s nullglob
+          tests=(scripts/tests/*.test.py)
+          if [ ${#tests[@]} -eq 0 ]; then
+            echo "SKIP — no Python tests present."
+            exit 0
+          fi
+          rc=0
+          for t in "${tests[@]}"; do
+            echo "=== $t ==="
+            python3 "$t" || rc=1
+          done
+          exit $rc
 
   typescript:
     name: TypeScript — tests, lint, types (hard)

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,15 @@ __pycache__/
 # (e.g. content/schema/references.ts -> <content-repo>/content/schema/references.ts).
 # Machine-local absolute paths — useful in a working clone, meaningless in git.
 content/schema/
+
+# The same script bridges the bibliography by a SECOND path, because the
+# platform imports it two ways — qa-checkers-extended.ts reads
+# <clone>/content/schema/references (above) and export-bibtex.ts reads
+# <clone>/schemas/references (here). That second link was added later and
+# never ignored, so it has been showing up as an untracked file in every
+# working clone.
+#
+# Scoped to the one path, NOT the directory: schemas/ holds real tracked
+# source (block-qa.ts, lean-packages.ts, ...) and ignoring it wholesale
+# would silence `git add` on all of it.
+/schemas/references.ts

--- a/scripts/pdf-structure.py
+++ b/scripts/pdf-structure.py
@@ -497,7 +497,24 @@ def parse_front_matter(pages: list[str]) -> dict[str, Any]:
         #
         # Only once something above it was already skipped, so a title
         # sitting on line 0 above a date line is never mistaken for one.
-        if skipped and any(furniture(x) for x in lines[i + 1:i + 3] if x):
+        #
+        # The furniture run has to genuinely CONTINUE — both of the next two
+        # non-empty lines — not merely have some furniture near it. Asking
+        # for *any* furniture within two lines, which this did, matches the
+        # commonest front matter there is and eats the title and the byline
+        # together:
+        #
+        #   0| arXiv:hep-th/9310164v2  22 Jul 1998   furniture
+        #   1| SPHERICAL CA TEGORIES                 <- the title
+        #   2| John W. Barrett & Bruce W. Westbury   <- the byline
+        #   3| 10 August 1993; revised 22 July 1998  furniture (a date)
+        #
+        # Line 3 is furniture, so line 1 was skipped for it, then line 2 for
+        # the same line, and `start` landed on the abstract: no title, no
+        # authors, nothing to fall back on. A byline is not furniture, so
+        # requiring the run to continue tells the two layouts apart.
+        nxt = [x for x in lines[i + 1:i + 6] if x][:2]
+        if skipped and len(nxt) == 2 and all(furniture(x) for x in nxt):
             start = i + 1
             continue
         break

--- a/scripts/tests/pdf-front-matter.test.py
+++ b/scripts/tests/pdf-front-matter.test.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""
+Regression test for `pdf-structure.py`'s page-1 front-matter parse.
+
+`parse_front_matter` decides where a document's title starts, and it had no
+test at all — which is how a rule meant for one layout came to eat the title
+of the commonest layout there is.
+
+The hard part is not finding the title, it is knowing where the publisher's
+furniture stops. Furniture appears *above* the title (an arXiv stamp, a
+journal banner), *below* it (a DOI URL under the byline, a rotated margin
+stamp pypdf emits last), and interleaved with it. So the scan skips a
+contiguous run and stops at the first line that is not furniture — with one
+exception, for a bare journal name that carries no volume or year and is
+unrecognisable on its own, sitting *inside* a run.
+
+That exception is the delicate part, and both failure directions are here:
+too narrow and a journal name is taken as the title, too wide and the real
+title is skipped for a date printed two lines under it.
+
+Run: python3 scripts/tests/pdf-front-matter.test.py
+
+Standalone by design, like `pdf-text-repair.test.py`: it execs the relevant
+slice of the script rather than importing it, because the script exits when
+pypdf is missing and these functions do not need pypdf.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+import types
+import unicodedata
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Any
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCRIPT = os.path.join(os.path.dirname(HERE), "pdf-structure.py")
+
+
+def load():
+    src = open(SCRIPT, encoding="utf-8").read()
+    start = src.index("# ------------------------------------------------"
+                      "---------------- patterns")
+    end = src.index("def split_sections(")
+    name = "pdf_structure_slice"
+    ns: dict[str, Any] = {
+        "__name__": name, "re": re, "unicodedata": unicodedata,
+        "Counter": Counter, "Any": Any, "os": os, "sys": sys,
+        "dataclass": dataclass, "field": field,
+    }
+    # `@dataclass` resolves its module through sys.modules, so the slice
+    # needs a module object to live in or the decorator raises.
+    mod = types.ModuleType(name)
+    mod.__dict__.update(ns)
+    sys.modules[name] = mod
+    exec(compile(src[start:end], SCRIPT, "exec"), mod.__dict__)
+    return mod.parse_front_matter
+
+
+# Each page is real page-1 text from the qou library, trimmed to the lines
+# that decide the outcome.
+CASES = [
+    (
+        "arXiv stamp, then title, byline and a date under it",
+        # The bug: line 3 is furniture, so the look-ahead skipped line 1 for
+        # it, then line 2 for the same line, and `start` landed on the
+        # abstract. Title and authors were both lost — arxiv-hep-th-9310164v2.
+        """arXiv:hep-th/9310164v2  22 Jul 1998
+SPHERICAL CA TEGORIES
+John W. Barrett & Bruce W. Westbury
+10 August 1993; revised 22 July 1998
+Abstract. This paper is a study of monoidal categories with duals.
+spherical categories spherical categories spherical categories""",
+        "SPHERICAL CATEGORIES",
+        "John W. Barrett & Bruce W. Westbury",
+    ),
+    (
+        "a bare journal name INSIDE a furniture run is still skipped",
+        # The case the look-ahead exists for: "Algebraic & Geometric
+        # Topology" carries no volume or year, so it is unrecognisable
+        # alone — but the run continues under it. agt-v3-n1-p17-p.
+        """ISSN 1472-2739 (on-line) 1472-2747 (printed)
+Algebraic & Geometric Topology
+ATG
+Volume 3 (2003) 537-556
+Published: 16 June 2003
+Skein-theoretical derivation of some formulas of Habiro
+Abstract. We use skein theory.""",
+        "Skein-theoretical derivation of some formulas of Habiro",
+        None,
+    ),
+    (
+        "a journal banner carrying its own volume is furniture on its own",
+        # arxiv-1206.6004v2. The banner names the journal AND the volume, so
+        # it is recognisable without the look-ahead; the title spans two
+        # lines and the byline ends the run.
+        """Symmetry, Integrability and Geometry: Methods and Applications SIGMA 8 (2012), 065, 20 pages
+Bring’s Curve: its Period Matrix
+and the Vector of Riemann Constants ⋆
+Harry W. BRADEN and Timothy P. NORTHOVER
+School of Mathematics, Edinburgh University, Edinburgh, Scotland, UK""",
+        "Bring’s Curve: its Period Matrix and the Vector of Riemann Constants ⋆",
+        "Harry W. BRADEN and Timothy P. NORTHOVER",
+    ),
+    (
+        "a title on line 0 is never skipped for furniture below it",
+        # `skipped` guards this: nothing above the title was furniture, so
+        # the exception cannot fire and a date underneath is harmless.
+        """On the geometry of certain moduli spaces
+Jane Q. Author and John R. Author
+15 March 2011
+Abstract. We study moduli.""",
+        "On the geometry of certain moduli spaces",
+        "Jane Q. Author and John R. Author",
+    ),
+]
+
+
+def main() -> int:
+    parse = load()
+    failed = 0
+    for what, page, want_title, want_authors in CASES:
+        meta = parse([page])
+        got_t, got_a = meta.get("title"), meta.get("authors_raw")
+        ok = got_t == want_title and (want_authors is None or got_a == want_authors)
+        if ok:
+            print(f"  ok   {what}")
+        else:
+            failed += 1
+            print(f"  FAIL {what}")
+            print(f"         title  got {got_t!r}")
+            print(f"                want {want_title!r}")
+            if want_authors is not None:
+                print(f"         authors got {got_a!r}")
+                print(f"                 want {want_authors!r}")
+    print(f"\n  {len(CASES) - failed}/{len(CASES)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/pdf-text-repair.test.py
+++ b/scripts/tests/pdf-text-repair.test.py
@@ -18,6 +18,28 @@ exists rather than a one-off check:
   * first-seam-only lookup swallowed an entire title into one token, on a
     run whose first seam happened to be a real join.
 
+Known limitation, with the measurement that closes it: when the damage sits
+in a *running head* it repeats once per page, so the fragments outnumber the
+word they came from and the frequency gate rejects a correct join. Four
+titles in the qou library are affected ("TURAEV-VIRO INV ARIANTS" x3,
+"A SUR VEY OF TWISTED ALEXANDER POLYNOMIALS").
+
+Discounting occurrences *inside* the pair — comparing against how often each
+fragment stands alone — repairs all four, and cannot be adopted, because the
+two shapes are numerically identical and want opposite answers:
+
+    arxiv-1004.1533v3   "inv ariants" 54   "invariants" 18   -> welded is right
+    aif-2009-59-1-347-0 "institut fourier" 63  "institutfourier" 18
+                                                          -> spaced is right
+
+Same majority-spaced / minority-welded shape, opposite correct answers, so no
+statistic over these counts separates them. What does separate them is that
+"fourier" is a word and "ariants" is not — which needs either a dictionary or
+a cross-document vocabulary, and this producer takes one PDF and consults
+only that PDF. The four titles are therefore corrected downstream in
+`docs/audits/library-title-overrides.json` (qou), where a human verdict is
+the recorded mechanism, rather than guessed at here.
+
 Run: python3 scripts/tests/pdf-text-repair.test.py
 
 Standalone by design — it loads the two functions out of the script's


### PR DESCRIPTION
Follow-on to #119 (merged). The content half is litlfred/qou#5216.

## The bug

`parse_front_matter` skips a contiguous run of publisher furniture at the top of page 1, with one exception for a bare journal name — a line carrying no volume or year, unrecognisable on its own, sitting *inside* a run.

That exception tested for **any** furniture within two lines below. Which matches the commonest front matter there is:

```
0| arXiv:hep-th/9310164v2  22 Jul 1998   furniture
1| SPHERICAL CA TEGORIES                 <- the title
2| John W. Barrett & Bruce W. Westbury   <- the byline
3| 10 August 1993; revised 22 July 1998  furniture (a date)
```

Line 3 is furniture, so line 1 was skipped for it, then line 2 for the same line, and `start` landed on the abstract: `title: None`, `authors_raw: None`, nothing to fall back on. That is Barrett & Westbury's *Spherical Categories*, held in the qou library with no title at all.

**Fix:** require the run to actually *continue* — both of the next two non-empty lines — rather than merely have furniture near it. A byline is not furniture, so the two layouts separate cleanly, and the journal-name case is unaffected because the run genuinely does continue under it.

## `parse_front_matter` had no test

It decides where every title in the corpus starts. `scripts/tests/pdf-front-matter.test.py` covers four real page-1 layouts and both failure directions of the exception — too narrow and a journal name becomes the title, too wide and the title is skipped for a date under it.

## The Python tests ran nowhere

`run-tests.sh` delegates to `bun test`, which collects only `*.test.ts`, and no workflow named them. So `pdf-text-repair.test.py` and `who-l1-extractor.test.py` have been green by never being executed. Added to the `python-imports` job, which already has a Python toolchain, discovered by glob rather than listed by name.

## A negative worth recording

Four qou titles keep a visible kerning split (`TURAEV-VIRO INV ARIANTS` ×3, `A SUR VEY OF…`) because the damage is in the **running head**: it repeats once per page and so outnumbers the correct form in the body. Discounting occurrences inside the pair repairs all four — and cannot be adopted:

| document | spaced | welded | correct |
|---|---|---|---|
| `arxiv-1004.1533v3` | `inv ariants` 54 | `invariants` 18 | **welded** |
| `aif-2009-59-1-347-0` | `institut fourier` 63 | `institutfourier` 18 | **spaced** |

Identical shape, opposite answers, so no statistic over these counts separates them. What separates them is that "fourier" is a word and "ariants" is not — a dictionary or a cross-document vocabulary, and this producer reads one PDF and consults only that PDF. Recorded in the test header so it is not re-attempted; the four titles are corrected downstream in qou's `library-title-overrides.json`, where a human verdict is the recorded mechanism.

## Gates

| Gate | Result |
|---|---|
| `bun test` | 730 pass, 51 skip, **0 fail** |
| `eslint .` | exit 0 |
| `tsc --noEmit` | exit 0 |
| `gen-schema-docs` + `gen-skill-docs` | no uncommitted diff |
| `ruff F401,F403` (the CI gate's own invocation) | All checks passed |
| `pdf-front-matter.test.py` | 4/4 |
| `pdf-text-repair.test.py` | 16/16 |
| `who-l1-extractor.test.py` | passes — **synthetic fixture only** |

## Limits

- The front-matter fix recovers exactly one title across the 373-document qou library (`SPHERICAL CATEGORIES`, plus its byline). It is a correctness fix on a common layout, not a bulk win — the other damaged titles need a reader, and got one.
- The WHO L1 extractor is still logic-tested against a synthetic fixture. No L1 PDF is in the corpus and `who.int` returns 403, so the real-layout question remains untested.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AWgkrPkXGZ1Hb2UmMmFMcP)_