### PR TITLE
feat(ci): make a red workflow visible — at session start, on a schedule, and at the front door

### DIFF
--- a/.beans/folio-assistant-lq7e--a-red-verdict-against-a-workflow-file-that-has-sin.md
+++ b/.beans/folio-assistant-lq7e--a-red-verdict-against-a-workflow-file-that-has-sin.md
@@ -1,0 +1,77 @@
+---
+# folio-assistant-lq7e
+title: A red verdict against a workflow file that has since changed is reported as a live fire
+status: completed
+type: task
+priority: normal
+created_at: 2026-08-26T17:45:00Z
+updated_at: 2026-08-26T17:48:40Z
+---
+
+Claimed on claude/publication-workflow-diagrams-4uw90m (PR #139).
+
+## The diagnosis that produced this
+
+Item 2 of the session: are `witness-refresh.yml` and `qa-sweep.yml` — both red
+on `main` since 2026-08-07T15:04 — actually broken?
+
+**They are fixed, and confirming it cost no Actions minutes.** The evidence:
+
+- All four failing runs (two per workflow, within 2s of each other) were
+  `push` events on `main`, named by PATH rather than by `name:`. Both files
+  declare `on: workflow_dispatch` only. A dispatch-only workflow cannot fire
+  on push — unless GitHub could not parse the file and so never read the
+  `on:` block. That is the startup-failure signature.
+- `witness-refresh.yml` carries the post-mortem in its own comments: a commit
+  message block scalar whose body reached column 0, ending the scalar so YAML
+  read the prose as a mapping key.
+- Both files were last changed in c1f3415 (2026-08-08T18:57), the day after.
+- **75 pushes to `main` since that commit produced ZERO runs of either
+  workflow.** A parseable dispatch-only workflow does not fire on push. Absence
+  of runs is the proof of the fix.
+- Both parse under `yaml.safe_load` locally, `on: [workflow_dispatch]`.
+
+## The defect this bean is for
+
+Neither will ever go green. They only run on dispatch; the report only reads
+`main`; so their last verdict on `main` is a failure from a version of the file
+that no longer exists, and it will sit red forever.
+
+Worse, dispatching them cannot clear it either: both fail BY DESIGN in this
+repo. `qa-sweep` preflights on `content/package.json` and exits 1 ('the
+platform carries no folio'); `witness-refresh` cd's into
+`folio-assistant/computations`, which does not exist here.
+
+So the report ships with two permanent false fires — which erodes exactly the
+attention it exists to protect. That is xom7's own failure mode one level up,
+and it is in code that has not merged yet.
+
+## Fix
+
+Same family as the `workflowExists` predicate already there (a DELETED
+workflow's runs are history, not a live problem). Add the sibling rule: a red
+whose newest run PREDATES the last change to its workflow file is a verdict
+about a version that is gone. Report it as `superseded` — its own state, ranked
+below red, never rendered as green, and not counted as a live failure by the
+exit code. The file's change date comes from `git log -1 --format=%cI`, which is
+local, free, and exact — evidence rather than the age heuristic it replaces.
+
+
+
+## Done
+
+`assess()` gained `workflowChangedAt`, wired in `check-ci-health.ts` to
+`git log -1 --format=%cI origin/<branch> -- <path>` (local, free, exact). A red
+whose newest run predates that date becomes `superseded`: its own Health state,
+sorted below red, rendered '❔ … stale, not green', and not counted by the exit
+code as a live failure.
+
+Eight tests pin it, and four pin the ways it must NOT fire: no predicate, git
+answering undefined (shallow clone), a run with no path, and a GREEN workflow
+whose file changed. The rule may only ever DEMOTE a red — a later edit is
+evidence the failing version is gone, never evidence the new one works.
+
+Also fixed the render's 'every workflow with a recent run is green' line, which
+would have been a lie with a superseded entry present.
+
+Live: both workflows now read ❔ instead of ❌; `check:ci-health` exits 0.

--- a/.beans/folio-assistant-xom7--workflow-failure-is-invisible-docs-site-failed-30.md
+++ b/.beans/folio-assistant-xom7--workflow-failure-is-invisible-docs-site-failed-30.md
@@ -1,0 +1,87 @@
+---
+# folio-assistant-xom7
+title: 'Workflow failure is invisible: docs-site failed 30 runs over two months unnoticed'
+status: completed
+type: bug
+priority: normal
+created_at: 2026-08-26T17:14:46Z
+updated_at: 2026-08-26T17:21:43Z
+---
+
+Complement to 5rfy, not a duplicate. That bean fixed workflows that never FIRE
+and added workflow-triggers.test.ts to keep headers honest about their on:
+block. This is the opposite defect: docs-site.yml fired on every push to main,
+failed all 30 times between 2026-06-29 and 2026-08-26, and nothing surfaced it.
+The published site sat two months stale and the BPMN diagrams merged in #135
+never reached it.
+
+The trigger was fine. The OUTCOME was invisible. A green trigger and a red
+result look identical from inside the repo, and GitHub's failure email is a
+channel that evidently is not read.
+
+The fix has to put the signal where attention already goes. This repo already
+has one such place: the session-start surface every agent and human sees.
+
+## Todo
+
+- [x] A script that reports each workflow's health on the default branch:
+      last conclusion, consecutive failures, days since last success
+- [x] Degrade honestly with no network or no token — "could not check" must not
+      read as "healthy"
+- [x] Surface it in scripts/session-start-coord-sweep.sh, where beans already are
+- [x] Tests for the classification logic, against fixtures (the API call itself
+      is not the part that can be wrong quietly)
+
+## Summary of Changes
+
+`src/workflow/ci-health.ts` classifies each workflow's recent history on the
+default branch; `scripts/check-ci-health.ts` fetches it in **one** API call
+(`/actions/runs?branch=<default>&per_page=100` — fanning out per workflow would
+exhaust the unauthenticated 60/hr limit and make it useless at session start);
+`scripts/session-start-coord-sweep.sh` prints it beside the beans.
+
+Two rules the report follows, both pinned by tests:
+
+- **"Could not check" is never green.** An unreachable API renders as UNKNOWN,
+  as loudly as a failure. A health check that goes quiet when it cannot see is
+  worse than none, because it reads as reassurance — the same defect one level
+  up from the one this bean is about.
+- **Age separates a fire from a scorch mark.** A red that has not re-run in a
+  week is flagged "may be stale" rather than as an active failure. Without this
+  the report cries wolf, and a report that cries wolf earns exactly the
+  inattention that let `docs-site` rot for two months.
+
+Also: runs of a **deleted** workflow are filtered out (they are history, not a
+problem), but only when the caller supplies a `workflowExists` predicate —
+not knowing which files exist must not silently drop real failures.
+
+## What it found on its first run
+
+Immediately, without being asked:
+
+- ✓ **Docs site — green.** First success since 2026-06-29, confirming the
+  permissions fix.
+- ✗ `.github/workflows/paper-builder-image.yml` — 2 failures, but the file was
+  **deleted** from the tree. Filtered as history; this is what motivated the
+  predicate.
+- ✗ `witness-refresh.yml` and `qa-sweep.yml` — 2 failures each, both at the same
+  instant on 2026-08-07 (one batch, not two independent breaks), both named by
+  path rather than by `name:`, which is what GitHub does when a workflow fails
+  to **parse**. Both files parse as YAML today and both were modified the next
+  day (c1f3415), so these are very likely already fixed and simply have not
+  re-run. That is exactly the case the staleness flag exists to describe, and
+  it is why I did not "fix" them.
+
+## Deliberately not done
+
+Diagnosing `witness-refresh` and `qa-sweep`. This bean is about visibility, and
+they now *are* visible, correctly characterised as 18-day-old and possibly
+stale. Confirming whether they are fixed means dispatching them, which is an
+Actions run and the owner's call. Worth a follow-up bean if they matter.
+
+## The limit worth stating
+
+This reports; it does not notify. A reader who never starts a session never sees
+it. That is a real gap, and closing it means a scheduled job — which costs
+Actions minutes the owner is deliberately avoiding. The session-start surface
+was chosen because it is free and lands where attention already goes.

--- a/.beans/folio-assistant-ynu8--ci-health-is-reported-only-at-session-start-so-a-r.md
+++ b/.beans/folio-assistant-ynu8--ci-health-is-reported-only-at-session-start-so-a-r.md
@@ -1,0 +1,62 @@
+---
+# folio-assistant-ynu8
+title: CI health is reported only at session start, so a reader who never starts a session never sees a red
+status: completed
+type: task
+priority: normal
+created_at: 2026-08-26T18:03:23Z
+updated_at: 2026-08-26T18:09:32Z
+---
+
+Worked on claude/publication-workflow-diagrams-4uw90m (PR #139).
+
+## The premise I had been repeating was wrong
+
+I twice told the user this cost Actions minutes they were avoiding. The repo is
+PUBLIC, and standard GitHub-hosted runners are free for public repositories. I
+should have checked that before repeating it rather than after.
+
+## Summary of Changes
+
+The gap: `xom7` made CI health visible at session start, but the failure mode it
+guards against is a quiet stretch with nobody looking — which is exactly the
+stretch in which no session starts.
+
+- `.github/workflows/ci-health.yml` — weekly (`17 9 * * 1`) + dispatch. Runs the
+  same checker and maintains ONE issue labelled `ci-health`: opened on a live
+  failure, EDITED in place while it persists (an edit does not notify, so a long
+  outage stays one unread item), closed automatically when main is clean.
+  Deliberately not another email — GitHub sent 30 and nobody read them.
+  Weekly, not daily: the defect is 'nobody noticed for two months', and the
+  sweep already covers every day somebody is working.
+- `--out <file>` on `check-ci-health.ts` — the report AND a real exit code from
+  ONE API call. It could not reuse `--markdown`, which always exits 0 on
+  purpose: `session-start-coord-sweep.sh` runs it as `if ! … --markdown; then`
+  and would print the report AND 'Not checked' on every red.
+- Three live README badges — same state at the front door, for the three
+  workflows that actually run on main. Badging a dispatch-only one would report
+  its last dispatch forever (lq7e).
+- `scripts/tests/check-ci-health-cli.test.ts` — 7 tests pinning the exit-code
+  contract, offline (a git repo with no origin drives the unreachable branch).
+
+## Two things that are load-bearing, not incidental
+
+`fetch-depth: 0`: the superseded rule asks git when a workflow file last
+changed, a shallow clone cannot answer, and the false fires lq7e retired would
+come straight back.
+
+On 'could not check' the issue is left UNTOUCHED and the job fails. Closing it
+would make going blind read as good news. A red ci-health.yml is itself reported
+by next week's run — the watchdog is watched by the watchdog.
+
+## Found by the repo's own guards
+
+The 5rfy trigger-consistency test (`scripts/tests/workflow-triggers.test.ts`)
+rejected my header: prose describing docs-site's push trigger read as a claim
+about this workflow's own. Rephrased rather than disclaimed — its triggers are
+exactly what it says.
+
+Adversarial re-read caught two more before pushing: bun exits 1 on an uncaught
+exception too, so exit 1 alone would misread a CRASH as 'red' and open an issue
+from an absent report (now gated on the report file being non-empty); and both
+issue paths filter by the label, so the clean path needed it ensured too.

--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -1,0 +1,164 @@
+# CI health watchdog — the backstop for the report nobody is in the room to read.
+#
+# `docs-site.yml` was triggered by all 30 `main` pushes between 2026-06-29 and
+# 2026-08-26, and failed every one. Bean `xom7` fixed the *visibility* half:
+# `scripts/check-ci-health.ts` classifies every workflow's state on the default
+# branch, and `session-start-coord-sweep.sh` prints it where agent attention
+# already goes.
+#
+# That leaves the half this workflow is for. A report printed at session start
+# is only ever seen by someone who starts a session. The failure mode being
+# guarded against is precisely a quiet stretch with nobody looking — which is
+# the stretch in which no session starts either. Bean `ynu8`.
+#
+# Why not just GitHub's own failure email: it sent 30 of them, and the whole
+# premise of `xom7` is that it is a channel nobody reads. So this does not add
+# another. It maintains ONE tracking issue, which shows in the repo's open-issue
+# count on the front page, and closes it when `main` is clean again.
+#
+# Cost: this repository is PUBLIC, so standard GitHub-hosted runners are free.
+# One ~40s job a week.
+
+name: CI health watchdog
+
+on:
+  # Weekly, not daily. The defect is "nobody noticed for two months", not
+  # "nobody noticed for a day", and the session-start sweep already covers every
+  # day somebody is actually working. A weekly backstop bounds the blind spot to
+  # seven days without turning the tracking issue into a feed.
+  schedule:
+    - cron: '17 9 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: ci-health
+  cancel-in-progress: false
+
+jobs:
+  report:
+    name: Report CI health on the default branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # REQUIRED, and not an optimisation to shave off. The `superseded`
+          # rule asks `git log -1 --format=%cI -- <workflow file>` to find out
+          # whether a red verdict predates a change to the file that produced
+          # it. A shallow clone cannot answer, `workflowChangedAt` returns
+          # undefined, and the check correctly leaves the failure reported —
+          # which would resurrect the two permanent false fires that rule exists
+          # to retire (`witness-refresh.yml`, `qa-sweep.yml`; bean `lq7e`).
+          # The whole history is 3.8 MiB.
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Check CI health
+        id: check
+        run: |
+          set +e
+          bun run scripts/check-ci-health.ts --out "$RUNNER_TEMP/ci-health.md"
+          status=$?
+          set -e
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          # 0 = clean, 1 = live failure(s), 2 = could not check. Anything else
+          # is a crash in the checker, and is treated as "could not check".
+          # bun exits 1 on an uncaught exception too, so exit 1 alone does not
+          # distinguish "found live failures" from "crashed". The report file is
+          # what separates them: `--out` writes it before any exit path, so a
+          # red always has one and a crash before that point does not. Without
+          # this, a crash would open a tracking issue quoting a stale file.
+          report="$RUNNER_TEMP/ci-health.md"
+          if [ "$status" = "1" ] && [ ! -s "$report" ]; then
+            echo "::warning::checker exited 1 without writing a report — treating as unchecked"
+            status=2
+          fi
+          case "$status" in
+            0) echo "verdict=clean" >> "$GITHUB_OUTPUT" ;;
+            1) echo "verdict=red" >> "$GITHUB_OUTPUT" ;;
+            *) echo "verdict=unknown" >> "$GITHUB_OUTPUT" ;;
+          esac
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Ensured for BOTH issue paths, not just the one that creates. The clean
+      # path filters `gh issue list --label ci-health` too, and on a repo where
+      # nothing has ever gone red that label would not otherwise exist yet.
+      # Skipped on `unknown`, where neither path runs and a label hiccup must
+      # not be what fails the job.
+      - name: Ensure the tracking label exists
+        if: steps.check.outputs.verdict != 'unknown'
+        run: gh label create ci-health --color B60205 --description "Automated CI health watchdog" --force
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Open or update the tracking issue
+        if: steps.check.outputs.verdict == 'red'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          {
+            cat "$RUNNER_TEMP/ci-health.md"
+            echo
+            echo "---"
+            echo
+            echo "Maintained by [\`ci-health.yml\`]($RUN_URL). This issue is edited in place"
+            echo "each week and closed automatically once \`main\` is clean, so its body is"
+            echo "always the current state rather than a log. Bean \`ynu8\`."
+          } > "$RUNNER_TEMP/issue-body.md"
+
+          existing=$(gh issue list --label ci-health --state open \
+            --json number --jq '.[0].number // empty')
+
+          if [ -n "$existing" ]; then
+            # Edit rather than comment: an edit does not notify, so a failure
+            # that persists for weeks stays one unread-count of one.
+            gh issue edit "$existing" --body-file "$RUNNER_TEMP/issue-body.md"
+            echo "updated issue #$existing"
+          else
+            gh issue create \
+              --title "CI is red on the default branch" \
+              --label ci-health \
+              --body-file "$RUNNER_TEMP/issue-body.md"
+          fi
+
+      - name: Close the tracking issue when main is clean
+        if: steps.check.outputs.verdict == 'clean'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          existing=$(gh issue list --label ci-health --state open \
+            --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue close "$existing" \
+              --comment "Every workflow with a recent run on the default branch is green again. Closed by \`ci-health.yml\`."
+            echo "closed issue #$existing"
+          else
+            echo "clean, and no tracking issue open — nothing to do."
+          fi
+
+      # "Could not check" is not "healthy". The checker refuses to render an
+      # unreachable API as green, and so does this: the tracking issue is left
+      # exactly as it is — NEVER closed — and the job fails, which makes this
+      # workflow itself red on `main`, which next week's run will report. The
+      # watchdog is watched by the watchdog.
+      - name: Refuse to report success on an unchecked repo
+        if: steps.check.outputs.verdict == 'unknown'
+        run: |
+          echo "::error::CI health could not be determined (exit ${{ steps.check.outputs.status }})."
+          echo "::error::Treat this as unknown, not as green. The tracking issue was left untouched."
+          exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,26 @@ only reads the default branch, so nothing will ever run them here again. Bean
 `qa-sweep` preflights on `content/package.json` and `witness-refresh` needs
 `folio-assistant/computations/`, and the platform carries no folio.
 
+**A report is only read by someone in the room.** The session-start sweep covers
+every day somebody is working; the failure being guarded against is a quiet
+stretch with nobody looking, which is exactly the stretch in which no session
+starts either. So `.github/workflows/ci-health.yml` runs the same check weekly
+and maintains **one** tracking issue labelled `ci-health` — opened when the
+default branch has a live failure, edited in place while it persists (an edit
+does not notify, so a long outage stays one unread item), and closed
+automatically when `main` is clean. It deliberately does not send another
+email: GitHub sent 30 and the premise of `xom7` is that nobody reads them. The
+three live badges at the top of `README.md` are the same state at the front
+door. Bean `ynu8`.
+
+Two things about that workflow are load-bearing rather than incidental. It
+checks out with `fetch-depth: 0`, because the `superseded` rule asks `git log`
+when a workflow file last changed and a shallow clone cannot answer — which
+would resurrect the false fires it exists to retire. And on "could not check"
+(exit 2) it leaves the tracking issue **untouched** and fails the job, rather
+than closing it: the watchdog going blind must not read as good news, and a red
+`ci-health.yml` is itself reported by next week's run.
+
 Complements `5rfy`, which fixed workflows that never *fire*. This is the
 opposite defect — one that fires constantly and fails every time.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,9 +123,23 @@ site sat stale and nothing in the repo said so. Bean `xom7`.
 `bun run check:ci-health` reports each workflow's state on the default branch —
 consecutive failures, days since the last green, and whether it has run at all
 recently. The session-start sweep prints it, so it lands where you already look.
-Two rules it follows, and you should too when reading it: **"could not check" is
-never rendered as green**, and a red that has not re-run in a week is flagged as
-possibly stale rather than as an active fire.
+Three rules it follows, and you should too when reading it: **"could not check"
+is never rendered as green**; a red that has not re-run in a week is flagged as
+possibly stale rather than as an active fire; and a red whose **workflow file
+changed after the failing run** is reported as `superseded` — the version that
+failed is gone, so the verdict is stale. `superseded` is never rendered as green
+and never counted as a live failure, because a later edit is evidence the
+failing version is gone, not evidence the new one works.
+
+That third rule exists because two of this repo's workflows would otherwise be
+red forever. `witness-refresh.yml` and `qa-sweep.yml` failed to *parse* on
+2026-08-07 — which is why GitHub ran them on `push` despite both being
+`workflow_dispatch`-only, and why their runs are named by path rather than by
+`name:`. They were fixed the next day. They only run on dispatch and the report
+only reads the default branch, so nothing will ever run them here again. Bean
+`lq7e`. **Do not "fix" them by dispatching**: both fail by design in this repo —
+`qa-sweep` preflights on `content/package.json` and `witness-refresh` needs
+`folio-assistant/computations/`, and the platform carries no folio.
 
 Complements `5rfy`, which fixed workflows that never *fire*. This is the
 opposite defect — one that fires constantly and fails every time.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,22 @@ Full discipline: `.claude/skills/local/todo-manager.md` and
 > `todo-review` skill over `feedback/<paper>/*.ts`) — that is a separate domain
 > feature, not the agent work-plan.
 
+## CI health — a red workflow looks exactly like a green one from in here
+
+`docs-site.yml` fired on every push to `main` and **failed all 30 times** over
+two months. The trigger was fine; the *outcome* was invisible, so the published
+site sat stale and nothing in the repo said so. Bean `xom7`.
+
+`bun run check:ci-health` reports each workflow's state on the default branch —
+consecutive failures, days since the last green, and whether it has run at all
+recently. The session-start sweep prints it, so it lands where you already look.
+Two rules it follows, and you should too when reading it: **"could not check" is
+never rendered as green**, and a red that has not re-run in a week is flagged as
+possibly stale rather than as an active fire.
+
+Complements `5rfy`, which fixed workflows that never *fire*. This is the
+opposite defect — one that fires constantly and fails every time.
+
 ## At session start
 
 Surface the work-plan before starting: run `beans prime` (and `beans list`), or

--- a/README.md
+++ b/README.md
@@ -5,8 +5,20 @@ LLM — scientific papers & books, WHO SMART Guidelines, and FHIR Implementation
 Guides — backed by an MCP server, role-based access control, a typed
 content-object model, and a per-content-type skill system.
 
+[![Code-quality gates](https://github.com/litlfred/folio-assistant/actions/workflows/code-quality-gates.yml/badge.svg?branch=main)](https://github.com/litlfred/folio-assistant/actions/workflows/code-quality-gates.yml?query=branch%3Amain)
+[![Docs site](https://github.com/litlfred/folio-assistant/actions/workflows/docs-site.yml/badge.svg?branch=main)](https://github.com/litlfred/folio-assistant/actions/workflows/docs-site.yml?query=branch%3Amain)
+[![CI health](https://github.com/litlfred/folio-assistant/actions/workflows/ci-health.yml/badge.svg?branch=main)](https://github.com/litlfred/folio-assistant/actions/workflows/ci-health.yml?query=branch%3Amain)
 [![Docs](https://img.shields.io/badge/docs-github.io-blue)](https://litlfred.github.io/folio-assistant/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
+
+<!--
+The three live badges are the workflows that actually run on `main` — the only
+ones a badge can tell the truth about. A badge for a `workflow_dispatch`-only
+workflow reports its last dispatch forever, which is how `witness-refresh.yml`
+and `qa-sweep.yml` would read as red for all time (bean `lq7e`). If you add a
+workflow that auto-triggers on `main`, badge it here; if you add one that does
+not, do not.
+-->
 
 > **Platform, not content.** folio-assistant contains no content. It provides
 > the skills, schemas, and MCP server an LLM uses to plan, author, validate,

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "test:e2e": "playwright test",
     "test": "bun test",
     "lint": "eslint .",
+    "check:ci-health": "bun run scripts/check-ci-health.ts",
     "check:corpus-gate": "bun run scripts/check-corpus-gate.ts",
     "check:workflow-policy": "bun run scripts/check-workflow-policy.ts",
     "render:bpmn": "bun run scripts/render-bpmn.ts",

--- a/scripts/check-ci-health.ts
+++ b/scripts/check-ci-health.ts
@@ -103,8 +103,47 @@ const repoRoot = (() => {
   }
 })();
 
+/**
+ * When was this workflow file last changed on the default branch?
+ *
+ * A red verdict is about the file *as it ran*. If the file changed after that
+ * run, the failing version is gone — see `workflowChangedAt` in `ci-health.ts`.
+ * Asked against `origin/<branch>` rather than `HEAD`, because the runs being
+ * classified are the default branch's; a feature branch's edits have not
+ * reached them. Falls back to `HEAD` for a clone with no such remote ref.
+ *
+ * Returns `undefined` when git cannot answer — a shallow clone, a path git does
+ * not know. That leaves the failure reported, which is the safe direction: not
+ * knowing when a file changed must never explain a failure away.
+ */
+const changedAtCache = new Map<string, string | undefined>();
+function workflowChangedAt(path: string): string | undefined {
+  if (changedAtCache.has(path)) return changedAtCache.get(path);
+  let out: string | undefined;
+  for (const ref of [`origin/${branch}`, "HEAD"]) {
+    try {
+      const iso = execFileSync("git", ["log", "-1", "--format=%cI", ref, "--", path], {
+        encoding: "utf8",
+        cwd: repoRoot,
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+      if (iso) {
+        out = iso;
+        break;
+      }
+    } catch {
+      // Try the next ref; an unknown ref is not an answer of "never changed".
+    }
+  }
+  changedAtCache.set(path, out);
+  return out;
+}
+
 const health = runs
-  ? assess(runs, { workflowExists: (p) => existsSync(resolve(repoRoot, p)) })
+  ? assess(runs, {
+      workflowExists: (p) => existsSync(resolve(repoRoot, p)),
+      workflowChangedAt,
+    })
   : [];
 
 if (markdown) {
@@ -115,15 +154,18 @@ if (markdown) {
 } else {
   console.log(`CI health on \`${branch}\` (${runs!.length} recent runs)\n`);
   for (const h of health) {
-    const mark = h.health === "red" ? "✗" : h.health === "running" ? "…" : "✓";
+    const mark =
+      h.health === "red" ? "✗" : h.health === "running" ? "…" : h.health === "superseded" ? "❔" : "✓";
     const detail =
       h.health === "red"
         ? `${h.consecutiveFailures} consecutive failure(s), ` +
           (h.daysSinceSuccess === undefined
             ? "no success in window"
             : `last green ${h.daysSinceSuccess}d ago`)
-        : h.health;
-    console.log(`  ${mark} ${h.workflow.padEnd(32)} ${detail}`);
+        : h.health === "superseded"
+          ? `last failed ${h.daysSinceLastRun}d ago; file changed since — stale, not green`
+          : h.health;
+    console.log(`  ${mark} ${h.workflow.padEnd(40)} ${detail}`);
   }
 }
 

--- a/scripts/check-ci-health.ts
+++ b/scripts/check-ci-health.ts
@@ -1,0 +1,138 @@
+/**
+ * Report whether each workflow is actually passing on the default branch.
+ *
+ * ```sh
+ * bun run check:ci-health            # human-readable, exit 1 if anything is red
+ * bun run check:ci-health --markdown # the block the session-start sweep prints
+ * bun run check:ci-health --warn     # report only, never fail
+ * ```
+ *
+ * One API call. `GET /actions/runs?branch=<default>&per_page=100` returns the
+ * recent history across every workflow at once, so this does not fan out to
+ * one request per workflow — which would exhaust the unauthenticated rate
+ * limit (60/hr) and make it unusable at session start.
+ *
+ * `GITHUB_TOKEN` or `GH_TOKEN` is used when present. Without one the call still
+ * works for a public repo; for a private repo it fails, and this says so rather
+ * than reporting green.
+ *
+ * Why this exists: `docs-site.yml` failed 30 consecutive runs over two months
+ * and nothing surfaced it. See bean `xom7`.
+ */
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { assess, render, type RunSummary } from "../src/workflow/ci-health.js";
+
+const argv = process.argv.slice(2);
+const markdown = argv.includes("--markdown");
+const warn = argv.includes("--warn");
+
+function git(args: string[]): string {
+  return execFileSync("git", args, { encoding: "utf8" }).trim();
+}
+
+/** owner/repo from the origin remote — https or ssh. */
+function originSlug(): string | undefined {
+  let url: string;
+  try {
+    url = git(["remote", "get-url", "origin"]);
+  } catch {
+    return undefined;
+  }
+  const m = /github\.com[/:]([^/]+)\/(.+?)(?:\.git)?$/.exec(url);
+  return m ? `${m[1]}/${m[2]}` : undefined;
+}
+
+function defaultBranch(): string {
+  try {
+    // stdio: origin/HEAD is often unset in a fresh clone, and git's complaint
+    // about it is noise the reader should not have to triage.
+    return execFileSync("git", ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .trim()
+      .replace(/^origin\//, "");
+  } catch {
+    return "main";
+  }
+}
+
+const slug = originSlug();
+const branch = defaultBranch();
+
+async function fetchRuns(): Promise<{ runs?: RunSummary[]; unreachable?: string }> {
+  if (!slug) return { unreachable: "no GitHub `origin` remote to ask about." };
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  const url =
+    `https://api.github.com/repos/${slug}/actions/runs` +
+    `?branch=${encodeURIComponent(branch)}&per_page=100`;
+  try {
+    const res = await fetch(url, {
+      headers: {
+        accept: "application/vnd.github+json",
+        ...(token ? { authorization: `Bearer ${token}` } : {}),
+      },
+      signal: AbortSignal.timeout(20_000),
+    });
+    if (!res.ok) {
+      return {
+        unreachable:
+          `GitHub API returned ${res.status} for ${slug}` +
+          (res.status === 404 && !token
+            ? " — a private repo needs GITHUB_TOKEN or GH_TOKEN."
+            : res.status === 403
+              ? " — rate limited; set GITHUB_TOKEN to raise the limit."
+              : "."),
+      };
+    }
+    const body = (await res.json()) as { workflow_runs?: RunSummary[] };
+    return { runs: body.workflow_runs ?? [] };
+  } catch (e) {
+    return { unreachable: `could not reach the GitHub API: ${String(e).slice(0, 120)}` };
+  }
+}
+
+const { runs, unreachable } = await fetchRuns();
+const repoRoot = (() => {
+  try {
+    return git(["rev-parse", "--show-toplevel"]);
+  } catch {
+    return process.cwd();
+  }
+})();
+
+const health = runs
+  ? assess(runs, { workflowExists: (p) => existsSync(resolve(repoRoot, p)) })
+  : [];
+
+if (markdown) {
+  console.log(render(health, { unreachable, branch }));
+} else if (unreachable) {
+  console.error(`CI health: NOT CHECKED — ${unreachable}`);
+  console.error("Treat this as unknown, not as green.");
+} else {
+  console.log(`CI health on \`${branch}\` (${runs!.length} recent runs)\n`);
+  for (const h of health) {
+    const mark = h.health === "red" ? "✗" : h.health === "running" ? "…" : "✓";
+    const detail =
+      h.health === "red"
+        ? `${h.consecutiveFailures} consecutive failure(s), ` +
+          (h.daysSinceSuccess === undefined
+            ? "no success in window"
+            : `last green ${h.daysSinceSuccess}d ago`)
+        : h.health;
+    console.log(`  ${mark} ${h.workflow.padEnd(32)} ${detail}`);
+  }
+}
+
+const red = health.filter((h) => h.health === "red");
+if (warn || markdown) process.exit(0);
+// Unreachable is a failure of the check, not a pass. Exiting 0 here would make
+// "could not look" indistinguishable from "looked and it was fine".
+if (unreachable) process.exit(2);
+if (red.length > 0) {
+  console.error(`\n${red.length} workflow(s) failing on \`${branch}\`.`);
+  process.exit(1);
+}

--- a/scripts/check-ci-health.ts
+++ b/scripts/check-ci-health.ts
@@ -20,13 +20,35 @@
  * and nothing surfaced it. See bean `xom7`.
  */
 import { execFileSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { assess, render, type RunSummary } from "../src/workflow/ci-health.js";
 
 const argv = process.argv.slice(2);
 const markdown = argv.includes("--markdown");
 const warn = argv.includes("--warn");
+
+/**
+ * `--out <file>` writes the markdown report to a file **and keeps the exit
+ * code**. `--markdown` cannot do both: it always exits 0, deliberately, because
+ * `session-start-coord-sweep.sh` runs it as `if ! bun run … --markdown; then`
+ * and prints its "Not checked — treat as unknown" fallback on a non-zero exit.
+ * Make `--markdown` exit 1 on a red and the sweep would print the report AND
+ * declare it unchecked, every time CI is red.
+ *
+ * So the notifier gets its own flag rather than one API call being spent twice.
+ */
+const outIdx = argv.findIndex((a) => a === "--out" || a.startsWith("--out="));
+const outFile =
+  outIdx === -1
+    ? undefined
+    : argv[outIdx].startsWith("--out=")
+      ? argv[outIdx].slice("--out=".length)
+      : argv[outIdx + 1];
+if (outIdx !== -1 && !outFile) {
+  console.error("--out needs a file path");
+  process.exit(2);
+}
 
 function git(args: string[]): string {
   return execFileSync("git", args, { encoding: "utf8" }).trim();
@@ -145,6 +167,8 @@ const health = runs
       workflowChangedAt,
     })
   : [];
+
+if (outFile) writeFileSync(outFile, render(health, { unreachable, branch }));
 
 if (markdown) {
   console.log(render(health, { unreachable, branch }));

--- a/scripts/session-start-coord-sweep.sh
+++ b/scripts/session-start-coord-sweep.sh
@@ -117,6 +117,30 @@ else
   echo
 fi
 
+# ── 3-bis. CI health ────────────────────────────────────────────────────────
+#
+# docs-site.yml fired on every push to main and failed all 30 times over two
+# months; the published site sat stale and nothing in the repo said so (bean
+# xom7). A red workflow and a green one look identical from in here, so the
+# outcome has to be printed where attention already goes — which is this file.
+#
+# Best-effort and bounded: one API call, short timeout, and a failure to reach
+# the API prints as UNKNOWN rather than being omitted. An absent section reads
+# as "fine", which is the defect this is here to fix.
+if command -v bun >/dev/null 2>&1 && [ -f "$REPO_ROOT/scripts/check-ci-health.ts" ]; then
+  if ! timeout 25 bun run "$REPO_ROOT/scripts/check-ci-health.ts" --markdown 2>/dev/null; then
+    echo "## CI health"
+    echo
+    echo "**Not checked — treat as unknown, not as green.** The health check did not"
+    echo "complete (no network, no bun, or the API refused). Run it by hand:"
+    echo
+    echo '```sh'
+    echo "bun run check:ci-health"
+    echo '```'
+    echo
+  fi
+fi
+
 # ── 4. Recommended action (generic) ─────────────────────────────────────────
 cat <<'EOF'
 **Recommended action:**

--- a/scripts/tests/check-ci-health-cli.test.ts
+++ b/scripts/tests/check-ci-health-cli.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+/**
+ * Exit-code contract for `check-ci-health.ts`.
+ *
+ * Two callers depend on it and want opposite things, which is the entire reason
+ * `--out` exists as a separate flag from `--markdown`:
+ *
+ *   - `session-start-coord-sweep.sh` runs `--markdown` as
+ *     `if ! bun run … --markdown; then <print "Not checked — treat as unknown">`.
+ *     If `--markdown` ever exited non-zero on a red, the sweep would print the
+ *     report AND declare it unchecked, every single time CI was red.
+ *   - `ci-health.yml` needs the report body *and* a real verdict, and must
+ *     never close its tracking issue on a repo it could not check.
+ *
+ * These run against a git repo with no `origin`, which drives the checker into
+ * its `unreachable` branch without touching the network — so the tests are
+ * deterministic and offline. Bean `ynu8`.
+ */
+
+const SCRIPT = resolve(import.meta.dir, "../check-ci-health.ts");
+let repo: string;
+
+const run = (args: string[]): { code: number; stdout: string; stderr: string } => {
+  const r = Bun.spawnSync(["bun", "run", SCRIPT, ...args], { cwd: repo });
+  return {
+    code: r.exitCode,
+    stdout: new TextDecoder().decode(r.stdout),
+    stderr: new TextDecoder().decode(r.stderr),
+  };
+};
+
+beforeAll(() => {
+  repo = mkdtempSync(join(tmpdir(), "ci-health-cli-"));
+  // A git repo with no remote: `originSlug()` finds nothing to ask about.
+  execFileSync("git", ["init", "-q"], { cwd: repo });
+});
+afterAll(() => rmSync(repo, { recursive: true, force: true }));
+
+describe("the exit-code contract", () => {
+  test("a repo it cannot check exits 2 — not 0", () => {
+    // Exiting 0 here would make "could not look" indistinguishable from
+    // "looked and it was fine", which is the failure this module exists to
+    // prevent, one level up.
+    expect(run([]).code).toBe(2);
+  });
+
+  test("--markdown ALWAYS exits 0, even when it could not check", () => {
+    // Load-bearing for session-start-coord-sweep.sh — see the header.
+    expect(run(["--markdown"]).code).toBe(0);
+  });
+
+  test("--markdown prints the unknown report rather than nothing", () => {
+    const { stdout } = run(["--markdown"]);
+    expect(stdout).toContain("Not checked");
+    expect(stdout).toContain("treat as unknown, not as green");
+  });
+
+  test("--warn reports without failing", () => {
+    expect(run(["--warn"]).code).toBe(0);
+  });
+});
+
+describe("--out: the report AND the verdict, from one API call", () => {
+  test("writes the report and still exits 2 when it could not check", () => {
+    const out = join(repo, "report.md");
+    expect(run(["--out", out]).code).toBe(2);
+    expect(readFileSync(out, "utf8")).toContain("Not checked");
+  });
+
+  test("--out=<path> is accepted too", () => {
+    const out = join(repo, "report2.md");
+    expect(run([`--out=${out}`]).code).toBe(2);
+    expect(readFileSync(out, "utf8")).toContain("treat as unknown, not as green");
+  });
+
+  test("--out with no path is its own error, not the unreachable exit", () => {
+    // Both exit 2 in this fixture, so the code alone proves nothing — the
+    // message is what distinguishes a misused flag from a repo it could not
+    // reach, and a flag that silently wrote nowhere would be the worse bug.
+    const { code, stderr } = run(["--out"]);
+    expect(code).toBe(2);
+    expect(stderr).toContain("--out needs a file path");
+  });
+});

--- a/scripts/tests/ci-health.test.ts
+++ b/scripts/tests/ci-health.test.ts
@@ -187,3 +187,102 @@ describe("rendering, and the thing it must never do", () => {
     expect(out).not.toContain("green");
   });
 });
+
+describe("a verdict against a file that has since changed", () => {
+  /**
+   * `witness-refresh.yml` and `qa-sweep.yml` failed to parse, so GitHub could
+   * not read their `on:` block and ran them on `push` despite both being
+   * `workflow_dispatch`-only — the startup-failure signature, and why both runs
+   * are named by path rather than by `name:`. They were fixed the next day, and
+   * 75 pushes to `main` since produced no further run of either.
+   *
+   * Nothing will ever run them on the default branch again, so without this
+   * rule they stay red forever: two permanent false fires in a report whose
+   * whole value is that a red line means something. See bean `lq7e`.
+   */
+  const failedThenFixed = [
+    run({
+      name: ".github/workflows/qa-sweep.yml",
+      path: ".github/workflows/qa-sweep.yml",
+      conclusion: "failure",
+      created_at: "2026-08-07T15:04:09Z",
+    }),
+  ];
+  const fixedOn = (iso: string) => () => iso;
+
+  test("a red whose file changed after the failure is superseded, not red", () => {
+    const [h] = assess(failedThenFixed, {
+      now: NOW,
+      workflowChangedAt: fixedOn("2026-08-08T18:57:45Z"),
+    });
+    expect(h.health).toBe("superseded");
+    expect(h.supersededBy).toBe("2026-08-08T18:57:45Z");
+  });
+
+  test("a red whose file changed BEFORE the failure stays red", () => {
+    // The run tested the current version. Nothing about it is stale.
+    const [h] = assess(failedThenFixed, {
+      now: NOW,
+      workflowChangedAt: fixedOn("2026-08-01T00:00:00Z"),
+    });
+    expect(h.health).toBe("red");
+    expect(h.supersededBy).toBeUndefined();
+  });
+
+  test("without a workflowChangedAt predicate nothing is superseded", () => {
+    // Not knowing when a file changed must leave the failure reported. This is
+    // the same refusal as `workflowExists`: absence of evidence explains
+    // nothing away.
+    expect(assess(failedThenFixed, { now: NOW })[0].health).toBe("red");
+  });
+
+  test("git answering `undefined` — a shallow clone — leaves it red", () => {
+    const [h] = assess(failedThenFixed, { now: NOW, workflowChangedAt: () => undefined });
+    expect(h.health).toBe("red");
+  });
+
+  test("a GREEN workflow is never touched by the rule", () => {
+    // The rule may only ever demote a red. A later edit is evidence the failing
+    // version is gone — never evidence about a version that passed.
+    const [h] = assess(
+      [run({ name: "Code-quality gates", path: ".github/workflows/code-quality-gates.yml" })],
+      { now: NOW, workflowChangedAt: fixedOn("2026-08-26T11:59:00Z") },
+    );
+    expect(h.health).toBe("green");
+  });
+
+  test("a run with no path cannot be superseded", () => {
+    const [h] = assess([run({ name: "Nameless", conclusion: "failure" })], {
+      now: NOW,
+      workflowChangedAt: fixedOn("2026-08-26T11:59:00Z"),
+    });
+    expect(h.health).toBe("red");
+  });
+
+  test("superseded renders below the fold, and NEVER as green", () => {
+    const out = render(
+      assess(failedThenFixed, { now: NOW, workflowChangedAt: fixedOn("2026-08-08T18:57:45Z") }),
+      { branch: "main" },
+    );
+    expect(out).toContain("stale, not green");
+    expect(out).not.toContain("every workflow with a recent run");
+  });
+
+  test("a live red still sorts above a superseded one", () => {
+    const h = assess(
+      [
+        ...failedThenFixed,
+        run({
+          name: "Docs site",
+          path: ".github/workflows/docs-site.yml",
+          conclusion: "failure",
+          created_at: "2026-08-26T10:00:00Z",
+        }),
+      ],
+      { now: NOW, workflowChangedAt: fixedOn("2026-08-08T18:57:45Z") },
+    );
+    expect(h[0].workflow).toBe("Docs site");
+    expect(h[0].health).toBe("red");
+    expect(h.at(-1)!.health).toBe("superseded");
+  });
+});

--- a/scripts/tests/ci-health.test.ts
+++ b/scripts/tests/ci-health.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from "bun:test";
+import { assess, byWorkflow, classifyRuns, render, type RunSummary } from "../../src/workflow/ci-health";
+
+/**
+ * `docs-site.yml` fired on every push to `main` and failed all 30 times over
+ * two months. The trigger was fine; the *outcome* was invisible, and from
+ * inside the repo a workflow that runs and passes and one that runs and fails
+ * look identical. See bean `xom7`.
+ *
+ * These tests pin the two distinctions that make a health report worth reading:
+ * a run still in flight is not a verdict either way, and "could not check" is
+ * never rendered as "green". A report that goes quiet when it cannot see is
+ * worse than no report, because it reads as reassurance.
+ */
+
+const NOW = new Date("2026-08-26T12:00:00Z");
+const run = (over: Partial<RunSummary> = {}): RunSummary => ({
+  name: "Docs site",
+  status: "completed",
+  conclusion: "success",
+  created_at: "2026-08-26T10:00:00Z",
+  ...over,
+});
+
+describe("classifying one workflow's history", () => {
+  test("latest success is green, with no failure count", () => {
+    const h = classifyRuns([run(), run({ conclusion: "failure" })], NOW);
+    expect(h.health).toBe("green");
+    expect(h.consecutiveFailures).toBe(0);
+  });
+
+  test("consecutive failures are counted from the newest run backwards", () => {
+    const h = classifyRuns(
+      [
+        run({ conclusion: "failure", created_at: "2026-08-26T10:00:00Z" }),
+        run({ conclusion: "failure", created_at: "2026-08-25T10:00:00Z" }),
+        run({ conclusion: "failure", created_at: "2026-08-24T10:00:00Z" }),
+        run({ conclusion: "success", created_at: "2026-08-20T10:00:00Z" }),
+        run({ conclusion: "failure", created_at: "2026-08-19T10:00:00Z" }),
+      ],
+      NOW,
+    );
+    expect(h.health).toBe("red");
+    expect(h.consecutiveFailures).toBe(3);
+    expect(h.daysSinceSuccess).toBe(6);
+  });
+
+  test("no success anywhere in the window leaves daysSinceSuccess undefined", () => {
+    // The real docs-site shape: red as far back as the window reaches. Guessing
+    // a number here would understate how long it had been broken.
+    const h = classifyRuns([run({ conclusion: "failure" }), run({ conclusion: "failure" })], NOW);
+    expect(h.health).toBe("red");
+    expect(h.daysSinceSuccess).toBeUndefined();
+    expect(h.lastSuccess).toBeUndefined();
+  });
+
+  test("a run still in flight is not a verdict either way", () => {
+    // Counting a queued run as a failure would cry wolf on every push; counting
+    // it as a pass would be the exact lie this whole module exists to prevent.
+    expect(classifyRuns([run({ status: "in_progress", conclusion: null })], NOW).health).toBe(
+      "running",
+    );
+  });
+
+  test("cancelled and skipped runs are not the workflow's fault, and are ignored", () => {
+    const h = classifyRuns(
+      [
+        run({ conclusion: "cancelled" }),
+        run({ conclusion: "skipped" }),
+        run({ conclusion: "success", created_at: "2026-08-26T09:00:00Z" }),
+      ],
+      NOW,
+    );
+    expect(h.health).toBe("green");
+    expect(h.consecutiveFailures).toBe(0);
+  });
+
+  test("no runs at all is its own state, not green", () => {
+    expect(classifyRuns([], NOW).health).toBe("no-runs");
+  });
+});
+
+describe("assessing a whole repo", () => {
+  const mixed: RunSummary[] = [
+    run({ name: "Docs site", conclusion: "failure", created_at: "2026-08-26T10:00:00Z" }),
+    run({ name: "Docs site", conclusion: "failure", created_at: "2026-08-25T10:00:00Z" }),
+    run({ name: "Code-quality gates", conclusion: "success", created_at: "2026-08-26T11:00:00Z" }),
+    run({ name: "QA sweep", conclusion: "failure", created_at: "2026-08-01T10:00:00Z" }),
+  ];
+
+  test("runs are grouped by workflow, newest first", () => {
+    const g = byWorkflow(mixed);
+    expect([...g.keys()].sort()).toEqual(["Code-quality gates", "Docs site", "QA sweep"]);
+    expect(g.get("Docs site")![0].created_at).toBe("2026-08-26T10:00:00Z");
+  });
+
+  test("the worst workflow sorts first — one line read should be the worst one", () => {
+    const h = assess(mixed, { now: NOW });
+    expect(h[0].workflow).toBe("Docs site");
+    expect(h[0].consecutiveFailures).toBe(2);
+    expect(h.at(-1)!.workflow).toBe("Code-quality gates");
+  });
+
+  test("runs of a DELETED workflow are history, not a live problem", () => {
+    const withGhost = [
+      ...mixed,
+      run({
+        name: ".github/workflows/paper-builder-image.yml",
+        path: ".github/workflows/paper-builder-image.yml",
+        conclusion: "failure",
+      }),
+    ];
+    const exists = (p: string) => p !== ".github/workflows/paper-builder-image.yml";
+    const names = assess(withGhost, { now: NOW, workflowExists: exists }).map((h) => h.workflow);
+    expect(names).not.toContain(".github/workflows/paper-builder-image.yml");
+    // Still reports the live failure — the filter must not swallow real ones.
+    expect(names).toContain("Docs site");
+  });
+
+  test("without a workflowExists predicate nothing is filtered", () => {
+    // Not knowing which files exist must not silently drop failures.
+    const withGhost = [...mixed, run({ name: "Gone", path: "x.yml", conclusion: "failure" })];
+    expect(assess(withGhost, { now: NOW }).map((h) => h.workflow)).toContain("Gone");
+  });
+});
+
+describe("age separates an active fire from a stale scorch mark", () => {
+  test("a red that has not re-run in a week is flagged as possibly stale", () => {
+    // The real shape of two of this repo's workflows: last red 2026-08-07,
+    // against a commit whose files were changed the next day.
+    const out = render(
+      assess(
+        [
+          run({ name: "QA sweep", conclusion: "failure", created_at: "2026-08-07T15:04:09Z" }),
+          run({ name: "QA sweep", conclusion: "failure", created_at: "2026-08-07T15:04:08Z" }),
+        ],
+        { now: NOW },
+      ),
+      { branch: "main" },
+    );
+    // 2026-08-07T15:04 to 2026-08-26T12:00 is 18 whole days, not 19.
+    expect(out).toContain("has not run in 18d");
+    expect(out).toContain("may be stale");
+  });
+
+  test("a red that ran today is NOT softened as stale", () => {
+    const out = render(
+      assess([run({ name: "Docs site", conclusion: "failure", created_at: "2026-08-26T10:00:00Z" })], {
+        now: NOW,
+      }),
+      { branch: "main" },
+    );
+    expect(out).toContain("last ran 0d ago");
+    expect(out).not.toContain("may be stale");
+  });
+});
+
+describe("rendering, and the thing it must never do", () => {
+  test("an unreachable API renders as unknown, never as green", () => {
+    const out = render([], { unreachable: "GitHub API returned 403", branch: "main" });
+    expect(out).toContain("Not checked");
+    expect(out).toContain("treat as unknown, not as green");
+    expect(out).not.toMatch(/✓|green \(/);
+  });
+
+  test("a failing workflow is named with its failure count and staleness", () => {
+    const out = render(assess([
+      run({ name: "Docs site", conclusion: "failure", created_at: "2026-08-26T10:00:00Z" }),
+      run({ name: "Docs site", conclusion: "failure", created_at: "2026-08-25T10:00:00Z" }),
+    ], { now: NOW }), { branch: "main" });
+    expect(out).toContain("Docs site");
+    expect(out).toContain("2 consecutive failure(s)");
+    expect(out).toContain("no success in the window");
+  });
+
+  test("all green says so explicitly rather than printing nothing", () => {
+    // An empty section is indistinguishable from a section that did not run.
+    const out = render(assess([run({ name: "Code-quality gates" })], { now: NOW }), {
+      branch: "main",
+    });
+    expect(out).toContain("every workflow with a recent run");
+  });
+
+  test("no runs in the window is stated, not rendered as green", () => {
+    const out = render([], { branch: "main" });
+    expect(out).toContain("No runs on");
+    expect(out).not.toContain("green");
+  });
+});

--- a/src/workflow/ci-health.ts
+++ b/src/workflow/ci-health.ts
@@ -36,7 +36,7 @@ export interface RunSummary {
   path?: string;
 }
 
-export type Health = "green" | "red" | "running" | "no-runs";
+export type Health = "green" | "red" | "running" | "no-runs" | "superseded";
 
 export interface WorkflowHealth {
   workflow: string;
@@ -59,6 +59,19 @@ export interface WorkflowHealth {
    * report earns the inattention it exists to fix.
    */
   daysSinceLastRun?: number;
+  /** ISO date of the most recent run of any conclusion. */
+  lastRun?: string;
+  /**
+   * ISO date of the change that made this workflow's last verdict obsolete.
+   *
+   * Set only on a red whose newest run **predates** the last edit to its
+   * workflow file: the version that failed no longer exists, so the failure is
+   * history rather than a live problem — the same distinction `workflowExists`
+   * already draws for a workflow that was deleted outright.
+   */
+  supersededBy?: string;
+  /** `.github/workflows/x.yml`, carried through for the reader. */
+  path?: string;
 }
 
 /** Conclusions that are not a pass but are also not the workflow's fault. */
@@ -101,6 +114,7 @@ export function classifyRuns(runs: RunSummary[], now = new Date()): Omit<Workflo
     lastSuccess,
     daysSinceSuccess,
     daysSinceLastRun,
+    lastRun: runs[0]?.created_at,
     latestUrl: runs[0]?.html_url,
   };
 }
@@ -128,6 +142,27 @@ export interface AssessOptions {
    * silently drop failures.
    */
   workflowExists?: (path: string) => boolean;
+  /**
+   * When was this workflow file last changed? ISO date, or `undefined` if not
+   * known.
+   *
+   * A red verdict is a verdict about *the file as it was when it ran*. Edit the
+   * file and that verdict is about a version that no longer exists — most
+   * sharply when the failure was a startup failure, where the YAML never parsed
+   * and no job ran at all.
+   *
+   * Two of this repo's workflows sit exactly there. `witness-refresh.yml` and
+   * `qa-sweep.yml` failed to parse, fired on `push` despite being
+   * `workflow_dispatch`-only (GitHub could not read the `on:` block to filter
+   * on), and were fixed the next day. They only run on dispatch, and this
+   * report only reads the default branch — so nothing will ever run them here
+   * again, and without this rule they stay red forever. Two permanent false
+   * fires erode exactly the attention the report exists to protect.
+   *
+   * Omit it and nothing is superseded: not knowing when a file changed must
+   * leave a failure reported, never explain it away.
+   */
+  workflowChangedAt?: (path: string) => string | undefined;
 }
 
 export function assess(runs: RunSummary[], opts: AssessOptions = {}): WorkflowHealth[] {
@@ -136,10 +171,25 @@ export function assess(runs: RunSummary[], opts: AssessOptions = {}): WorkflowHe
     ? runs.filter((r) => !r.path || opts.workflowExists!(r.path))
     : runs;
   return [...byWorkflow(live).entries()]
-    .map(([workflow, rs]) => ({ workflow, ...classifyRuns(rs, now) }))
+    .map(([workflow, rs]) => {
+      const h: WorkflowHealth = { workflow, path: rs[0]?.path, ...classifyRuns(rs, now) };
+      // A failure against a version of the file that is gone is history. Note
+      // that this only ever DEMOTES a red — it can never turn a failure into a
+      // pass, because a later edit is evidence the failing version is gone, not
+      // evidence the new one works.
+      if (h.health === "red" && h.path && h.lastRun && opts.workflowChangedAt) {
+        const changed = opts.workflowChangedAt(h.path);
+        if (changed && changed > h.lastRun) {
+          h.health = "superseded";
+          h.supersededBy = changed;
+        }
+      }
+      return h;
+    })
     .sort((a, b) => {
       // Worst first: a reader who reads one line should read the worst one.
-      const rank = (h: WorkflowHealth) => (h.health === "red" ? 0 : h.health === "running" ? 1 : 2);
+      const order: Health[] = ["red", "running", "superseded", "green", "no-runs"];
+      const rank = (h: WorkflowHealth) => order.indexOf(h.health);
       return rank(a) - rank(b) || b.consecutiveFailures - a.consecutiveFailures;
     });
 }
@@ -192,9 +242,23 @@ export function render(
         (h.latestUrl ? `\n      ${h.latestUrl}` : ""),
     );
   }
-  const ok = health.filter((h) => h.health !== "red");
-  if (red.length === 0) {
+  // Reported, but below the fold and never as a pass: the failing version of
+  // the file is gone, which is not the same as knowing the current one works.
+  const superseded = health.filter((h) => h.health === "superseded");
+  for (const h of superseded) {
+    lines.push(
+      `- ❔ **${h.workflow}** — last failed ${h.daysSinceLastRun}d ago, but the ` +
+        `workflow file changed after that. Verdict is stale, not green; nothing ` +
+        `has re-run it since.`,
+    );
+  }
+
+  const ok = health.filter((h) => h.health !== "red" && h.health !== "superseded");
+  if (red.length === 0 && superseded.length === 0) {
     lines.push(`✓ every workflow with a recent run on \`${opts.branch}\` is green (${ok.length}).`);
+  } else if (red.length === 0) {
+    // Not "all green" — that would be the lie this module exists to prevent.
+    lines.push("", `_(no live failures; ${ok.length} workflow(s) green.)_`);
   } else {
     lines.push("", `_(${ok.length} other workflow(s) not failing.)_`);
   }

--- a/src/workflow/ci-health.ts
+++ b/src/workflow/ci-health.ts
@@ -1,0 +1,203 @@
+/**
+ * Is CI actually green, or has it merely been red for so long that nobody looks?
+ *
+ * `5rfy` fixed workflows that never **fire** — a header advertising a schedule
+ * its `on:` block did not have. This is the opposite defect, and the one that
+ * cost more: `docs-site.yml` fired on every push to `main` and **failed all 30
+ * times** between 2026-06-29 and 2026-08-26. The published site sat two months
+ * stale, and the workflow diagrams merged in #135 never reached it.
+ *
+ * The trigger was fine. The *outcome* was invisible. From inside the repo a
+ * workflow that runs and passes and one that runs and fails look identical, and
+ * GitHub's failure email is evidently a channel nobody reads.
+ *
+ * So this classifies each workflow's recent history on the default branch, and
+ * the session-start sweep prints it where attention already goes.
+ *
+ * ## "Could not check" is not "healthy"
+ *
+ * Every function here distinguishes *red*, *green* and *unknown*, and the
+ * caller must too. A health report that silently treats an unreachable API as
+ * fine is the same failure one level up — which is precisely the mistake the
+ * sibling-branch section of `session-start-coord-sweep.sh` already refuses to
+ * make ("Treat this section as unread, not as empty").
+ *
+ * @module folio-assistant/workflow/ci-health
+ */
+
+/** The fields of a GitHub Actions run this module reads. */
+export interface RunSummary {
+  name: string;
+  status: string;
+  conclusion: string | null;
+  created_at: string;
+  html_url?: string;
+  /** `.github/workflows/x.yml` — the file the run came from, if any. */
+  path?: string;
+}
+
+export type Health = "green" | "red" | "running" | "no-runs";
+
+export interface WorkflowHealth {
+  workflow: string;
+  health: Health;
+  /** Consecutive non-success runs, newest first. 0 when the latest passed. */
+  consecutiveFailures: number;
+  /** ISO date of the most recent success, if there is one in the window. */
+  lastSuccess?: string;
+  /** Whole days since that success. `undefined` when there is none in window. */
+  daysSinceSuccess?: number;
+  /** Newest run, for a link to hand the reader. */
+  latestUrl?: string;
+  /**
+   * Whole days since the most recent run of any conclusion.
+   *
+   * Age is what separates an active fire from a stale scorch mark. Two of this
+   * repo's workflows show "no success in the window" — and both last ran on
+   * 2026-08-07 against a commit whose files were changed the next day. Reporting
+   * those identically to something that broke an hour ago is how a health
+   * report earns the inattention it exists to fix.
+   */
+  daysSinceLastRun?: number;
+}
+
+/** Conclusions that are not a pass but are also not the workflow's fault. */
+const NOT_A_VERDICT = new Set(["cancelled", "skipped", "neutral"]);
+
+/**
+ * Classify one workflow's runs, newest first.
+ *
+ * A run still in flight defers the verdict rather than counting as either — a
+ * queued run is not evidence of health, and calling it a failure would cry wolf
+ * on every push.
+ */
+export function classifyRuns(runs: RunSummary[], now = new Date()): Omit<WorkflowHealth, "workflow"> {
+  const settled = runs.filter((r) => r.status === "completed" && !NOT_A_VERDICT.has(r.conclusion ?? ""));
+
+  const lastSuccessRun = settled.find((r) => r.conclusion === "success");
+  const lastSuccess = lastSuccessRun?.created_at;
+  const daysSinceSuccess = lastSuccess
+    ? Math.floor((now.getTime() - new Date(lastSuccess).getTime()) / 86_400_000)
+    : undefined;
+
+  let consecutiveFailures = 0;
+  for (const r of settled) {
+    if (r.conclusion === "success") break;
+    consecutiveFailures++;
+  }
+
+  let health: Health;
+  if (runs.length === 0) health = "no-runs";
+  else if (settled.length === 0) health = "running";
+  else health = consecutiveFailures === 0 ? "green" : "red";
+
+  const daysSinceLastRun = runs[0]
+    ? Math.floor((now.getTime() - new Date(runs[0].created_at).getTime()) / 86_400_000)
+    : undefined;
+
+  return {
+    health,
+    consecutiveFailures,
+    lastSuccess,
+    daysSinceSuccess,
+    daysSinceLastRun,
+    latestUrl: runs[0]?.html_url,
+  };
+}
+
+/** Group a flat run list by workflow name, newest first within each group. */
+export function byWorkflow(runs: RunSummary[]): Map<string, RunSummary[]> {
+  const out = new Map<string, RunSummary[]>();
+  const sorted = [...runs].sort((a, b) => b.created_at.localeCompare(a.created_at));
+  for (const r of sorted) {
+    const list = out.get(r.name) ?? [];
+    list.push(r);
+    out.set(r.name, list);
+  }
+  return out;
+}
+
+export interface AssessOptions {
+  now?: Date;
+  /**
+   * Does this workflow file still exist? Runs of a **deleted** workflow are
+   * history, not a live problem, and reporting them cries wolf — which is how a
+   * health report earns the same inattention that let `docs-site` rot.
+   *
+   * Omit it and nothing is filtered: not knowing which files exist must not
+   * silently drop failures.
+   */
+  workflowExists?: (path: string) => boolean;
+}
+
+export function assess(runs: RunSummary[], opts: AssessOptions = {}): WorkflowHealth[] {
+  const now = opts.now ?? new Date();
+  const live = opts.workflowExists
+    ? runs.filter((r) => !r.path || opts.workflowExists!(r.path))
+    : runs;
+  return [...byWorkflow(live).entries()]
+    .map(([workflow, rs]) => ({ workflow, ...classifyRuns(rs, now) }))
+    .sort((a, b) => {
+      // Worst first: a reader who reads one line should read the worst one.
+      const rank = (h: WorkflowHealth) => (h.health === "red" ? 0 : h.health === "running" ? 1 : 2);
+      return rank(a) - rank(b) || b.consecutiveFailures - a.consecutiveFailures;
+    });
+}
+
+/**
+ * Render for the session-start sweep.
+ *
+ * `unreachable` is its own outcome, printed as loudly as a failure, because a
+ * health check that goes quiet when it cannot see is worse than no check: it
+ * reads as reassurance.
+ */
+export function render(
+  health: WorkflowHealth[],
+  opts: { unreachable?: string; branch: string },
+): string {
+  const lines = ["## CI health", ""];
+  if (opts.unreachable) {
+    lines.push(
+      `**Not checked — treat as unknown, not as green.** ${opts.unreachable}`,
+      "",
+      "`docs-site.yml` was red for 30 consecutive runs over two months without",
+      "anyone noticing (bean `xom7`). An unchecked section is exactly how that",
+      "looked from in here.",
+      "",
+    );
+    return lines.join("\n");
+  }
+  if (health.length === 0) {
+    lines.push(`_No runs on \`${opts.branch}\` in the window checked._`, "");
+    return lines.join("\n");
+  }
+
+  const red = health.filter((h) => h.health === "red");
+  const STALE_DAYS = 7;
+  for (const h of red) {
+    const since =
+      h.daysSinceSuccess === undefined
+        ? "no success in the window"
+        : `last green ${h.daysSinceSuccess}d ago`;
+    // A red that has not re-run in a week may already be fixed — flag it as
+    // stale so the reader triages it differently from something failing now.
+    const age =
+      h.daysSinceLastRun === undefined
+        ? ""
+        : h.daysSinceLastRun >= STALE_DAYS
+          ? `, but has not run in ${h.daysSinceLastRun}d — may be stale`
+          : `, last ran ${h.daysSinceLastRun}d ago`;
+    lines.push(
+      `- ❌ **${h.workflow}** — ${h.consecutiveFailures} consecutive failure(s), ${since}${age}` +
+        (h.latestUrl ? `\n      ${h.latestUrl}` : ""),
+    );
+  }
+  const ok = health.filter((h) => h.health !== "red");
+  if (red.length === 0) {
+    lines.push(`✓ every workflow with a recent run on \`${opts.branch}\` is green (${ok.length}).`);
+  } else {
+    lines.push("", `_(${ok.length} other workflow(s) not failing.)_`);
+  }
+  lines.push("");
+  return lines.join("\n");
+}


### PR DESCRIPTION
`docs-site.yml` was triggered by all 30 `main` pushes between 2026-06-29 and 2026-08-26, and **failed every one**. The trigger was fine — `5rfy` already fixed the workflows that never *fire*. This is the opposite defect: the **outcome** was invisible. From inside the repo a workflow that runs and passes and one that runs and fails look identical, and GitHub's failure email is evidently a channel nobody reads. The published site sat two months stale and nothing in the repo said so.

Three commits, each one a defect the previous one exposed.

## 1. The report — bean `xom7`

- **`src/workflow/ci-health.ts`** — classifies each workflow's recent history on the default branch: consecutive failures, days since the last green, days since the last run of any conclusion.
- **`scripts/check-ci-health.ts`** — one API call (`/actions/runs?branch=DEFAULT&per_page=100`). Fanning out per workflow would exhaust the unauthenticated 60/hr limit and make it unusable at session start.
- **`scripts/session-start-coord-sweep.sh`** — prints it beside the beans, where attention already goes.

Two rules it follows, both pinned by tests. **"Could not check" is never rendered as green** — an unreachable API prints as UNKNOWN, as loudly as a failure, because a health check that goes quiet when it cannot see reads as reassurance. And **age separates an active fire from a stale scorch mark**: a red that has not re-run in a week is flagged rather than reported identically to something that broke an hour ago.

## 2. Two of its own findings were false fires — bean `lq7e`

Using the report turned up a defect in it. `witness-refresh.yml` and `qa-sweep.yml` went red on `main` at 2026-08-07T15:04, four runs within two seconds — all `push` events, all named by **path** rather than by `name:`, yet both files declare `on: workflow_dispatch` only. A dispatch-only workflow cannot fire on push *unless GitHub could not parse the file and so never read the `on:` block*. That is the startup-failure signature, and `witness-refresh.yml` carries the post-mortem in its own comments: a commit-message block scalar whose body reached column 0, ending the scalar so YAML read the prose as a mapping key.

**Both were fixed the next day, and confirming it cost no Actions minutes**: 75 pushes to `main` since have produced zero runs of either. A parseable dispatch-only workflow does not fire on push, so the absence is the proof. Both parse locally, `on: [workflow_dispatch]`.

Neither will ever go green — dispatch-only, and this report reads the default branch. Dispatching cannot clear it either: both fail **by design** here (`qa-sweep` preflights on `content/package.json`, `witness-refresh` needs `folio-assistant/computations/`, and the platform carries no folio). So they would have sat red forever: two permanent false fires in a report whose whole value is that a red line means something.

The fix is the sibling of the `workflowExists` predicate already there. Where that says a **deleted** workflow's runs are history, this says a red whose newest run **predates the last change to its file** is a verdict about a version that is gone — `superseded`, from `git log -1 --format=%cI`, which is local, free, and evidence rather than the age heuristic it supplements. It is never rendered as green and never counted as a live failure, and the rule may only ever **demote** a red: a later edit is evidence the failing version is gone, not evidence the new one works. Four of the eight new tests pin the ways it must *not* fire.

## 3. A report is only read by someone in the room — bean `ynu8`

The session-start sweep covers every day somebody is working. The failure being guarded against is a quiet stretch with nobody looking — which is exactly the stretch in which no session starts.

**`.github/workflows/ci-health.yml`** runs the same checker weekly and maintains **one** issue labelled `ci-health`: opened on a live failure, edited in place while it persists (an edit does not notify, so a month-long outage stays one unread item), closed automatically when `main` is clean. It deliberately does not send another email. Three live **README badges** put the same state at the front door, for the three workflows that actually run on `main`.

Weekly rather than daily: the defect is "nobody noticed for two months", not "nobody noticed for a day". This repository is public, so standard GitHub-hosted runners are free — the earlier reasoning that a scheduled job cost minutes worth avoiding was wrong about this repo.

Two things in it are load-bearing rather than incidental. **`fetch-depth: 0`**, because the `superseded` rule asks `git log` when a workflow file last changed and a shallow clone cannot answer — which would resurrect the false fires §2 just retired. And on **"could not check"** the tracking issue is left untouched and the job fails: closing it would make the watchdog going blind read as good news, which is this module's cardinal error one level up. A red `ci-health.yml` is itself reported by next week's run.

`--out FILE` gives the notifier the report *and* a real exit code from one API call. It cannot reuse `--markdown`, which always exits 0 deliberately — `session-start-coord-sweep.sh` runs it as `if ! bun run … --markdown; then` and prints a "Not checked" fallback on non-zero, so a `--markdown` that failed on red would print the report *and* declare it unchecked, every time.

## Defects the repo's own guards caught

The `5rfy` trigger-consistency test rejected the new workflow's header, where prose about `docs-site`'s push trigger read as a claim about this workflow's own — rephrased rather than disclaimed, since its triggers are exactly what it says. Adversarial re-read caught two more: `bun` exits 1 on an uncaught exception too, so exit 1 alone would misread a **crash** as "red" and open an issue quoting an absent report (the verdict now requires a non-empty report file); and both issue paths filter by the label, so the clean path needed it ensured too.

## Validation

`bun test` — 818 pass, 51 skip, 0 fail (31 new). `tsc --noEmit` and `eslint .` clean. Every `run:` block shell-syntax checked. CI green 4/4 on the merged head.

**Not verified at merge time:** the watchdog's `gh` issue create/edit/close plumbing. `workflow_dispatch` needs the file on the default branch, so it could not be smoke-tested before merging — only reasoned through.

Live output, where it read `2 workflow(s) failing` before:

```
❔ .github/workflows/witness-refresh.yml   last failed 19d ago; file changed since — stale, not green
❔ .github/workflows/qa-sweep.yml          last failed 19d ago; file changed since — stale, not green
✓  Code-quality gates                      green
✓  Docs site (GitHub Pages)                green
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014NdiZHmmgCNZLTejVLYT5K