### PR TITLE
feat(pipeline): establish block identity by importing the module, not scanning its source

### DIFF
--- a/.beans/folio-assistant-fsl7--repoint-remaining-hand-rolled-block-scanners-at-th.md
+++ b/.beans/folio-assistant-fsl7--repoint-remaining-hand-rolled-block-scanners-at-th.md
@@ -1,11 +1,11 @@
 ---
 # folio-assistant-fsl7
 title: Repoint remaining hand-rolled block scanners at the module loader
-status: todo
+status: completed
 type: task
 priority: normal
 created_at: 2026-08-08T13:25:41Z
-updated_at: 2026-08-26T13:58:47Z
+updated_at: 2026-08-26T14:11:38Z
 ---
 
 Follow-up to jwd9, which replaced the source-text scan with module imports in conjectural-propagation-audit and conditional-class-banner-audit and added write-verification to prune-transitive-deps.
@@ -316,7 +316,51 @@ one of the three the change exists to fix — never reached the loader at all. T
 test caught it. The label is a question about identity, not about candidacy; the
 gate is the builder call alone.
 
-### Why `verify` is opt-in and not the default
+### The measurement ran, and the default is flipped
+
+I first wrote that the corpus "lives in the folio repo, not here, and this
+session had no access to one". That was wrong, and wrong in the cheap way:
+`add_repo litlfred/qou` attached it in one call. I asserted a limitation I had
+never tested. The measurement it was blocking takes about a second.
+
+`bun run content/pipeline/verify-block-walk.ts /home/user/qou/content/quantum-observable-universe`
+
+    QA mode    (includeUnlabelled)  textual 3557 blocks / 450 ms
+                                    verified 3557 blocks / 1475 ms
+    graph mode (default)            textual 3494 · verified 3494, identical
+                                    (kind, label, ts) triples
+
+    blocks only the verified walk finds  0
+    blocks only the textual walk finds   0
+    blocks whose identity differs        0
+    blocks that would not import         0
+
+So on `qou` the flip is a **no-op plus one second**. Its value is not fixing
+something broken there; it is that the three failure classes become impossible
+rather than merely absent-so-far, and that the walk stops depending on a parser
+that can drift. `verify` defaults to `true`; `verify: false` is the escape
+hatch.
+
+Two things the run itself turned up:
+
+- **A folio needs its platform symlink.** Importing a block resolves its
+  imports, and `qou/content/schema/builders.ts` re-exports through
+  `<folio>/folio-assistant`, which `scripts/setup-folio-assistant.sh` creates.
+  Without it all 3557 blocks fail to load. The walk still yields every one of
+  them under its textual identity and says so — the fallback doing its job —
+  but the first run printed 3557 warning lines and buried the one line that
+  said what to fix. Now capped at five named files plus a summary that names
+  the likely cause.
+- **The warning budget was process-global**, so a second walk in the same
+  process (`qa-sweep` calls `usesGraphHash` before its own) would have had its
+  genuine failures silently swallowed by the first walk having spent it. Scoped
+  per walk.
+
+And the flip broke `verify-block-walk` itself — both of its arms had been
+relying on the default, so it started comparing the verified reading with
+itself. Both arms now state `verify` explicitly.
+
+### Why it was opt-in first
 
 `walkBlocks(root, { verify: true, onLoadFailure })`. Default `false`.
 
@@ -339,5 +383,11 @@ coverage hole, which is `qou/3fui` in reverse.
 
 ### Still open
 
-Only the flip, and it is now one measurement away rather than one refactor away.
-Bullet 1 stays closed by owner decision.
+Nothing in this bean's subject. Both scanners are addressed: bullet 1 closed by
+owner decision, bullet 2 repointed at the loader and the default flipped on a
+measurement.
+
+What a future reader should know rather than rediscover: the default was
+measured against **one** corpus. Another folio should be run through
+`verify-block-walk.ts` before its walks are trusted to verify, and
+`verify: false` is there when it disagrees.

--- a/.beans/folio-assistant-fsl7--repoint-remaining-hand-rolled-block-scanners-at-th.md
+++ b/.beans/folio-assistant-fsl7--repoint-remaining-hand-rolled-block-scanners-at-th.md
@@ -3,8 +3,9 @@
 title: Repoint remaining hand-rolled block scanners at the module loader
 status: todo
 type: task
+priority: normal
 created_at: 2026-08-08T13:25:41Z
-updated_at: 2026-08-08T16:05:00Z
+updated_at: 2026-08-26T13:58:47Z
 ---
 
 Follow-up to jwd9, which replaced the source-text scan with module imports in conjectural-propagation-audit and conditional-class-banner-audit and added write-verification to prune-transitive-deps.
@@ -266,3 +267,77 @@ before it was reported as a risk.
 
 So the change is cheap AND quiet. The prose was clean; it simply could not be
 seen to be.
+
+## 2026-08-26 — the loader exists; bullet 2 is repointed behind an opt-in
+
+Bullet 2 was filed as "fine as is **unless a sync loader appears**". One
+appeared. Bun's `require` loads a TypeScript ES module synchronously, so
+`walkBlocks` — a sync generator with fourteen production callers, which is the
+whole reason it reads identity out of source text — can now import a block
+without becoming async.
+
+`loadBlockModuleSync` in `content/pipeline/block-module.ts`. Cost, measured over
+300 generated manifests plus 10 non-block helpers, cold:
+
+    regex readBlockManifest   16.0 ms   0.052 ms / file
+    loadBlockModuleSync       67.1 ms   0.216 ms / file
+
+Four times the regex, 0.76 s across three and a half thousand blocks. Matches
+the 0.66 ms/block the async loader measured in `jwd9`.
+
+### The textual read is wrong in three ways, and one of them is a wrong answer
+
+Not asserted — demonstrated, and pinned in
+`scripts/tests/block-walk-verify.test.ts`:
+
+| source                             | regex reads           | the block *is*         |
+|------------------------------------|-----------------------|------------------------|
+| `label: LBL` (a constant)          | `undefined` → skipped | `prop:computed`        |
+| an earlier `label:` in a helper    | `not-the-block`       | `prop:real`            |
+| `proposition({label:"theorem:x"})` | `theorem:x`           | rejected by the schema |
+
+Row 2 is the sharp one. It is not a miss, it is a confident wrong answer — a
+sidecar and a graph node keyed to a label the block does not have. Same shape as
+the `root`-is-a-stem bug that reported "0 siblings across 3486 blocks" and
+looked plausible enough to nearly publish.
+
+### The candidate gate stays textual, and that is load-bearing
+
+Importing a module runs it, and a content tree holds scripts as well as
+manifests — `content/pipeline/qa-agent-drain-queue.ts` in this repo starts a
+sweep at import time. So `readBlockManifest`'s masked builder-call match now
+decides *what may be executed*, and the loader decides *what it is*. Two tests
+pin the gate: a helper with a top-level side effect is never imported, and
+neither is the `#125` shape (a builder call inside a template literal).
+
+Writing this turned up a mistake in my own first cut. I had gated verification
+on the file having a textual `label:`, which meant the computed-label case —
+one of the three the change exists to fix — never reached the loader at all. The
+test caught it. The label is a question about identity, not about candidacy; the
+gate is the builder call alone.
+
+### Why `verify` is opt-in and not the default
+
+`walkBlocks(root, { verify: true, onLoadFailure })`. Default `false`.
+
+Fourteen tools consume this generator, and this repo has twice learned that
+changing what the walk enumerates must be measured against real content before
+it lands: `#125` admitted a non-block, `qou/3fui` missed 63 real ones — and in
+that case the measurement *reversed* the recommendation the change had been
+argued on. The corpus that would settle it is in the folio repo, not here, and
+this session had no access to one.
+
+So the flip is staged, not deferred indefinitely.
+`bun run content/pipeline/verify-block-walk.ts <content-root>` walks both ways
+and prints every disagreement, every block only one mode finds, every block that
+will not import, and what the flip costs in wall-clock. Run it against `qou`;
+flip the default on what it prints.
+
+A block that fails to import is reported and **still yielded**, carrying its
+degraded textual identity. Dropping it would trade a loud problem for a silent
+coverage hole, which is `qou/3fui` in reverse.
+
+### Still open
+
+Only the flip, and it is now one measurement away rather than one refactor away.
+Bullet 1 stays closed by owner decision.

--- a/content/pipeline/block-module.ts
+++ b/content/pipeline/block-module.ts
@@ -50,6 +50,7 @@
 
 import { readdir } from "node:fs/promises";
 import { writeFileSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
 import { join, dirname, basename } from "node:path";
 import { BLOCK_KINDS } from "../../schemas/types";
 
@@ -81,7 +82,70 @@ const KINDS = new Set<string>(BLOCK_KINDS);
  */
 export async function loadBlockModule(tsPath: string): Promise<LoadedBlock | undefined> {
   const mod = (await import(tsPath)) as { default?: unknown };
-  const block = mod.default as Record<string, unknown> | undefined;
+  return asLoadedBlock(mod.default, tsPath);
+}
+
+/**
+ * The synchronous sibling of `loadBlockModule`.
+ *
+ * `walkBlocks` — the enumeration every QA tool runs on — is a synchronous
+ * generator with fourteen production callers, so it could not `await` an
+ * import. That is the only reason it still reads block identity out of source
+ * text with a regex, and the reason `fsl7` sat open: *"repointing needs either
+ * a sync loader or a restructure … A sync loader, which bullet 1 already names.
+ * Still absent."*
+ *
+ * It is absent no longer. Bun's `require` loads a TypeScript ES module
+ * synchronously, so a block's builder runs and its validated default export
+ * comes back in one call, with no promise to await.
+ *
+ * ## Cost
+ *
+ * Measured over 300 generated block manifests plus 10 non-block helpers, cold:
+ *
+ *     regex readBlockManifest   16.0 ms    0.052 ms / file
+ *     loadBlockModuleSync       67.1 ms    0.216 ms / file
+ *
+ * Four times the regex, and 0.76 s across a corpus of three and a half
+ * thousand. Consistent with the 0.66 ms/block the async loader measured above.
+ *
+ * ## Runtime
+ *
+ * `require` of a `.ts` ES module is a **Bun** capability. Under a runtime that
+ * cannot do it the call throws, which is the honest outcome: a caller must not
+ * get silence and conclude the corpus is clean. Everything in
+ * `content/pipeline` already runs under Bun.
+ *
+ * ## This does not decide which files to execute
+ *
+ * Importing a module runs it. `walkBlocks` recurses a content root and reads
+ * every `.ts` beneath it, and a content tree holds more than block manifests —
+ * `content/pipeline/qa-agent-drain-queue.ts` in this very repo starts a sweep
+ * at import time. So the caller decides what is worth executing *before*
+ * calling this, and `readBlockManifest`'s masked regex is exactly that gate:
+ * cheap, and it already refuses a builder call written inside a string or a
+ * comment (`#125`). Candidate detection stays textual; block *identity* comes
+ * from here.
+ */
+export function loadBlockModuleSync(tsPath: string): LoadedBlock | undefined {
+  const mod = requireSync(tsPath) as { default?: unknown };
+  return asLoadedBlock(mod.default, tsPath);
+}
+
+/** `createRequire` is resolved once; building one per call is measurable. */
+let cachedRequire: ((id: string) => unknown) | undefined;
+
+function requireSync(tsPath: string): unknown {
+  cachedRequire ??= createRequire(import.meta.url) as unknown as (id: string) => unknown;
+  return cachedRequire(tsPath);
+}
+
+/**
+ * Shared by both loaders, so "what counts as a block" cannot drift between the
+ * sync and async paths — the drift this whole module exists to end.
+ */
+function asLoadedBlock(value: unknown, file: string): LoadedBlock | undefined {
+  const block = value as Record<string, unknown> | undefined;
   if (!block || typeof block !== "object") return undefined;
   const kind = block.kind;
   const label = block.label;
@@ -92,7 +156,7 @@ export async function loadBlockModule(tsPath: string): Promise<LoadedBlock | und
     kind,
     label,
     uses: Array.isArray(rawUses) ? rawUses.filter((u): u is string => typeof u === "string") : [],
-    file: tsPath,
+    file,
     block,
   };
 }

--- a/content/pipeline/qa-utils.ts
+++ b/content/pipeline/qa-utils.ts
@@ -720,14 +720,27 @@ export interface WalkBlocksOptions {
    * (`qa-agent-drain-queue.ts` starts a sweep at import time). Verification
    * upgrades identity; it does not widen what gets executed.
    *
-   * **Default `false`, deliberately.** Fourteen production tools consume this
-   * generator, and this repo has twice learned that changing what the walk
-   * enumerates must be measured against real content before it lands (`#125`
-   * admitted a non-block; `qou/3fui` missed 63 real ones, and the measurement
-   * reversed the recommendation). The corpus that would settle it lives in the
-   * content repo, not here. `bun run content/pipeline/verify-block-walk.ts
-   * <content-root>` runs both modes and diffs them; flip this default on that
-   * evidence, not on this comment.
+   * **Default `true`, on measured evidence.** This repo has twice learned that
+   * changing what the walk enumerates must be measured against real content
+   * before it lands — `#125` admitted a non-block, `qou/3fui` missed 63 real
+   * ones and the measurement reversed the recommendation the change had been
+   * argued on. So `verify-block-walk.ts` was written first and run against the
+   * `qou` corpus, all 3557 blocks:
+   *
+   *     textual walk : 3557 blocks in  493 ms
+   *     verified walk: 3557 blocks in 1473 ms
+   *     identity differences 0 · found by only one mode 0 · failed to import 0
+   *
+   * A second of wall-clock, and nothing else about that corpus moves. What it
+   * buys is the three failure classes above becoming impossible rather than
+   * merely absent-so-far. Measured on **one** corpus; `verify: false` is the
+   * escape hatch, and re-run that command on any other folio before relying on
+   * the default there.
+   *
+   * The one new coupling: importing a block resolves its imports, and a folio's
+   * blocks import the platform through a symlink its setup script creates
+   * (`<folio>/folio-assistant`). Without it every block fails to load — the
+   * walk still yields all of them under their textual identity, and says so.
    */
   verify?: boolean;
 
@@ -762,6 +775,8 @@ export function* walkBlocks(
   // the .lean (wall-side, compute-prop-has-probe/-consumer, voice, q-usage).
   const REPO_ROOT = findContentRepoRoot();
   const lakeCache: LakeTreeCache = new Map();
+  const verify = opts.verify ?? true;
+  const report = makeFailureReporter(opts);
 
   function* recurse(d: string): Generator<BlockPaths> {
     if (!existsSync(d)) return;
@@ -780,12 +795,12 @@ export function* walkBlocks(
         // Reading the unlabelled shape costs a second read + mask, so only pay
         // it when someone can act on the answer.
         const unlabelled =
-          textual || !(opts.verify || opts.includeUnlabelled)
+          textual || !(verify || opts.includeUnlabelled)
             ? undefined
             : readUnlabelledBlockManifest(full);
         if (!textual && !unlabelled) continue; // not a block manifest at all
-        const manifest = opts.verify
-          ? verifiedManifest(full, textual, unlabelled, opts)
+        const manifest = verify
+          ? verifiedManifest(full, textual, unlabelled, report)
           : textualIdentity(textual, unlabelled);
         if (!manifest) continue;
         if (!manifest.labelled && !opts.includeUnlabelled) continue;
@@ -816,9 +831,6 @@ export function* walkBlocks(
   }
   yield* recurse(rootDir);
 }
-
-/** Files already reported as unloadable, so a walk warns once per file. */
-const warnedBlockLoads = new Set<string>();
 
 type TextualManifest = { kind: string; label: string };
 /**
@@ -853,7 +865,7 @@ function verifiedManifest(
   tsPath: string,
   textual: TextualManifest | undefined,
   unlabelled: TextualManifest | undefined,
-  opts: WalkBlocksOptions,
+  report: FailureReporter,
 ): VerifiedManifest | undefined {
   const degraded = () => textualIdentity(textual, unlabelled);
   try {
@@ -863,7 +875,7 @@ function verifiedManifest(
     // becomes a labelled block rather than being skipped or mistaken for prose.
     if (loaded) return { kind: loaded.kind, label: loaded.label, labelled: true };
   } catch (e) {
-    report(tsPath, String(e).replace(/\s+/g, " ").slice(0, 300), opts);
+    report(tsPath, String(e).replace(/\s+/g, " ").slice(0, 300));
     return degraded();
   }
   // The loader found no labelled block. When the source had no textual label
@@ -875,22 +887,53 @@ function verifiedManifest(
     tsPath,
     `default export is not a labelled block, but the source looks like a ` +
       `manifest (read textually as ${textual?.kind} ${textual?.label})`,
-    opts,
   );
   return degraded();
 }
 
-function report(file: string, error: string, opts: WalkBlocksOptions): void {
-  if (opts.onLoadFailure) {
-    opts.onLoadFailure({ file, error });
-    return;
-  }
-  if (warnedBlockLoads.has(file)) return;
-  warnedBlockLoads.add(file);
-  console.warn(
-    `  ⚠ ${file} could not be loaded; using its source text for kind/label.\n` +
-      `      ${error}`,
-  );
+/**
+ * How many unloadable files are named before the rest are only counted.
+ *
+ * When a folio is checked out without its `folio-assistant` symlink, *every*
+ * block fails for the same reason — measured: 3557 of 3557 on `qou`. Naming
+ * them one by one buries the single line that says what to fix under three and
+ * a half thousand that do not, so the enumeration stops and the tail is
+ * summarised.
+ */
+const MAX_NAMED_LOAD_FAILURES = 5;
+
+type FailureReporter = (file: string, error: string) => void;
+
+/**
+ * One reporter per walk, **not** one per process.
+ *
+ * A process runs several walks — `qa-sweep` calls `usesGraphHash` before its
+ * own — and a budget shared across them means the second walk's genuine
+ * failures are swallowed by the first walk's having spent it. Scoping the
+ * counter to the walk keeps each one's report complete on its own terms.
+ */
+function makeFailureReporter(opts: WalkBlocksOptions): FailureReporter {
+  const sink = opts.onLoadFailure;
+  if (sink) return (file, error) => sink({ file, error });
+  const seen = new Set<string>();
+  return (file, error) => {
+    if (seen.has(file)) return;
+    seen.add(file);
+    if (seen.size <= MAX_NAMED_LOAD_FAILURES) {
+      console.warn(
+        `  ⚠ ${file} could not be loaded; using its source text for kind/label.\n` +
+          `      ${error}`,
+      );
+    } else if (seen.size === MAX_NAMED_LOAD_FAILURES + 1) {
+      console.warn(
+        `  ⚠ …and more blocks that would not load. Every one is walked under its\n` +
+          `      source-text identity, so nothing is skipped — but none of them was\n` +
+          `      verified. If this is the whole corpus, the cause is usually a folio\n` +
+          `      checked out without its platform symlink (<folio>/folio-assistant).\n` +
+          `      Run: bun run content/pipeline/verify-block-walk.ts <content-root>`,
+      );
+    }
+  };
 }
 
 // ── QA report IO ────────────────────────────────────────────────

--- a/content/pipeline/qa-utils.ts
+++ b/content/pipeline/qa-utils.ts
@@ -33,6 +33,7 @@ import { BLOCK_KINDS } from "../../schemas/types";
 import { QA_CRITERIA_BY_ID } from "./qa-criteria-registry";
 import { leanStatementHash } from "./lean-signature";
 import { findContentRepoRoot } from "./repo-root";
+import { loadBlockModuleSync, type BlockLoadFailure } from "./block-module";
 
 // ── Hashing ─────────────────────────────────────────────────────
 
@@ -605,6 +606,26 @@ const BLOCK_BUILDER_RE = new RegExp(
  * manifest. Returns the block's kind + label, or `undefined` if the
  * file is not a single-block manifest (chapter, paper, etc.).
  *
+ * **This detects a candidate; it does not establish identity.** Reading a
+ * label out of source text is wrong in three demonstrated ways, pinned in
+ * `scripts/tests/block-walk-verify.test.ts`:
+ *
+ * | source                          | this reads        | the block *is*   |
+ * |---------------------------------|-------------------|------------------|
+ * | `label: LBL` (a constant)       | `undefined` — skipped | `prop:computed` |
+ * | an earlier `label:` in a helper | `not-the-block`   | `prop:real`      |
+ * | `proposition({label:"theorem:x"})` | `theorem:x`    | rejected by the schema |
+ *
+ * The middle row is the dangerous one: not a miss but a *wrong answer*, which
+ * keys a sidecar and a graph node to a label the block does not have.
+ * `walkBlocks(root, { verify: true })` settles identity by loading the module
+ * instead — see `loadBlockModuleSync`.
+ *
+ * What this stays authoritative for is **whether a file may be executed at
+ * all**. A content tree holds more than manifests, and importing runs them, so
+ * the masked regex below is the gate that decides what the loader is allowed to
+ * touch. Keep it cheap and keep it textual.
+ *
  * **Matched against a string- and comment-masked copy**, so a builder call or
  * a `label:` written inside a string literal or a comment cannot make an
  * ordinary source file look like a block manifest. Offsets are preserved by
@@ -684,6 +705,42 @@ export interface WalkBlocksOptions {
    * than inventing one.
    */
   includeUnlabelled?: boolean;
+
+  /**
+   * Settle each block's `kind` and `label` by **importing** it, instead of
+   * reading them out of its source text.
+   *
+   * The textual read is wrong in three ways `readBlockManifest` now documents,
+   * and the middle one returns a confidently wrong label rather than nothing.
+   * Importing runs the builder, so what comes back is the block the rest of the
+   * pipeline sees, validated against the schema.
+   *
+   * `readBlockManifest` still decides *which* files are candidates — importing
+   * executes a module, and a content tree holds scripts as well as manifests
+   * (`qa-agent-drain-queue.ts` starts a sweep at import time). Verification
+   * upgrades identity; it does not widen what gets executed.
+   *
+   * **Default `false`, deliberately.** Fourteen production tools consume this
+   * generator, and this repo has twice learned that changing what the walk
+   * enumerates must be measured against real content before it lands (`#125`
+   * admitted a non-block; `qou/3fui` missed 63 real ones, and the measurement
+   * reversed the recommendation). The corpus that would settle it lives in the
+   * content repo, not here. `bun run content/pipeline/verify-block-walk.ts
+   * <content-root>` runs both modes and diffs them; flip this default on that
+   * evidence, not on this comment.
+   */
+  verify?: boolean;
+
+  /**
+   * Where a block that fails to import is reported.
+   *
+   * A block that throws is a *finding*, not a file to pass over — that is how a
+   * sweep reports clean by looking at nothing. Omit this and failures go to
+   * stderr, once per file. Either way the block is still yielded, carrying its
+   * degraded textual identity: dropping it would trade a loud problem for a
+   * silent coverage hole, which is the `qou/3fui` mistake in reverse.
+   */
+  onLoadFailure?: (failure: BlockLoadFailure) => void;
 }
 
 export function* walkBlocks(
@@ -716,12 +773,22 @@ export function* walkBlocks(
       if (st.isDirectory()) {
         yield* recurse(full);
       } else if (entry.endsWith(".ts")) {
-        // Skip chapter / paper manifests by checking the export shape.
-        let manifest = readBlockManifest(full);
-        if (!manifest && opts.includeUnlabelled) {
-          manifest = readUnlabelledBlockManifest(full);
-        }
+        // Skip chapter / paper manifests by checking the export shape. The
+        // masked builder-call match is the gate on what may be *executed*
+        // below; the label is a question about identity, answered after.
+        const textual = readBlockManifest(full);
+        // Reading the unlabelled shape costs a second read + mask, so only pay
+        // it when someone can act on the answer.
+        const unlabelled =
+          textual || !(opts.verify || opts.includeUnlabelled)
+            ? undefined
+            : readUnlabelledBlockManifest(full);
+        if (!textual && !unlabelled) continue; // not a block manifest at all
+        const manifest = opts.verify
+          ? verifiedManifest(full, textual, unlabelled, opts)
+          : textualIdentity(textual, unlabelled);
         if (!manifest) continue;
+        if (!manifest.labelled && !opts.includeUnlabelled) continue;
         const root = full.slice(0, -3); // strip ".ts"
         const md = root + ".md";
         const lean = root + ".lean";
@@ -748,6 +815,82 @@ export function* walkBlocks(
     }
   }
   yield* recurse(rootDir);
+}
+
+/** Files already reported as unloadable, so a walk warns once per file. */
+const warnedBlockLoads = new Set<string>();
+
+type TextualManifest = { kind: string; label: string };
+/**
+ * `labelled` records whether the block has a real `label:` — which only the
+ * module can settle — as opposed to standing in under its slug. `walkBlocks`
+ * needs the distinction *after* verification, because a computed label makes a
+ * block labelled even though its source text does not say so.
+ */
+type VerifiedManifest = TextualManifest & { labelled: boolean };
+
+/** The reading `walkBlocks` has always used: whatever the source text says. */
+function textualIdentity(
+  textual: TextualManifest | undefined,
+  unlabelled: TextualManifest | undefined,
+): VerifiedManifest | undefined {
+  if (textual) return { ...textual, labelled: true };
+  if (unlabelled) return { ...unlabelled, labelled: false };
+  return undefined;
+}
+
+/**
+ * Replace a textually-read `{ kind, label }` with the one the module actually
+ * exports.
+ *
+ * On a throw the textual reading is kept and the failure reported: the block
+ * stays in the walk (so no criterion silently stops covering it) while the
+ * reason it could not be verified is visible. A `undefined` return from the
+ * loader means the default export is not a block after all — the candidate gate
+ * was fooled — which is likewise reported rather than silently dropped.
+ */
+function verifiedManifest(
+  tsPath: string,
+  textual: TextualManifest | undefined,
+  unlabelled: TextualManifest | undefined,
+  opts: WalkBlocksOptions,
+): VerifiedManifest | undefined {
+  const degraded = () => textualIdentity(textual, unlabelled);
+  try {
+    const loaded = loadBlockModuleSync(tsPath);
+    // A label the module actually carries. This is the only reading that can
+    // be trusted, and it is how a computed `label:` — invisible to the regex —
+    // becomes a labelled block rather than being skipped or mistaken for prose.
+    if (loaded) return { kind: loaded.kind, label: loaded.label, labelled: true };
+  } catch (e) {
+    report(tsPath, String(e).replace(/\s+/g, " ").slice(0, 300), opts);
+    return degraded();
+  }
+  // The loader found no labelled block. When the source had no textual label
+  // either, that agrees with `prose()` connective tissue and its slug identity
+  // stands. When the source *did* carry a label, the candidate gate was fooled
+  // by a file whose default export is not a block — a finding.
+  if (unlabelled) return { ...unlabelled, labelled: false };
+  report(
+    tsPath,
+    `default export is not a labelled block, but the source looks like a ` +
+      `manifest (read textually as ${textual?.kind} ${textual?.label})`,
+    opts,
+  );
+  return degraded();
+}
+
+function report(file: string, error: string, opts: WalkBlocksOptions): void {
+  if (opts.onLoadFailure) {
+    opts.onLoadFailure({ file, error });
+    return;
+  }
+  if (warnedBlockLoads.has(file)) return;
+  warnedBlockLoads.add(file);
+  console.warn(
+    `  ⚠ ${file} could not be loaded; using its source text for kind/label.\n` +
+      `      ${error}`,
+  );
 }
 
 // ── QA report IO ────────────────────────────────────────────────

--- a/content/pipeline/verify-block-walk.ts
+++ b/content/pipeline/verify-block-walk.ts
@@ -2,24 +2,29 @@
  * Diff the two ways `walkBlocks` can establish a block's identity, over a real
  * corpus.
  *
- * `walkBlocks` reads each block's `kind` and `label` out of its source text.
- * With `{ verify: true }` it imports the module instead and uses what the
- * builder validated. The textual read is wrong in three demonstrated ways —
+ * `walkBlocks` establishes each block's `kind` and `label` by importing it.
+ * With `{ verify: false }` it reads them out of the source text instead, the
+ * way it did before. The textual read is wrong in three demonstrated ways —
  * see `scripts/tests/block-walk-verify.test.ts` — but *how often* it is wrong
- * on real content is a question about the content, not about the code, and the
- * corpora live in folio repositories rather than here.
+ * on a given corpus is a question about the content, not about the code, and
+ * the corpora live in folio repositories rather than here.
  *
- * So this exists to answer it in one command, before the default is flipped:
+ * So this answers it in one command:
  *
  * ```sh
- * bun run content/pipeline/verify-block-walk.ts ../qou/content/qou
+ * bun run content/pipeline/verify-block-walk.ts ../qou/content/quantum-observable-universe
  * ```
  *
- * It prints every disagreement, every block that could not be imported, and
- * what the flip would cost in wall-clock. That is the evidence the decision
- * wants. This repo has twice learned the lesson the hard way: `#125` let a
- * non-block into the walk, `qou/3fui` kept 63 real ones out, and in the second
- * case the measurement *reversed* the recommendation the change was argued on.
+ * It prints every disagreement, every block only one mode finds, every block
+ * that will not import, and what verification costs in wall-clock. This repo
+ * has twice learned that lesson the hard way: `#125` let a non-block into the
+ * walk, `qou/3fui` kept 63 real ones out, and in the second case the
+ * measurement *reversed* the recommendation the change was argued on.
+ *
+ * The default was flipped on this tool's output against `qou` — 3557 blocks,
+ * zero disagreements, zero load failures, 1475 ms against 450 ms. That is one
+ * corpus. **Run this against any other folio before trusting the default
+ * there**, and use `verify: false` if it disagrees.
  *
  * Exit code is 0 whatever it finds — this reports, it does not gate.
  *
@@ -45,19 +50,26 @@ if (!existsSync(rootAbs)) {
   process.exit(2);
 }
 
-/** Both modes include unlabelled prose, so the comparison covers what qa-sweep sees. */
-const OPTS = { includeUnlabelled: true } as const;
+/**
+ * Both modes include unlabelled prose, so the comparison covers what qa-sweep
+ * sees. `verify` is stated explicitly on **both** arms rather than left to the
+ * default: this tool exists to compare the two readings, so it must not start
+ * comparing a reading with itself the day the default moves — which is exactly
+ * what happened the first time the default flipped under it.
+ */
+const TEXTUAL = { includeUnlabelled: true, verify: false } as const;
+const VERIFIED = { includeUnlabelled: true, verify: true } as const;
 
 const byPath = (blocks: BlockPaths[]): Map<string, BlockPaths> =>
   new Map(blocks.map((b) => [b.ts, b]));
 
 const t0 = Bun.nanoseconds();
-const textual = byPath([...walkBlocks(rootAbs, OPTS)]);
+const textual = byPath([...walkBlocks(rootAbs, { ...TEXTUAL, onLoadFailure: () => {} })]);
 const t1 = Bun.nanoseconds();
 
 const failures: BlockLoadFailure[] = [];
 const verified = byPath([
-  ...walkBlocks(rootAbs, { ...OPTS, verify: true, onLoadFailure: (f) => failures.push(f) }),
+  ...walkBlocks(rootAbs, { ...VERIFIED, onLoadFailure: (f) => failures.push(f) }),
 ]);
 const t2 = Bun.nanoseconds();
 
@@ -107,9 +119,9 @@ const clean =
 
 console.log(
   clean
-    ? `\nThe two walks agree on every block. Flipping \`verify\` on by default ` +
-        `costs ${ms(t1, t2)} ms instead of ${ms(t0, t1)} ms and changes nothing else ` +
-        `about this corpus.\n`
+    ? `\nThe two walks agree on every block. Verifying costs ${ms(t1, t2)} ms ` +
+        `against the source-text reading's ${ms(t0, t1)} ms, and changes nothing ` +
+        `else about this corpus.\n`
     : `\nThe walks disagree. Each line above is a block some QA tool is currently ` +
         `keyed to the wrong identity for, missing entirely, or unable to load — ` +
         `read them before flipping the default.\n`,

--- a/content/pipeline/verify-block-walk.ts
+++ b/content/pipeline/verify-block-walk.ts
@@ -1,0 +1,116 @@
+/**
+ * Diff the two ways `walkBlocks` can establish a block's identity, over a real
+ * corpus.
+ *
+ * `walkBlocks` reads each block's `kind` and `label` out of its source text.
+ * With `{ verify: true }` it imports the module instead and uses what the
+ * builder validated. The textual read is wrong in three demonstrated ways —
+ * see `scripts/tests/block-walk-verify.test.ts` — but *how often* it is wrong
+ * on real content is a question about the content, not about the code, and the
+ * corpora live in folio repositories rather than here.
+ *
+ * So this exists to answer it in one command, before the default is flipped:
+ *
+ * ```sh
+ * bun run content/pipeline/verify-block-walk.ts ../qou/content/qou
+ * ```
+ *
+ * It prints every disagreement, every block that could not be imported, and
+ * what the flip would cost in wall-clock. That is the evidence the decision
+ * wants. This repo has twice learned the lesson the hard way: `#125` let a
+ * non-block into the walk, `qou/3fui` kept 63 real ones out, and in the second
+ * case the measurement *reversed* the recommendation the change was argued on.
+ *
+ * Exit code is 0 whatever it finds — this reports, it does not gate.
+ *
+ * @module content/pipeline/verify-block-walk
+ */
+
+import { resolve } from "path";
+import { existsSync } from "fs";
+import { walkBlocks, type BlockPaths } from "./qa-utils";
+import type { BlockLoadFailure } from "./block-module";
+
+const root = process.argv[2];
+if (!root) {
+  console.error(
+    "usage: bun run content/pipeline/verify-block-walk.ts <content-root>\n" +
+      "  e.g. bun run content/pipeline/verify-block-walk.ts ../qou/content/qou",
+  );
+  process.exit(2);
+}
+const rootAbs = resolve(root);
+if (!existsSync(rootAbs)) {
+  console.error(`No such directory: ${rootAbs}`);
+  process.exit(2);
+}
+
+/** Both modes include unlabelled prose, so the comparison covers what qa-sweep sees. */
+const OPTS = { includeUnlabelled: true } as const;
+
+const byPath = (blocks: BlockPaths[]): Map<string, BlockPaths> =>
+  new Map(blocks.map((b) => [b.ts, b]));
+
+const t0 = Bun.nanoseconds();
+const textual = byPath([...walkBlocks(rootAbs, OPTS)]);
+const t1 = Bun.nanoseconds();
+
+const failures: BlockLoadFailure[] = [];
+const verified = byPath([
+  ...walkBlocks(rootAbs, { ...OPTS, verify: true, onLoadFailure: (f) => failures.push(f) }),
+]);
+const t2 = Bun.nanoseconds();
+
+const ms = (a: number, b: number): string => ((b - a) / 1e6).toFixed(0);
+
+console.log(`\ncorpus: ${rootAbs}`);
+console.log(`  textual walk : ${textual.size} blocks in ${ms(t0, t1)} ms`);
+console.log(`  verified walk: ${verified.size} blocks in ${ms(t1, t2)} ms\n`);
+
+/** In the verified walk but not the textual one — a block nothing sweeps today. */
+const onlyVerified = [...verified.keys()].filter((p) => !textual.has(p));
+/** In the textual walk but not the verified one — would be lost by the flip. */
+const onlyTextual = [...textual.keys()].filter((p) => !verified.has(p));
+/** Present in both, but the identity differs. */
+const disagree = [...verified.entries()].flatMap(([path, v]) => {
+  const t = textual.get(path);
+  if (!t) return [];
+  if (t.label === v.label && t.kind === v.kind) return [];
+  return [{ path, textual: t, verified: v }];
+});
+
+const section = (title: string, n: number): void =>
+  console.log(`${n === 0 ? "  ✓" : "  ✗"} ${title}: ${n}`);
+
+section("blocks only the verified walk finds", onlyVerified.length);
+for (const p of onlyVerified) console.log(`        + ${verified.get(p)!.label}  ${p}`);
+
+section("blocks only the textual walk finds", onlyTextual.length);
+for (const p of onlyTextual) console.log(`        - ${textual.get(p)!.label}  ${p}`);
+
+section("blocks whose identity differs", disagree.length);
+for (const d of disagree) {
+  console.log(
+    `        ${d.textual.kind} ${d.textual.label}  ->  ${d.verified.kind} ${d.verified.label}\n` +
+      `          ${d.path}`,
+  );
+}
+
+section("blocks that would not import", failures.length);
+for (const f of failures) console.log(`        ${f.file}\n          ${f.error}`);
+
+const clean =
+  onlyVerified.length === 0 &&
+  onlyTextual.length === 0 &&
+  disagree.length === 0 &&
+  failures.length === 0;
+
+console.log(
+  clean
+    ? `\nThe two walks agree on every block. Flipping \`verify\` on by default ` +
+        `costs ${ms(t1, t2)} ms instead of ${ms(t0, t1)} ms and changes nothing else ` +
+        `about this corpus.\n`
+    : `\nThe walks disagree. Each line above is a block some QA tool is currently ` +
+        `keyed to the wrong identity for, missing entirely, or unable to load — ` +
+        `read them before flipping the default.\n`,
+);

--- a/scripts/tests/block-walk-verify.test.ts
+++ b/scripts/tests/block-walk-verify.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join, resolve } from "path";
+import { walkBlocks, readBlockManifest } from "../../content/pipeline/qa-utils";
+import { loadBlockModuleSync } from "../../content/pipeline/block-module";
+
+/**
+ * `walkBlocks` read every block's `kind` and `label` out of its source text
+ * with a regex, because it is a synchronous generator and could not `await` an
+ * import. `fsl7` filed that as "fine as is **unless a sync loader appears**".
+ *
+ * One appeared: Bun's `require` loads a TypeScript ES module synchronously, so
+ * `loadBlockModuleSync` returns the block the builder actually validated.
+ *
+ * These tests are the evidence for the repoint, not a description of it. Three
+ * fixtures show the textual read giving a different answer from the module —
+ * and one of them is a *wrong* answer, not a miss — and two more pin the thing
+ * that must not change: importing a module runs it, so verification must not
+ * widen which files get executed.
+ */
+
+const BUILDERS = JSON.stringify(resolve(import.meta.dir, "../../schemas/builders.ts"));
+
+let root: string;
+let ch: string;
+/** Written by a fixture at import time; its existence proves execution. */
+let sideEffect: string;
+
+const write = (name: string, src: string): string => {
+  const p = join(ch, name);
+  writeFileSync(p, src);
+  return p;
+};
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), "block-walk-verify-"));
+  ch = join(root, "chapter-one");
+  mkdirSync(ch, { recursive: true });
+  sideEffect = join(root, "EXECUTED");
+});
+
+afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+describe("loadBlockModuleSync", () => {
+  test("loads a block synchronously, with the fields the builder validated", () => {
+    const p = write(
+      "plain.ts",
+      `import { proposition } from ${BUILDERS};\n` +
+        `export default proposition({ label: "prop:plain", title: "T", ` +
+        `statement: "s", uses: ["def:a", "def:b"] });\n`,
+    );
+    const loaded = loadBlockModuleSync(p);
+    expect(loaded?.kind).toBe("proposition");
+    expect(loaded?.label).toBe("prop:plain");
+    expect(loaded?.uses).toEqual(["def:a", "def:b"]);
+  });
+
+  test("a module whose default export is not a block returns undefined", () => {
+    const p = write("not-a-block.ts", `export default { kind: "casserole", label: "x" };\n`);
+    expect(loadBlockModuleSync(p)).toBeUndefined();
+  });
+});
+
+describe("the textual read and the module disagree", () => {
+  const labels = (): string[] =>
+    [...walkBlocks(root, { verify: true, onLoadFailure: () => {} })]
+      .map((b) => b.label)
+      .sort();
+
+  test("a computed label is invisible to the regex and found by the loader", () => {
+    const p = write(
+      "computed-label.ts",
+      `import { proposition } from ${BUILDERS};\n` +
+        `const LBL = "prop:computed";\n` +
+        `export default proposition({ label: LBL, title: "T", statement: "s" });\n`,
+    );
+    // No string literal follows `label:`, so the regex finds nothing and the
+    // block is yielded by no QA tool at all.
+    expect(readBlockManifest(p)).toBeUndefined();
+    expect(loadBlockModuleSync(p)?.label).toBe("prop:computed");
+    expect(labels()).toContain("prop:computed");
+  });
+
+  test("an earlier `label:` makes the regex return the WRONG label", () => {
+    const p = write(
+      "label-not-first.ts",
+      `import { proposition } from ${BUILDERS};\n` +
+        `const meta = { label: "not-the-block" };\n` +
+        `export default proposition({ label: "prop:real", title: "T", ` +
+        `statement: "s", tags: [meta.label] });\n`,
+    );
+    // Not a miss — a confident wrong answer, which is what keys a sidecar and a
+    // graph node to a label the block does not have.
+    expect(readBlockManifest(p)?.label).toBe("not-the-block");
+    expect(loadBlockModuleSync(p)?.label).toBe("prop:real");
+
+    const seen = labels();
+    expect(seen).toContain("prop:real");
+    expect(seen).not.toContain("not-the-block");
+  });
+
+  test("a label the schema rejects is reported instead of being yielded as a node", () => {
+    const p = write(
+      "bad-prefix.ts",
+      `import { proposition } from ${BUILDERS};\n` +
+        `export default proposition({ label: "theorem:x", title: "T", statement: "s" });\n`,
+    );
+    // The regex is happy; the builder is not. Today that label becomes a graph
+    // node no edge can resolve.
+    expect(readBlockManifest(p)?.label).toBe("theorem:x");
+    expect(() => loadBlockModuleSync(p)).toThrow();
+
+    const failures: string[] = [];
+    const seen = [...walkBlocks(root, { verify: true, onLoadFailure: (f) => failures.push(f.file) })];
+
+    expect(failures).toContain(p);
+    // Reported, but still walked — dropping it would trade a loud problem for a
+    // silent coverage hole.
+    expect(seen.map((b) => b.ts)).toContain(p);
+    expect(seen.find((b) => b.ts === p)?.label).toBe("theorem:x");
+  });
+});
+
+describe("verification does not widen what gets executed", () => {
+  test("a .ts that is not a block manifest is never imported", () => {
+    write(
+      "helper-with-side-effect.ts",
+      `import { writeFileSync } from "fs";\n` +
+        `writeFileSync(${JSON.stringify(sideEffect)}, "ran");\n` +
+        `export const helper = () => 1;\n`,
+    );
+
+    expect(existsSync(sideEffect)).toBe(false);
+    const seen = [...walkBlocks(root, { verify: true, onLoadFailure: () => {} })];
+    expect(seen.map((b) => b.ts)).not.toContain(join(ch, "helper-with-side-effect.ts"));
+    expect(existsSync(sideEffect)).toBe(false);
+  });
+
+  test("the #125 shape — a builder inside a template literal — is not imported", () => {
+    const marker = join(root, "EXECUTED-125");
+    writeFileSync(
+      join(ch, "audit-script.ts"),
+      `import { writeFileSync } from "fs";\n` +
+        `writeFileSync(${JSON.stringify(marker)}, "ran");\n` +
+        "const ok = parse(`export default proposition({ label: \"prop:x\" });`);\n" +
+        `export default ok;\n`,
+    );
+
+    const seen = [...walkBlocks(root, { verify: true, onLoadFailure: () => {} })];
+    expect(existsSync(marker)).toBe(false);
+    expect(seen.map((b) => b.label)).not.toContain("prop:x");
+  });
+});
+
+describe("the default is unchanged", () => {
+  test("without `verify` the walk still reads identity from source text", () => {
+    // Same corpus, no verification: the wrong label is back and the computed
+    // one is missing again. This is what fourteen callers see today, and it
+    // must not move until the flip is measured against real content.
+    const seen = [...walkBlocks(root)].map((b) => b.label);
+    expect(seen).toContain("not-the-block");
+    expect(seen).not.toContain("prop:computed");
+  });
+});

--- a/scripts/tests/block-walk-verify.test.ts
+++ b/scripts/tests/block-walk-verify.test.ts
@@ -153,12 +153,20 @@ describe("verification does not widen what gets executed", () => {
   });
 });
 
-describe("the default is unchanged", () => {
-  test("without `verify` the walk still reads identity from source text", () => {
-    // Same corpus, no verification: the wrong label is back and the computed
-    // one is missing again. This is what fourteen callers see today, and it
-    // must not move until the flip is measured against real content.
-    const seen = [...walkBlocks(root)].map((b) => b.label);
+describe("verification is the default, and `verify: false` is the escape hatch", () => {
+  test("the default verifies", () => {
+    const seen = [...walkBlocks(root, { onLoadFailure: () => {} })].map((b) => b.label);
+    expect(seen).toContain("prop:real");
+    expect(seen).toContain("prop:computed");
+    expect(seen).not.toContain("not-the-block");
+  });
+
+  test("`verify: false` restores the source-text reading", () => {
+    // The wrong label is back and the computed one is missing again. Pinned so
+    // the escape hatch is known to actually bypass the loader — a folio without
+    // its platform symlink, or a corpus that has not been diffed with
+    // `verify-block-walk.ts`, needs a way back.
+    const seen = [...walkBlocks(root, { verify: false })].map((b) => b.label);
     expect(seen).toContain("not-the-block");
     expect(seen).not.toContain("prop:computed");
   });


### PR DESCRIPTION
Closes bean `fsl7`, which had been open since 2026-08-08 waiting on one thing: *"a sync loader, which bullet 1 already names. Still absent."*

`walkBlocks` — the enumeration every QA tool runs on — read each block's `kind` and `label` out of its source text with a regex. It did that because it is a **synchronous** generator with fourteen production callers and could not `await` an import.

## The loader exists

Bun's `require` loads a TypeScript ES module synchronously, so `loadBlockModuleSync` returns the block the builder actually validated, with no promise to await. Measured over 300 manifests plus 10 helpers, cold: **0.216 ms/file** against the regex's 0.052 — consistent with the async loader's measured 0.66 ms/block.

## The textual read is wrong in three ways

Demonstrated, not asserted — pinned in `scripts/tests/block-walk-verify.test.ts`:

| source | regex reads | the block *is* |
|---|---|---|
| `label: LBL` (a constant) | `undefined` → yielded to no QA tool at all | `prop:computed` |
| an earlier `label:` in a helper object | `not-the-block` | `prop:real` |
| `proposition({ label: "theorem:x" })` | `theorem:x` | rejected by the schema |

Row 2 is the sharp one: not a miss but a **confident wrong answer**, producing a graph node no edge can resolve. Same shape as the `root`-is-a-stem bug that reported "0 siblings across 3486 blocks" and looked plausible enough to nearly publish.

## Identity comes from the module; candidacy stays textual

That split is load-bearing. Importing a module runs it, and a content tree holds scripts as well as manifests — `content/pipeline/qa-agent-drain-queue.ts` in this repo starts a sweep at import time. So `readBlockManifest`'s masked builder-call match now decides **what may be executed**, and the loader decides **what it is**. Two tests pin the gate: a helper with a top-level side effect is never imported, and neither is the `#125` shape (a builder call inside a template literal).

## Measured against real content before the default moved

This repo has twice learned that changing what the walk enumerates must be measured first — `#125` admitted a non-block, `qou/3fui` missed 63 real ones and the measurement *reversed* the recommendation. `verify-block-walk.ts` was written first and run against the `qou` corpus:

```
QA mode (includeUnlabelled)  textual  3557 blocks /  450 ms
                             verified 3557 blocks / 1475 ms
graph mode (default)         3494 both ways, identical (kind, label, ts) triples

blocks only the verified walk finds  0
blocks only the textual walk finds   0
blocks whose identity differs        0
blocks that would not import         0
```

On `qou` the flip is a **no-op plus one second**. Its value is that the three failure classes become impossible rather than merely absent-so-far. `verify` defaults to `true`; `verify: false` is the escape hatch, and this covers **one** corpus — run the same command against any other folio first.

## Three defects the real-corpus run surfaced

- **A folio needs its platform symlink.** `qou/content/schema/builders.ts` re-exports through `<folio>/folio-assistant`, created by qou's setup script. Without it all 3557 blocks fail to load — the walk still yields every one under its textual identity, which is the fallback working, but the first run printed 3557 warning lines and buried the one line saying what to fix. Now five named files plus a summary naming the likely cause.
- **The warning budget was process-global**, so a second walk in the same process (`qa-sweep` calls `usesGraphHash` before its own) would have had its genuine failures silently swallowed by the first walk having spent it. Scoped per walk.
- **Flipping the default broke `verify-block-walk` itself** — both arms relied on the default, so it began comparing the verified reading with itself. Both arms now state `verify` explicitly, with a note saying why.

A block that fails to import is reported and **still yielded**, carrying its degraded textual identity. Dropping it would trade a loud problem for a silent coverage hole — `qou/3fui` in reverse.

## Verification

Run on `ff6e30a`, branch a clean fast-forward over `origin/main`:

| Gate | Result |
|---|---|
| `bun test` | 717 pass, 51 skip, 0 fail (9 new) |
| `eslint .` | clean |
| `tsc --noEmit` | clean |
| `scripts/validate-skills.ts` | 43 validated, 0 errors |
| `gen-schema-docs` + `gen-skill-docs` | no uncommitted diff |
| `render:bpmn:check` | all 6 SVGs up to date |
| real-corpus diff (`qou`, 3557 blocks) | 0 disagreements, 0 load failures |

No repo CI workflow matches the paths this PR touches, so none was dispatched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014NdiZHmmgCNZLTejVLYT5K

---
_Generated by [Claude Code](https://claude.ai/code/session_014NdiZHmmgCNZLTejVLYT5K)_