### PR TITLE
block-qa: enforce that an agent violation carries its evidence

### DIFF
--- a/schemas/block-qa-schema/python/block_qa_schema/__init__.py
+++ b/schemas/block-qa-schema/python/block_qa_schema/__init__.py
@@ -140,6 +140,36 @@ class QaCriterionEntry(BaseModel):
     # ISO-8601 UTC datetime; legacy agent entries may carry a bare ISO date.
     reviewed_at: str
     reviewed_sha: Optional[str] = None
+
+    @model_validator(mode="after")
+    def _agent_violation_needs_evidence(self) -> "QaCriterionEntry":
+        """An agent verdict asserting a violation must carry its evidence.
+
+        Mirrors the ``allOf`` conditional in ``block-qa.schema.json``. The
+        ``result`` docstring has always said so -- "fail = violated (evidence
+        must cite file:line + verbatim quote)" -- but nothing enforced it, and
+        1302 agent fail/warn entries accumulated with ``evidence`` empty, their
+        reasoning filed under ``notes``/``referee_argument`` instead.
+
+        Scoped to ``reviewer.kind == "agent"`` deliberately: 933 SCRIPT
+        fail/warn entries carry no reason under any key, so a universal rule
+        would reject them on arrival. Widening it is the end state and is
+        blocked on fixing those checkers.
+        """
+        if self.result not in ("fail", "warn"):
+            return self
+        if getattr(self.reviewer, "kind", None) != "agent":
+            return self
+        ev = self.evidence
+        empty = ev is None or (isinstance(ev, str) and not ev.strip()) or (
+            isinstance(ev, list) and not ev
+        )
+        if empty:
+            raise ValueError(
+                f"result={self.result!r} from an agent reviewer requires "
+                "non-empty `evidence` citing what was found"
+            )
+        return self
     notes: Optional[str] = None
 
     @model_validator(mode="after")

--- a/schemas/block-qa-schema/schema/block-qa.schema.json
+++ b/schemas/block-qa-schema/schema/block-qa.schema.json
@@ -202,6 +202,20 @@
           "description": "structural scope requires a non-empty rebuttal naming the invariant.",
           "if": { "required": ["scope"], "properties": { "scope": { "const": "structural" } } },
           "then": { "required": ["rebuttal", "referee_argument"] }
+        },
+        {
+          "description": "An AGENT verdict asserting a violation must carry its evidence. The `result` description has always said so, but nothing enforced it and 1302 agent fail/warn entries accumulated with `evidence` empty, their reasoning filed under `notes`/`referee_argument` instead. Scoped to reviewer.kind == 'agent' deliberately: 933 SCRIPT fail/warn entries carry no reason under any key, so a universal rule would reject them on arrival; widening this is the end state and is blocked on fixing those checkers.",
+          "if": {
+            "required": ["result", "reviewer"],
+            "properties": {
+              "result": { "enum": ["fail", "warn"] },
+              "reviewer": { "required": ["kind"], "properties": { "kind": { "const": "agent" } } }
+            }
+          },
+          "then": {
+            "required": ["evidence"],
+            "properties": { "evidence": { "oneOf": [{ "type": "string", "minLength": 1 }, { "type": "array", "minItems": 1 }] } }
+          }
         }
       ],
       "description": "The outcome of one reviewer evaluating one criterion on one block."

--- a/schemas/block-qa-schema/tests/test_python.py
+++ b/schemas/block-qa-schema/tests/test_python.py
@@ -230,3 +230,71 @@ def test_json_schema_files_present():
     script = json.loads((schema_dir / "qa-script.schema.json").read_text())
     assert script["title"] == "QaScriptSidecar"
     assert script["properties"]["$schema"]["const"] == "qa-script/v1"
+
+
+# ── agent violations must carry evidence ──────────────────────────────────
+#
+# The `result` docstring has always said "fail = violated (evidence must cite
+# file:line + verbatim quote)", but nothing enforced it and 1302 agent
+# fail/warn entries accumulated with `evidence` empty. These pin the rule in
+# the Pydantic mirror; the JSON Schema carries the same condition as an
+# `allOf`.
+
+
+def _agent_entry(**over):
+    base = {
+        "field_hash": {"md": "a1b2c3d4e5f6"},
+        "result": "fail",
+        "reviewer": {"kind": "agent", "id": "local/qa-agent-drain"},
+        "reviewed_at": "2026-08-25T00:00:00Z",
+    }
+    base.update(over)
+    return base
+
+
+@pytest.mark.parametrize("result", ["fail", "warn"])
+def test_agent_violation_requires_evidence(result):
+    with pytest.raises(ValueError, match="requires non-empty `evidence`"):
+        QaCriterionEntry.model_validate(_agent_entry(result=result))
+
+
+@pytest.mark.parametrize("blank", ["", "   "])
+def test_agent_violation_rejects_blank_evidence(blank):
+    with pytest.raises(ValueError):
+        QaCriterionEntry.model_validate(_agent_entry(evidence=blank))
+
+
+def test_agent_violation_rejects_empty_evidence_list():
+    with pytest.raises(ValueError):
+        QaCriterionEntry.model_validate(_agent_entry(evidence=[]))
+
+
+def test_agent_violation_accepts_string_evidence():
+    e = QaCriterionEntry.model_validate(
+        _agent_entry(evidence="braid.lean:22:28: error(unknownIdentifier)")
+    )
+    assert e.result == "fail"
+
+
+def test_agent_violation_accepts_structured_evidence():
+    # The shape some agent reviewers emit; blessed by the `evidence` schema.
+    e = QaCriterionEntry.model_validate(
+        _agent_entry(evidence=[{"line": 18, "text": "claims 'exact'"}])
+    )
+    assert e.evidence
+
+
+@pytest.mark.parametrize("result", ["pass", "n/a"])
+def test_non_violation_needs_no_evidence(result):
+    # A verdict that found nothing has nothing to evidence; requiring it here
+    # would hollow out the sweep from the other side.
+    assert QaCriterionEntry.model_validate(_agent_entry(result=result))
+
+
+def test_script_reviewer_is_out_of_scope():
+    # Deliberate: 933 script fail/warn entries carry no reason under any key,
+    # so a universal rule would reject them on arrival. Widening this is the
+    # end state, blocked on fixing those checkers.
+    assert QaCriterionEntry.model_validate(
+        _agent_entry(reviewer={"kind": "script", "id": "qa-checkers-uses.ts"})
+    )


### PR DESCRIPTION
Companion to **litlfred/qou#5745**, which migrates the data this makes enforceable. Land that one first.

## What

`criterionEntry` gains an `allOf` conditional: an **agent** verdict with `result: fail|warn` must carry non-empty `evidence`. Mirrored as a Pydantic `model_validator` so the two representations agree. 10 new tests.

## Why

The `result` description has always stated the rule:

> `fail` = violated (**evidence must cite file:line + verbatim quote**)

That is prose in a `description`. `evidence` is absent from `criterionEntry.required`, and nothing checked it — so **1302 agent `fail`/`warn` entries** across 645 qou sidecars accumulated with `evidence` empty, their reasoning filed under `notes`/`referee_argument` instead. qou#5745 migrates those; this stops new ones.

The mechanism is not new — this schema already uses `if`/`then` **seven times** to tie `ruling`/`verdict` to `result`. This is an eighth.

## Scoped to `reviewer.kind == "agent"` — deliberately

**933 script `fail`/`warn` entries carry no reason under any key.** Genuinely silent verdicts, concentrated in four checkers:

| criterion | silent |
|---|---|
| `uses-editorial-hygiene` | 363 |
| `detangler-block-tanglement` | 247 |
| `uses-formal-coverage` | 121 |
| `detangler-graph-energy` | 92 |
| `proof-not-machine-trivial` | 54 |
| `wall-base-ring-minimal` | 50 |

A universal rule would reject all 933 on arrival and be reverted the same day. Widening this to every reviewer kind is the end state; it's blocked on fixing those checkers — which is the case the platform's own rule was written for (*"a checker that cannot read its evidence has not verified anything"*).

`pass` and `n/a` stay exempt: a verdict that found nothing has nothing to evidence, and requiring it there would hollow out the sweep from the other side.

## Verification

> ⚠️ **The four green checks on this PR did NOT run these tests.** The only pytest workflow in this repo is `pyhecke.yml`, scoped to pyhecke — nothing runs `schemas/block-qa-schema/tests/`. The green ticks cover TypeScript, import hygiene and the Lean gate; the schema-package suite below was run **locally only**. Flagging it so the checkmarks aren't read as validating this change.

- `pytest schemas/block-qa-schema/tests/test_python.py` → **18 pass** (local). The 10 new tests are **non-vacuous**: 5 fail against the un-validated model, then pass once it's restored.
- **0 violations across all 340,886 criterion entries** in the qou corpus, measured two independent ways — the conditional in isolation, and a full before/after diff of the entire schema.
- The **69,466 pre-existing `field_hash` violations** are untouched by this. They're a separate and much larger problem, surfaced by this measurement rather than caused by it.
- Schema diff is **14 added / 0 deleted**. A first pass rewrote the file with `json.dumps` and silently reflowed its compact inline arrays (307/50 diff); this one is a surgical insertion preserving the existing style.

## Not done

- **Widening to `script`/`human` reviewers** — blocked on the 933.
- **The `field_hash` requirement**, which 69,466 entries already violate.
- **Adding the block-qa suite to CI** — a real gap (see the warning above), but out of scope here; happy to do it in a follow-up.
- **Version bump** across `pyproject.toml` / `package.json` / `js/index.ts` — the change is additive validation, and the TS mirror carries no validation logic to update. Say the word if you want the lockstep bump anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVe9BeRoCsWNqMQa5sWe1r