### PR TITLE
fix(pdf): survive a cryptography that panics instead of raising ImportError

### DIFF
--- a/scripts/_pypdf_compat.py
+++ b/scripts/_pypdf_compat.py
@@ -1,0 +1,87 @@
+"""Import pypdf robustly, including when `cryptography` is installed but broken.
+
+pypdf's import chain reaches `cryptography` to provide its encrypted-PDF
+support. In a container where `cryptography` is installed but its Rust
+extension cannot load, that import raises **`pyo3_runtime.PanicException`**,
+which derives from `BaseException` rather than `Exception`. So the usual
+
+    try:
+        from pypdf import PdfReader
+    except ImportError:
+        sys.exit("... pip install pypdf")
+
+does not catch it — and neither would `except Exception`. The caller sees a
+Rust backtrace and a non-zero exit, with nothing pointing at the real cause:
+
+    ModuleNotFoundError: No module named '_cffi_backend'
+    thread '<unnamed>' panicked at pyo3-0.20.2/src/err/mod.rs:788:5
+    pyo3_runtime.PanicException: Python API call failed
+
+pypdf needs `cryptography` **only** for encrypted PDFs, and falls back to its
+own no-crypto provider when the module is simply absent. So on that failure we
+make it absent for this process and retry the import once. Reading unencrypted
+PDFs — which is all the structure/extract/OCR/split scripts do — is unaffected;
+an encrypted PDF then fails with pypdf's own clear `DependencyError` instead of
+a panic.
+
+History: added 2026-08-25 after the panic was hit in a qou session, misread as
+permanent, and worked around with a duplicate ingester on the qou side rather
+than fixed here. The duplicate was the wrong shape — `pdf-structure.py` is the
+owner of `pdf-structure/v1` and there should be exactly one producer of it.
+
+Usage:
+
+    from _pypdf_compat import import_pypdf
+    PdfReader, PdfWriter = import_pypdf("PdfReader", "PdfWriter")
+"""
+
+from __future__ import annotations
+
+import sys
+
+_MISSING = "needs pypdf — pip install pypdf"
+
+
+class _BlockCryptography:
+    """Meta-path finder that makes `cryptography` unimportable this process."""
+
+    def find_spec(self, name, path=None, target=None):  # noqa: D102
+        if name == "cryptography" or name.startswith("cryptography."):
+            raise ImportError(
+                "cryptography disabled by _pypdf_compat: its native extension "
+                "failed to load. pypdf only needs it for encrypted PDFs."
+            )
+        return None
+
+
+def _purge(prefixes: tuple[str, ...]) -> None:
+    for mod in [m for m in sys.modules if m.split(".")[0] in prefixes]:
+        del sys.modules[mod]
+
+
+def import_pypdf(*names: str):
+    """Return the named pypdf attributes, retrying without `cryptography`.
+
+    Exits with a one-line message if pypdf itself is absent. Any other import
+    failure is retried once with `cryptography` blocked; if that also fails the
+    original error is re-raised, because at that point it is not this problem.
+    """
+    try:
+        import pypdf
+    except ImportError:
+        sys.exit(f"{_prog()}: {_MISSING}")
+    except BaseException:
+        # Not an ImportError -- most likely the cryptography panic described
+        # above. Drop the half-imported modules and retry without it.
+        _purge(("pypdf", "cryptography"))
+        sys.meta_path.insert(0, _BlockCryptography())
+        try:
+            import pypdf  # noqa: F811
+        except ImportError:
+            sys.exit(f"{_prog()}: {_MISSING}")
+    return tuple(getattr(pypdf, n) for n in names) if len(names) > 1 else getattr(pypdf, names[0])
+
+
+def _prog() -> str:
+    import os
+    return os.path.basename(sys.argv[0]) or "pdf-tool"

--- a/scripts/pdf-structure.py
+++ b/scripts/pdf-structure.py
@@ -55,10 +55,12 @@ from typing import Any
 
 warnings.filterwarnings("ignore")
 
-try:
-    from pypdf import PdfReader
-except ImportError:  # pragma: no cover
-    sys.exit("pdf-structure: needs pypdf — pip install pypdf")
+# pypdf's import chain reaches `cryptography`, which panics rather than raising
+# ImportError when its native extension is broken -- see scripts/_pypdf_compat.py.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _pypdf_compat import import_pypdf  # noqa: E402
+
+PdfReader = import_pypdf("PdfReader")
 
 SCHEMA = "pdf-structure/v1"
 

--- a/scripts/split-pdf-by-chapter.py
+++ b/scripts/split-pdf-by-chapter.py
@@ -39,14 +39,16 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import pathlib
 import sys
 from pathlib import Path
 
-try:
-    from pypdf import PdfReader, PdfWriter
-except ImportError:
-    print("ERROR: pypdf not installed. Install with: pip install pypdf", file=sys.stderr)
-    sys.exit(2)
+# See scripts/_pypdf_compat.py: a broken `cryptography` native extension panics
+# instead of raising ImportError, and the panic is not an Exception subclass.
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from _pypdf_compat import import_pypdf  # noqa: E402
+
+PdfReader, PdfWriter = import_pypdf("PdfReader", "PdfWriter")
 
 
 # Chapter slugs bundled into front-matter.pdf rather than as standalone PDFs.

--- a/tests/test_pypdf_compat.py
+++ b/tests/test_pypdf_compat.py
@@ -1,0 +1,57 @@
+"""The pypdf import must survive a `cryptography` that panics on import.
+
+Regression test for the failure mode described in scripts/_pypdf_compat.py:
+pyo3's PanicException derives from BaseException, so `except ImportError` --
+and even `except Exception` -- lets it through.
+"""
+import os
+import subprocess
+import sys
+
+SCRIPTS = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts")
+
+# Simulates the broken native extension: a meta-path finder that raises a
+# BaseException (not an Exception) the moment `cryptography` is imported,
+# exactly as the pyo3 panic does.
+PROBE = r'''
+import sys
+class Panic(BaseException):        # pyo3_runtime.PanicException is BaseException
+    pass
+class Detonate:
+    def find_spec(self, name, path=None, target=None):
+        if name == "cryptography" or name.startswith("cryptography."):
+            raise Panic("Python API call failed")
+        return None
+sys.meta_path.insert(0, Detonate())
+for m in [m for m in sys.modules if m.split(".")[0] in ("pypdf", "cryptography")]:
+    del sys.modules[m]
+sys.path.insert(0, {scripts!r})
+from _pypdf_compat import import_pypdf
+R = import_pypdf("PdfReader")
+print("RECOVERED", R.__name__)
+'''
+
+
+def test_survives_cryptography_panic():
+    out = subprocess.run([sys.executable, "-c", PROBE.format(scripts=SCRIPTS)],
+                         capture_output=True, text=True, timeout=120)
+    assert out.returncode == 0, f"guard did not recover:\n{out.stderr[-1500:]}"
+    assert "RECOVERED PdfReader" in out.stdout, out.stdout
+
+
+def test_naive_guard_would_have_failed():
+    """The control: `except ImportError` does NOT catch it. If this ever starts
+    passing, the panic is no longer BaseException-derived and the guard in
+    _pypdf_compat can be simplified."""
+    naive = PROBE.replace(
+        "from _pypdf_compat import import_pypdf\nR = import_pypdf(\"PdfReader\")",
+        "try:\n    from pypdf import PdfReader as R\nexcept ImportError:\n    print('caught as ImportError'); raise SystemExit(3)")
+    out = subprocess.run([sys.executable, "-c", naive.format(scripts=SCRIPTS)],
+                         capture_output=True, text=True, timeout=120)
+    assert out.returncode != 0 and "caught as ImportError" not in out.stdout, (
+        "naive guard unexpectedly handled the panic; see docstring")
+
+
+if __name__ == "__main__":
+    test_survives_cryptography_panic(); print("PASS survives panic")
+    test_naive_guard_would_have_failed(); print("PASS control: naive guard fails")


### PR DESCRIPTION
## The bug

`pypdf`'s import chain reaches `cryptography` for encrypted-PDF support. Where `cryptography` is installed but its native extension cannot load, that import raises **`pyo3_runtime.PanicException`** — which derives from `BaseException`, **not** `Exception`. So the guard in `pdf-structure.py`:

```python
try:
    from pypdf import PdfReader
except ImportError:
    sys.exit("pdf-structure: needs pypdf — pip install pypdf")
```

does not catch it. Neither would `except Exception`. The caller gets a Rust backtrace and a non-zero exit with nothing pointing at the cause:

```
ModuleNotFoundError: No module named '_cffi_backend'
thread '<unnamed>' panicked at pyo3-0.20.2/src/err/mod.rs:788:5
pyo3_runtime.PanicException: Python API call failed
```

## This is already known here — it was fixed in one file

`pdf-extract.py:147` carries `except BaseException:  # noqa: BLE001 -- PanicException is not an Exception`. So the failure mode was hit before and understood. That fix covers one script and **degrades** (returns `None`) rather than recovering.

This generalises it and **recovers** instead. `pypdf` needs `cryptography` only for encrypted PDFs and falls back to its own no-crypto provider when the module is simply absent — so `scripts/_pypdf_compat.py` makes it absent for the process and retries the import once. Unencrypted reading, which is all these scripts do, is unaffected; an encrypted PDF now fails with pypdf's own `DependencyError` instead of a panic.

Wired into `pdf-structure.py` and `split-pdf-by-chapter.py`, the two still on the narrow guard. `pdf-ocr.py` does not import pypdf.

## Tests

`tests/test_pypdf_compat.py` covers **both directions**:

| test | asserts |
|---|---|
| `test_survives_cryptography_panic` | the guard recovers from a simulated `BaseException`-raising `cryptography` |
| `test_naive_guard_would_have_failed` | the **control** — `except ImportError` does *not* catch it |

The control is the point: if pypdf ever stops routing through `cryptography`, that test fails and this shim can be **deleted** rather than kept forever on faith.

Both pass. `pdf-structure.py` verified end-to-end on a real PDF afterwards — `arxiv-0805.1447v2`, 8 sections, valid `pdf-structure/v1`.

## Provenance

Found from the qou side, where I hit the panic, **misdiagnosed it as permanent**, and worked around it with a duplicate ingester emitting `pdf-structure/v1` by hand. That was the wrong shape — `pdf-structure.py` owns that schema and there should be exactly one producer of it. The duplicate is being removed on the qou side ([litlfred/qou#5782](https://github.com/litlfred/qou/pull/5782)) in favour of this script.

Measured, the real tool is also simply better: 8 sections on `arxiv-0805.1447v2` against the duplicate's 6.

---
_Generated by [Claude Code](https://claude.ai/code/session_019qmr2EGCwvCZiTnSFkqYPG)_