### PR TITLE
fix(script-qa): the sweep audited ZERO scripts in every content repo — 0 → 3814 on qou

### DIFF
--- a/content/pipeline/script-sweep.ts
+++ b/content/pipeline/script-sweep.ts
@@ -389,6 +389,33 @@ async function run(): Promise<void> {
     }
   }
 
+  if (totalScripts === 0) {
+    // A sweep over nothing used to print "0 findings" and exit 0, which
+    // reads exactly like a clean sweep of everything. It is not a result,
+    // it is a misconfiguration, and it hid a broken root for months. Say so,
+    // name the roots actually walked, and fail.
+    console.error("");
+    console.error("script-sweep: NO SCRIPTS WERE AUDITED — this is a");
+    console.error("  misconfiguration, not a clean result. The roots below");
+    console.error("  are joined onto the CONTENT repo root; check that you");
+    console.error("  are running from the content repo and that they exist.");
+    console.error(`    content root : ${CONTENT_ROOT}`);
+    console.error(`    platform root: ${PLATFORM_ROOT}`);
+    for (const r of SCRIPT_ROOTS) {
+      const abs = resolve(CONTENT_ROOT, r.dir);
+      console.error(
+        `    root         : ${r.dir} -> ${abs}` +
+          `  [${existsSync(abs) ? "exists" : "MISSING"}]`,
+      );
+    }
+    if (args.filter) {
+      console.error(
+        `  NOTE: --filter ${args.filter} was set; a filter matching nothing`,
+      );
+      console.error("        also lands here, and is not a misconfiguration.");
+    }
+    process.exitCode = 1;
+  }
   if (args.json) {
     console.log(
       JSON.stringify(
@@ -409,33 +436,6 @@ async function run(): Promise<void> {
     );
   } else {
     console.log(`script-sweep: ${totalScripts} script(s) audited`);
-    if (totalScripts === 0) {
-      // A sweep over nothing used to print "0 findings" and exit 0, which
-      // reads exactly like a clean sweep of everything. It is not a result,
-      // it is a misconfiguration, and it hid a broken root for months. Say so,
-      // name the roots actually walked, and fail.
-      console.error("");
-      console.error("script-sweep: NO SCRIPTS WERE AUDITED — this is a");
-      console.error("  misconfiguration, not a clean result. The roots below");
-      console.error("  are joined onto the CONTENT repo root; check that you");
-      console.error("  are running from the content repo and that they exist.");
-      console.error(`    content root : ${CONTENT_ROOT}`);
-      console.error(`    platform root: ${PLATFORM_ROOT}`);
-      for (const r of SCRIPT_ROOTS) {
-        const abs = resolve(CONTENT_ROOT, r.dir);
-        console.error(
-          `    root         : ${r.dir} -> ${abs}` +
-            `  [${existsSync(abs) ? "exists" : "MISSING"}]`,
-        );
-      }
-      if (args.filter) {
-        console.error(
-          `  NOTE: --filter ${args.filter} was set; a filter matching nothing`,
-        );
-        console.error("        also lands here, and is not a misconfiguration.");
-      }
-      process.exitCode = 1;
-    }
     console.log(`           HEAD: ${headSha.slice(0, 12) || "(no git)"}`);
     console.log(`           criteria: ${runnableIds.join(", ")}`);
     console.log(

--- a/content/pipeline/script-sweep.ts
+++ b/content/pipeline/script-sweep.ts
@@ -25,7 +25,25 @@ import { dirname, relative, resolve } from "path";
 import { fileURLToPath } from "url";
 
 const __filename = fileURLToPath(import.meta.url);
-const REPO_ROOT = resolve(dirname(__filename), "..", "..");
+
+/**
+ * The PLATFORM root (folio-assistant itself). Criterion sources such as
+ * `content/pipeline/qa-checkers-python.ts` live here, and the sidecars record
+ * them platform-relative (`source_file`), so criterion hashing must use this.
+ */
+const PLATFORM_ROOT = resolve(dirname(__filename), "..", "..");
+
+/**
+ * The CONTENT repo root (qou, …). The audited scripts live here and the
+ * sidecars record them content-relative (`script_path`), so walking must use
+ * this.
+ *
+ * These were ONE constant, and that is the whole bug: the platform root was
+ * being joined onto a content-relative `SCRIPT_ROOTS` entry, yielding a
+ * doubled path that does not exist, so the walker yielded nothing and the
+ * sweep exited 0 over an empty set.
+ */
+const CONTENT_ROOT = findContentRepoRoot();
 
 import {
   QA_CRITERIA_BY_ID,
@@ -41,7 +59,12 @@ import {
   saveQaScriptSidecar,
   type CriterionScriptHashes,
 } from "./qa-utils";
-import { walkScripts, type ScriptTarget } from "./script-walker";
+import {
+  walkScripts,
+  SCRIPT_ROOTS,
+  type ScriptTarget,
+} from "./script-walker";
+import { findContentRepoRoot } from "./repo-root";
 import {
   checkDoesNotDefaultToFloat,
   checkComputeNoMpfToFloatCast,
@@ -114,7 +137,7 @@ const SCRIPT_CHECKERS: Record<string, ScriptCheckerFn> = {
   },
   connected_to_ci_pipeline: (t) => {
     if (t.language !== "python") return { result: "n/a", hits: [] };
-    return checkConnectedToCiPipeline(t.abs, REPO_ROOT);
+    return checkConnectedToCiPipeline(t.abs, CONTENT_ROOT);
   },
   deprecated: (t) => {
     if (t.language !== "python") return { result: "n/a", hits: [] };
@@ -216,7 +239,7 @@ async function run(): Promise<void> {
       id,
       getCriterionSourceFile(id),
       getCriterionExtraInputs(id),
-      REPO_ROOT,
+      PLATFORM_ROOT,
     );
   }
   const engineVersion = `bun-${Bun.version}`;
@@ -227,7 +250,7 @@ async function run(): Promise<void> {
   let totalMajor = 0;
   let totalMinor = 0;
 
-  for (const target of walkScripts(REPO_ROOT)) {
+  for (const target of walkScripts(CONTENT_ROOT)) {
     if (args.filter && !args.filter.test(target.rel)) continue;
     totalScripts++;
 
@@ -311,7 +334,7 @@ async function run(): Promise<void> {
         entry.severity = def.default_severity;
         entry.evidence = checkRes.hits
           .slice(0, 5)
-          .map((h) => `${relative(REPO_ROOT, h.file)}:${h.line}: ${h.text}`)
+          .map((h) => `${relative(CONTENT_ROOT, h.file)}:${h.line}: ${h.text}`)
           .join(" | ");
         if (def.default_severity === "critical") {
           sweepRow.fail_critical++;
@@ -362,7 +385,7 @@ async function run(): Promise<void> {
         last_run_sha: headSha,
         engine_version: engineVersion,
       };
-      saveQaScriptSidecar(sidecar, REPO_ROOT);
+      saveQaScriptSidecar(sidecar, CONTENT_ROOT);
     }
   }
 
@@ -386,6 +409,33 @@ async function run(): Promise<void> {
     );
   } else {
     console.log(`script-sweep: ${totalScripts} script(s) audited`);
+    if (totalScripts === 0) {
+      // A sweep over nothing used to print "0 findings" and exit 0, which
+      // reads exactly like a clean sweep of everything. It is not a result,
+      // it is a misconfiguration, and it hid a broken root for months. Say so,
+      // name the roots actually walked, and fail.
+      console.error("");
+      console.error("script-sweep: NO SCRIPTS WERE AUDITED — this is a");
+      console.error("  misconfiguration, not a clean result. The roots below");
+      console.error("  are joined onto the CONTENT repo root; check that you");
+      console.error("  are running from the content repo and that they exist.");
+      console.error(`    content root : ${CONTENT_ROOT}`);
+      console.error(`    platform root: ${PLATFORM_ROOT}`);
+      for (const r of SCRIPT_ROOTS) {
+        const abs = resolve(CONTENT_ROOT, r.dir);
+        console.error(
+          `    root         : ${r.dir} -> ${abs}` +
+            `  [${existsSync(abs) ? "exists" : "MISSING"}]`,
+        );
+      }
+      if (args.filter) {
+        console.error(
+          `  NOTE: --filter ${args.filter} was set; a filter matching nothing`,
+        );
+        console.error("        also lands here, and is not a misconfiguration.");
+      }
+      process.exitCode = 1;
+    }
     console.log(`           HEAD: ${headSha.slice(0, 12) || "(no git)"}`);
     console.log(`           criteria: ${runnableIds.join(", ")}`);
     console.log(

--- a/content/pipeline/script-walker.ts
+++ b/content/pipeline/script-walker.ts
@@ -3,8 +3,13 @@
  *
  * Walks the script roots declared in `SCRIPT_ROOTS` and yields one
  * descriptor per audited script. Currently covers Python compute
- * scripts under `folio-assistant/computations/`; extending to
+ * scripts under the CONTENT repo's `computations/`; extending to
  * TypeScript or Rust just adds another entry to `SCRIPT_ROOTS`.
+ *
+ * `SCRIPT_ROOTS` entries are relative to the **content repo**, and
+ * `walkScripts` must be handed that root — see `findContentRepoRoot()` in
+ * ./repo-root. Handing it the platform root instead is what made this
+ * walker a silent no-op; see the note on `SCRIPT_ROOTS` below.
  *
  * @module content/pipeline/script-walker
  */
@@ -50,9 +55,28 @@ export interface ScriptRoot {
   language: ScriptLanguage;
 }
 
+/**
+ * Paths here are relative to the **content repo** (`qou`, …), never to
+ * folio-assistant. That is the same convention the sidecars already record:
+ * a `script-qa/*.script-qa.json` carries `script_path:
+ * "computations/hecke/hecke_characters.py"`, with no `folio-assistant/`
+ * prefix.
+ *
+ * This read `folio-assistant/computations` and was joined onto the PLATFORM
+ * root, producing `<folio-assistant>/folio-assistant/computations` — a
+ * doubled path that does not exist. `walkRoot` returns early on
+ * `!existsSync`, so the sweep audited **zero** scripts and exited 0 reporting
+ * "0 script(s) audited / 0 findings" — indistinguishable from a clean sweep
+ * of everything. Measured on `qou` at the time of the fix: 1086 of 1798
+ * script-qa sidecars were hash-stale and unrefreshable behind it.
+ *
+ * `repo-root.ts` already diagnosed this class in its own docstring —
+ * "the caller reported a clean run over nothing" — and this walker was
+ * simply never migrated onto it.
+ */
 export const SCRIPT_ROOTS: ScriptRoot[] = [
   {
-    dir: "folio-assistant/computations",
+    dir: "computations",
     exts: [".py"],
     language: "python",
   },


### PR DESCRIPTION
`script-sweep` has been a **silent no-op for every content repo**. It exited 0 and printed `0 script(s) audited / 0 findings` — indistinguishable from a clean sweep of everything.

Found from the qou side (bean `qou-z8x9`): editing `computations/hecke/hecke_characters.py` made its `script-qa` sidecar hash-stale, and it could not be refreshed because the sweeper could not see the file.

| | before | after |
|---|---|---|
| scripts audited on qou | **0** | **3814** |
| exit code | 0 | 0 |
| findings | `0 / 0 / 0` | `106 critical / 2571 major / 8829 minor` |
| a sweep over nothing | exits 0, looks clean | **exits 1, says why** |

3814 is exactly `find computations -name '*.py' \| wc -l`, so coverage is now the whole corpus rather than a subset.

## Root cause — one constant doing two jobs

```ts
const REPO_ROOT = resolve(dirname(__filename), "..", "..");    // = PLATFORM root
SCRIPT_ROOTS = [{ dir: "folio-assistant/computations", … }]    // = CONTENT-relative
```

joined to `<folio-assistant>/folio-assistant/computations` — a **doubled path that does not exist**. `walkRoot` returns early on `!existsSync`, so the generator yielded nothing.

The two roots are genuinely different and both are needed, which is why one constant could not serve:

- **`PLATFORM_ROOT`** — criterion sources (`content/pipeline/qa-checkers-python.ts`), which sidecars record platform-relative as `source_file`.
- **`CONTENT_ROOT`** — the audited scripts, which sidecars record content-relative as `script_path` (`computations/hecke/hecke_characters.py`, no `folio-assistant/` prefix).

`CONTENT_ROOT` now comes from the **existing** helper `findContentRepoRoot()` in `./repo-root`, whose own docstring already diagnosed this class:

> the caller reported a clean run over nothing

This walker was simply never migrated onto it. `SCRIPT_ROOTS` becomes content-relative (`computations`), matching what the sidecars have always recorded.

Three further `REPO_ROOT` uses were checked **individually** rather than swapped en masse; all three want `CONTENT_ROOT` — `checkConnectedToCiPipeline` reads `<root>/.github/workflows` and greps sibling `.py`; `relative()` renders a hit inside an audited script; `saveQaScriptSidecar` writes next to the script.

## A zero-target sweep is now loud

This is the durable half. The failure hid for months because the output of *auditing nothing* was identical to the output of *finding nothing*.

```
script-sweep: NO SCRIPTS WERE AUDITED — this is a
  misconfiguration, not a clean result. …
    content root : /home/user/qou
    platform root: /home/user/folio-assistant
    root         : computations -> /home/user/qou/computations  [exists]
```

…and `process.exitCode = 1`. It also distinguishes the **legitimate** case: a `--filter` matching nothing says so explicitly and is not called a misconfiguration. Running from the platform root also lands here now, which is the right answer there — folio-assistant is the platform, not a folio.

## Scope — nothing was written

Every run in this PR used `--dry-run`. **No sidecars were created or modified.** Draining the newly-visible findings is content-repo work and does not belong here.

One caveat I want to be honest about: 568 of the 3814 are under `_deprecated/`, and the top-15 sample in the output is dominated by single-hit deprecated files — but the top-15 cap means **the full severity split is unmeasured**. Do not quote a breakdown off that sample.

Downstream consequence, measured on qou: **1086 of 1798** `script-qa` sidecars were hash-stale and unrefreshable behind this (708 fresh, 4 with a missing source).

## Verification

- **CI green, 4/4** on this head — including **`TypeScript — tests, lint, types (hard)`**, plus the Python-imports, Lean bare-import and Rust-wildcard gates. (Worth stating explicitly because the sibling repo qou has auto-triggers disabled repo-wide; **this** repo does run CI, and it passes.)
- `bunx tsc --noEmit` clean on both changed files locally, before the push.
- Targeted sweep audits the originating file and reports 3 real hits (was 0 before).
- Zero-target path reproduced deliberately: exits 1 with the diagnostic above.
- Full dry-run over qou at `bd7dacfd0`: 3814 audited in 3 m 22 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YaoTiLH4WC5zydwhEiQAf