### PR TITLE
feat(ingest): deterministic table/figure rung + the capability probes it needs

### DIFF
--- a/.beans/folio-assistant-fj94--pdf-ingestion-deterministic-tablefigure-rung-docli.md
+++ b/.beans/folio-assistant-fj94--pdf-ingestion-deterministic-tablefigure-rung-docli.md
@@ -1,0 +1,41 @@
+---
+# folio-assistant-fj94
+title: 'PDF ingestion: deterministic table/figure rung + Docling capability probe'
+status: in-progress
+type: task
+priority: normal
+created_at: 2026-08-26T20:40:19Z
+updated_at: 2026-08-26T20:54:31Z
+---
+
+Claimed by `claude/pdf-ingestion-pipeline-y6koyj`.
+
+
+## What landed
+
+- `scripts/pdf-tables.py` — `pdf-tables/v1` beside `structure.json`: cell
+  matrices, column edges, bboxes, captions, `section_id` joined from
+  `structure.json`, and a GFM rendering `render-latex.ts` already turns into a
+  `tabular`. Two backends (pdfplumber default, camelot-py preferred when
+  present for its per-table accuracy score); multi-page stitching over column
+  geometry with three guards; `tables: null` vs `[]` so an unparsed document
+  can never read as an empty one.
+- `.claude/skills/capabilities/{pdfplumber,camelot,docling}.json` — the docling
+  probe deliberately also requires `huggingface.co` to answer, because the
+  package importing is not the capability.
+- `scripts/tests/pdf-tables.test.py` — 38 cases, standalone (CI has neither
+  backend). Verified to fail when the reading-order fix is reverted.
+- `docs/proposals/rag-document-ingestion.md` §12.26 + §4.2 rows.
+- `skills/folio-paper-adapter/document-intake.md` Stage 3 + checklist.
+
+## Still open
+
+- **Never run against a corpus.** This repo carries no folio, so verification is
+  a synthetic fixture. §12.26 names the four numbers a corpus run would settle
+  (lines-vs-text recall, caption miss rate, `COL_TOL_PT`, vector-cluster
+  precision).
+- `structure.json` does not consume `tables.json`; consumers join on
+  `section_id`. Folding them together means either making pypdf-only Stage 1
+  depend on a table backend or reasoning about two SHAs.
+- Not exposed as an MCP tool — the integration point is the skill, matching
+  `pdf-extract.py` and `pdf-ocr.py`.

--- a/.claude/skills/capabilities/camelot.json
+++ b/.claude/skills/capabilities/camelot.json
@@ -1,0 +1,10 @@
+{
+  "id": "camelot",
+  "name": "camelot-py (table extraction with a confidence score)",
+  "description": "Optional second backend for scripts/pdf-tables.py, preferred when present. Extracts the same cells and column edges as pdfplumber on a ruled grid, and additionally reports a per-table parsing accuracy that lands in the artefact's `confidence` field, which pdfplumber has no equivalent for. Camelot 2.0 moved Ghostscript to an optional extra; the base install is numpy/pandas/opencv-headless/pypdfium2 and needs no egress after install. Install: pip install camelot-py.",
+  "detection": {
+    "method": "command",
+    "command": "python3 -c 'import camelot'"
+  },
+  "requires": ["python3"]
+}

--- a/.claude/skills/capabilities/docling.json
+++ b/.claude/skills/capabilities/docling.json
@@ -1,10 +1,12 @@
 {
   "id": "docling",
   "name": "Docling (layout-aware PDF parsing)",
-  "description": "IBM's MIT-licensed document parser: layout analysis, TableFormer table structure, formula enrichment. Stage 3 of docs/proposals/rag-document-ingestion.md §10 — the ~20 documents pypdf cannot serve (7 no-TOC, 17 unsectioned, 7 likely-scanned) plus the WHO L1 guidelines, where boxed recommendations and GRADE tables are layout facts. IMPORTANT: `pip install docling` succeeds but the first parse fetches weights from huggingface.co, which returns `CONNECT tunnel failed, response 403` under organisation policy (re-measured 2026-08-26). This probe therefore reports ABSENT in a sandboxed session even where the package imports, because the package importing is not the capability. Run it on a workstation or in CI and commit the artefacts.",
+  "description": "IBM's MIT-licensed document parser: layout analysis, TableFormer table structure, formula enrichment. Stage 3 of docs/proposals/rag-document-ingestion.md §10 — the ~20 documents pypdf cannot serve (7 no-TOC, 17 unsectioned, 7 likely-scanned) plus the WHO L1 guidelines, where boxed recommendations and GRADE tables are layout facts. IMPORTANT: `pip install docling` succeeds but a first parse fetches weights from huggingface.co, which returns `CONNECT tunnel failed, response 403` under organisation policy (re-measured 2026-08-26). So the import is NOT the capability, and this probe does not stop there: it passes when the weights are already cached locally, and otherwise falls back to a 5-second reachability check. A sandboxed session therefore reports ABSENT and a workstation with models downloaded passes offline and instantly. Run it where egress allows and commit the artefacts.",
   "detection": {
     "method": "command",
-    "command": "python3 -c 'import docling' && curl -sf --max-time 10 -o /dev/null https://huggingface.co"
+    "command": "python3 -c 'import docling' && { [ -d \"$HOME/.cache/docling/models\" ] || curl -sf --max-time 5 -o /dev/null https://huggingface.co; }"
   },
-  "requires": ["python3"]
+  "requires": [
+    "python3"
+  ]
 }

--- a/.claude/skills/capabilities/docling.json
+++ b/.claude/skills/capabilities/docling.json
@@ -1,0 +1,10 @@
+{
+  "id": "docling",
+  "name": "Docling (layout-aware PDF parsing)",
+  "description": "IBM's MIT-licensed document parser: layout analysis, TableFormer table structure, formula enrichment. Stage 3 of docs/proposals/rag-document-ingestion.md §10 — the ~20 documents pypdf cannot serve (7 no-TOC, 17 unsectioned, 7 likely-scanned) plus the WHO L1 guidelines, where boxed recommendations and GRADE tables are layout facts. IMPORTANT: `pip install docling` succeeds but the first parse fetches weights from huggingface.co, which returns `CONNECT tunnel failed, response 403` under organisation policy (re-measured 2026-08-26). This probe therefore reports ABSENT in a sandboxed session even where the package imports, because the package importing is not the capability. Run it on a workstation or in CI and commit the artefacts.",
+  "detection": {
+    "method": "command",
+    "command": "python3 -c 'import docling' && curl -sf --max-time 10 -o /dev/null https://huggingface.co"
+  },
+  "requires": ["python3"]
+}

--- a/.claude/skills/capabilities/pdfplumber.json
+++ b/.claude/skills/capabilities/pdfplumber.json
@@ -1,0 +1,10 @@
+{
+  "id": "pdfplumber",
+  "name": "pdfplumber (deterministic table extraction)",
+  "description": "Pure-Python PDF geometry reader, the default backend of scripts/pdf-tables.py. Extracts ruled and alignment-based tables with exact column edges and bounding boxes, which pdf-structure/v1 does not model. No model weights and no egress after install, so unlike Docling it runs in a sandboxed session. Install: pip install pdfplumber.",
+  "detection": {
+    "method": "command",
+    "command": "python3 -c 'import pdfplumber'"
+  },
+  "requires": ["python3"]
+}

--- a/docs/proposals/rag-document-ingestion.md
+++ b/docs/proposals/rag-document-ingestion.md
@@ -150,6 +150,8 @@ narrative guidelines.
 | **Marker** (Datalab) | GPL + commercial threshold | GPU preferred | good (Surya/texify) | good | CLI |
 | **RAGFlow DeepDoc** | Apache-2.0, but bundled | no (part of the stack) | moderate | good | **inside a product** |
 | **Nougat** (Meta) | MIT | GPU | math-native | weak | largely unmaintained; hallucinates |
+| **pdfplumber** | MIT | **yes** | none | ruled + alignment, exact column edges | **library**; the default backend of `scripts/pdf-tables.py` (§12.26) |
+| **camelot-py** | MIT | **yes** | none | ruled + alignment, **reports per-table accuracy** | library + CLI; 2.0 dropped Ghostscript to an optional extra (§12.26) |
 
 Docling is the right default: it is MIT, it runs on the CPU we actually
 have, and — decisively for this repo — **it is a library that produces a
@@ -158,6 +160,13 @@ integration contract (§5). MinerU is better at formulae, but constraint
 (a) means the documents where formula recognition matters most are the
 ones we should not be OCR-ing at all. Keep MinerU as an escalation for a
 math-heavy scan with no source.
+
+The last two rows are not competitors to Docling and do not do what it does —
+no layout model, no reading order, no formulae. They are there because
+Docling's weights come from HuggingFace and Docling therefore parses nothing in
+a sandboxed session, while these need no egress at all after their PyPI
+install. They recover **tables**, which is the part of the gap that can be
+closed deterministically; the rest of it waits for Stage 3. See §12.26.
 
 ### 4.3 Index
 
@@ -2212,3 +2221,154 @@ That makes a folio DAK joinable with WHO's published vocabularies rather than
 merely parallel to them.
 
 1027 tests pass, 0 fail; typecheck and lint clean.
+
+### 12.26 Tables and figures: the rung that runs where Docling cannot
+
+§12 opens by naming the defect this closes — `pdf-structure/v1`'s `Section`
+carries `id`, `number`, `title`, `level`, `page_start`, `page_end`, `n_chars`,
+`n_words`, `text`, and *nothing else*. No tables, no figures, no bounding
+boxes. That is not cosmetic. A GRADE evidence table or a boxed WHO
+recommendation is a **layout** fact, and a text extractor flattens it into a
+run of prose that reads exactly like prose; once flattened, no consumer can
+recover that the numbers it is reading were a 4×7 grid.
+
+#### The egress measurement holds, so the parser that closes it cannot be Docling
+
+Re-measured 2026-08-26, eleven days after §2a:
+
+| Host | Result |
+|---|---|
+| `huggingface.co` | `curl: (56) CONNECT tunnel failed, response 403` |
+| `cdn-lfs.huggingface.co` | same |
+| `arxiv.org` | blocked |
+| `pypi.org` | **200** |
+
+So the §10 Stage-3 caveat stands unchanged: `pip install docling` succeeds and
+the **first parse** is what fails, because that is when the layout, TableFormer
+and formula weights are fetched. Docling remains the better parser and remains
+a workstation/CI stage whose artefacts are committed.
+
+What was missing was any way for a consumer to *see* that Stage 3 had not run.
+`.claude/skills/capabilities/docling.json` now exists, and its probe is
+deliberately not `import docling` alone — it also requires `huggingface.co` to
+answer, because **the package importing is not the capability**. A probe that
+passed on the import would report Docling present in exactly the sessions where
+it cannot parse anything, which is the false pass §5 exists to prevent.
+
+#### `scripts/pdf-tables.py`, and the three meanings of an empty list
+
+`pdf-tables/v1`, written beside `structure.json`, carrying per table: page
+list, bbox, column edges, cell matrix, caption and where the caption was found,
+`section_id` joined from `structure.json`, and a GFM rendering — GFM
+specifically because `content/pipeline/render-latex.ts` already converts a GFM
+table node to `\begin{tabular}` with booktabs, so an extracted table is
+paste-able into a content block with no new converter in between.
+
+The design decision worth recording is the shape of "nothing". An empty
+`tables[]` has three unrelated meanings — the document has no tables, no
+backend was installed, or the file is a scan whose tables are pixels — and §5's
+contract is *absent tool ⇒ n/a, never a false pass*. They are three exit codes
+(0, 5, 2) and, in the artefact, **two different types**:
+
+```
+"tables": []      a backend looked and found none      status "ok"
+"tables": null    nothing looked                       status "n/a-…"
+```
+
+`null` is not `[]`. A consumer that forgets to check `status` still cannot read
+an unparsed document as an empty one. That is the property; the exit code is
+merely the convenient form of it.
+
+#### Camelot, and a stale objection
+
+§4.2's table does not list Camelot, and the reason it would have been excluded
+— that `lattice` shells out to Ghostscript, dragging an AGPL binary into an
+MIT-licensed platform — **is no longer true**. Camelot **2.0** moved Ghostscript
+to an optional extra; the base install is numpy / pandas / opencv-headless /
+pypdfium2 / playa-pdf, MIT throughout, and it was verified here on 2026-08-26
+importing and extracting with no egress at all after the PyPI install. `torch`
+and `transformers` appear only under the `[ml]` extra, so the HuggingFace
+problem does not reach the base install either.
+
+It is therefore the **second** backend, preferred when present, and the reason
+is not accuracy: on the two-page fixture both backends return identical cells
+and identical column edges. It is that Camelot reports a per-table
+`parsing_report.accuracy`, which lands in `confidence` and lets a consumer
+weight a table the way `toc_source: outline|inferred` already lets one weight a
+section. pdfplumber offers no equivalent, so `confidence` is `null` there rather
+than invented. pdfplumber stays the default on footprint, and because
+`smart-base-tools.md` already depends on it — it is a second use of an existing
+dependency rather than a new one.
+
+#### Stitching a table across a page break is ours, not the backend's
+
+A table continuing onto the next page is extracted by every tool as two tables,
+because that is what is on the two pages. Rejoining them is a judgement about
+column geometry, so it is made over `col_edges` — which both backends report
+identically — and works the same whichever backend ran.
+
+A wrong stitch is expensive in a specific way: it welds two unrelated tables
+into one plausible-looking one, and nothing downstream can detect that the rows
+under a header did not come from under that header. Hence three guards, each
+with a test that fails without it: consecutive pages only; same column count
+with every edge within tolerance; and a continuation carrying its own
+`Table N` caption with a *different* N is a new table however well its columns
+line up. A repeated header on the continuation is dropped, and `stitched_from`
+records what was merged, so the decision is auditable rather than invisible.
+
+One bug is worth recording because it was made and caught here. Only the
+**last** table on a page can continue onto the next — anything below it would
+come after the continuation — so a fragment is matched against the last table
+emitted, and the whole thing rests on sorting into reading order. pdfplumber
+reports top-down coordinates and Camelot bottom-up, so sorting on the raw
+`bbox[1]` reads a Camelot page *upwards* and matches the continuation against
+the wrong fragment. The fix is a backend-supplied sort key. The first version
+of the regression test did not catch it, because the fixture derived its bbox
+from its sort key and the two could not disagree — the same defect bean `6fnb`
+found in five other tests, reproduced while writing a test *about* correctness.
+It now fails when the fix is reverted, which was verified rather than assumed.
+
+#### Measured on a fixture, not on a corpus — and that is the honest limit
+
+Every number in §10's Stage 1 came from 339 real PDFs in the `qou` folio.
+**Nothing here has been run against a corpus**, because this repository is the
+platform and carries no folio; the verification is a synthetic two-page ruled
+table with a caption and a repeated header, plus a text-layer-less page for the
+exit-2 path. What that establishes is that the judgement layer is correct on
+inputs whose right answer is known. What it does **not** establish is recall on
+real journal tables — borderless grids, rotated tables, multi-level headers, a
+caption sitting three lines away in a two-column layout.
+
+So the work list a corpus run would settle, stated now rather than discovered
+later: what fraction of tables the `lines` strategy finds versus `text`; how
+often `detect_caption` returns `none` on documents that visibly have captions;
+whether `COL_TOL_PT = 2.0` is too tight for scanned rules; and how many of the
+`vector-cluster` figure candidates are real figures rather than page furniture.
+Those are the numbers that decide whether this rung is sufficient for the WHO
+L1 path or merely a floor under it.
+
+#### Two claims that were circulating, corrected by running them
+
+Both appear in tool round-ups and neither survives contact:
+
+- **"pdfplumber has a native CLI — `pdfplumber < file.pdf > output.json`."**
+  It has a CLI (a `pdfplumber` console script; `python -m pdfplumber` fails,
+  there is no `__main__`), but `infile` is a positional with no stdin default,
+  so the bare redirect prints usage and exits. More consequentially the CLI
+  **cannot extract tables at all** — `--format json` emits per-character
+  geometry, and `extract_tables()` is Python-API only. Verified against
+  pdfplumber 0.11.10.
+- **`magic-pdf -p … -m json`** is MinerU 1.x. The 2.x CLI is `mineru`. MinerU
+  is also AGPL-3.0 against Docling's MIT, which matters for anything this
+  platform distributes and which §4.2's licence column already records.
+
+#### Still not built
+
+`pdf-structure.py` does not consume `tables.json` — the two artefacts sit side
+by side and a consumer joins them on `section_id`. Folding tables into
+`structure.json` would mean either making pypdf-only Stage 1 depend on a table
+backend, which destroys the property that makes it work in a broken container,
+or a merge step that has to reason about staleness of two SHAs. Neither is
+obviously right, so neither was guessed at. Nor is any of this exposed as an
+MCP tool: the integration point today is the skill (`document-intake.md`
+Stage 3), matching how `pdf-extract.py` and `pdf-ocr.py` are already reached.

--- a/docs/proposals/rag-document-ingestion.md
+++ b/docs/proposals/rag-document-ingestion.md
@@ -2250,10 +2250,19 @@ a workstation/CI stage whose artefacts are committed.
 
 What was missing was any way for a consumer to *see* that Stage 3 had not run.
 `.claude/skills/capabilities/docling.json` now exists, and its probe is
-deliberately not `import docling` alone — it also requires `huggingface.co` to
-answer, because **the package importing is not the capability**. A probe that
-passed on the import would report Docling present in exactly the sessions where
-it cannot parse anything, which is the false pass §5 exists to prevent.
+deliberately not `import docling` alone, because **the package importing is not
+the capability** — a probe that passed on the import would report Docling
+present in exactly the sessions where it can parse nothing, which is the false
+pass §5 exists to prevent. What it asks instead is whether the weights are
+*usable*: cached locally, or failing that reachable, on a 5-second bound.
+
+Cache-first and not reachability-first, for a reason `capabilities.ts` states
+about its own `mcp-probe` case — *a check that hangs is worse than one that
+abstains*. A workstation that has already downloaded the models passes
+instantly and offline, and never touches the network to answer a dependency
+check; only an installed-but-unprimed Docling pays the 5 seconds. In a
+sandboxed session the `import` fails first and the probe short-circuits, so
+`--check-deps` stays at half a second.
 
 #### `scripts/pdf-tables.py`, and the three meanings of an empty list
 

--- a/docs/reference/skill-instructions/document-intake.md
+++ b/docs/reference/skill-instructions/document-intake.md
@@ -152,6 +152,7 @@ Two failure modes it exists to prevent, both observed in practice:
 | HTML | Readability + turndown |
 | DOCX | Pandoc → markdown |
 | Images | Claude vision API |
+| PDF (tables/figures) | `scripts/pdf-tables.py` → `tables.json` (see Stage 3) |
 
 For scanned documents the script's OCR rung fires automatically **if**
 `tesseract` and `pdftoppm` are installed (`apt-get install -y tesseract-ocr
@@ -195,8 +196,47 @@ domain-specific; record it in `intake.json.classification.normativeLevel`.
 > generic paper adapter. This skill detects the *shape* and hands off the
 > domain-specific mapping rules to the relevant adapter.
 
+#### Tables and figures — run `scripts/pdf-tables.py`
+
+Text extraction destroys tables. A GRADE evidence table or a boxed
+recommendation comes out of Stage 2 as a run of prose that reads exactly like
+prose, and nothing downstream can recover that it was a grid — which matters
+most for precisely the guideline documents this skill exists to process.
+
+```bash
+python3 scripts/pdf-tables.py FILE.pdf -o uploads/<document-id>/
+python3 scripts/pdf-tables.py --check     # which backends are installed
+```
+
+Writes `tables.json` (`pdf-tables/v1`) beside `structure.json`, with each
+table's cell matrix, column edges, caption, containing `section_id`, and a
+**GFM rendering that can be pasted straight into a content block** — the
+LaTeX pipeline already converts a GFM table to `\begin{tabular}`.
+
+Tables split across a page break are rejoined when their column geometry
+matches; `stitched_from` records what was merged, so check it on any table
+whose rows look like two tables.
+
+**Read `status` before you read `tables`.** The three ways to get no tables are
+distinguished on purpose, and `tables` is `null` — not `[]` — whenever nothing
+actually looked:
+
+| `status` | Exit | Means |
+|---|---|---|
+| `ok` | 0 | a backend looked; `tables: []` means the document has none |
+| `n/a-no-backend` | 5 | `pip install pdfplumber` (or `camelot-py`) |
+| `n/a-no-text-layer` | 2 | a scan — its tables are pixels; see Stage 2's OCR route |
+
+Needs `pdfplumber` or `camelot-py`, both pure PyPI installs with no model
+weights. **Docling is the better parser and is not this**: its weights come
+from HuggingFace, which is 403-blocked in sandboxed sessions, so it is a
+workstation/CI stage whose artefacts get committed — the
+`docling` capability probe reports it absent here rather than letting a session
+believe it ran. See `docs/proposals/rag-document-ingestion.md` §12.26.
+
 **Output**: `extracted-blocks.json` — array of detected blocks with
-provisional kinds, titles, and content.
+provisional kinds, titles, and content; `tables.json` for the layout-bearing
+parts that do not survive as text.
 
 ### Stage 4: Mapping (→ `mapped`)
 
@@ -311,6 +351,8 @@ Before marking intake complete:
 - [ ] `intake.json` has complete metadata
 - [ ] `extracted-text.md` reviewed for OCR errors
 - [ ] `extracted-blocks.json` reviewed and confirmed by user
+- [ ] `tables.json` written, `status` checked (not silently `n/a`), and any
+      `stitched_from` table spot-checked against the PDF
 - [ ] All content objects generated with correct builders
 - [ ] Blocks tagged with `["imported", "source:<document-id>"]`
 - [ ] Chapter/section structure matches document

--- a/scripts/_pypdf_compat.py
+++ b/scripts/_pypdf_compat.py
@@ -29,10 +29,18 @@ permanent, and worked around with a duplicate ingester on the qou side rather
 than fixed here. The duplicate was the wrong shape — `pdf-structure.py` is the
 owner of `pdf-structure/v1` and there should be exactly one producer of it.
 
+`pdfplumber` reaches the same `cryptography` import through `pdfminer.six`, and
+for the same reason: encrypted-PDF support it does not need to read an
+unencrypted file. So `import_pdfplumber` shares this machinery rather than
+duplicating it, and the module keeps its pypdf-flavoured name — renaming it
+would touch four importers and a test to say nothing new. What it actually owns
+is the cryptography workaround, not pypdf.
+
 Usage:
 
-    from _pypdf_compat import import_pypdf
+    from _pypdf_compat import import_pypdf, import_pdfplumber
     PdfReader, PdfWriter = import_pypdf("PdfReader", "PdfWriter")
+    pdfplumber = import_pdfplumber()          # None when absent
 """
 
 from __future__ import annotations
@@ -80,6 +88,35 @@ def import_pypdf(*names: str):
         except ImportError:
             sys.exit(f"{_prog()}: {_MISSING}")
     return tuple(getattr(pypdf, n) for n in names) if len(names) > 1 else getattr(pypdf, names[0])
+
+
+def import_pdfplumber():
+    """Return the `pdfplumber` module, or `None` when it is not usable.
+
+    Deliberately **not** `sys.exit` on absence, unlike `import_pypdf`. pypdf is
+    the floor for `pdf-structure.py` — without it there is no artefact at all.
+    pdfplumber is an *optional rung*: `pdf-tables.py` still has to write an
+    artefact saying it looked and could not, because `tables: []` from a missing
+    library must not read the same as `tables: []` from a document with no
+    tables (`rag-document-ingestion.md` §5: absent tool => n/a, never a false
+    pass). Returning `None` lets the caller say which of the two happened.
+
+    The `BaseException` retry is the same cryptography workaround documented at
+    the top of this module; pdfplumber reaches it through `pdfminer.six`.
+    """
+    try:
+        import pdfplumber
+        return pdfplumber
+    except ImportError:
+        return None
+    except BaseException:
+        _purge(("pdfplumber", "pdfminer", "cryptography"))
+        sys.meta_path.insert(0, _BlockCryptography())
+        try:
+            import pdfplumber  # noqa: F811
+            return pdfplumber
+        except BaseException:
+            return None
 
 
 def _prog() -> str:

--- a/scripts/pdf-tables.py
+++ b/scripts/pdf-tables.py
@@ -1,0 +1,690 @@
+#!/usr/bin/env python3
+"""
+pdf-tables — the deterministic table and figure rung.
+
+WHY THIS EXISTS.  `pdf-structure/v1`'s `Section` carries `id`, `number`,
+`title`, `level`, `page_start`, `page_end`, `n_chars`, `n_words`, `text` — and
+nothing else.  No tables, no figures, no bounding boxes.
+`docs/proposals/rag-document-ingestion.md` §12 opens by naming that as the
+schema's central defect, and it is not cosmetic: a GRADE evidence table or a
+boxed WHO recommendation is a *layout* fact, and a text extractor flattens it
+into a run of prose that reads exactly like prose.  Once flattened, no
+downstream consumer can tell that the numbers it is reading were a 4x7 grid.
+
+WHY NOT DOCLING, WHICH IS THE BETTER PARSER.  This does not replace it.
+Docling's layout, TableFormer and formula weights are fetched from HuggingFace
+on first use, and both `huggingface.co` and `cdn-lfs.huggingface.co` answer
+
+    curl: (56) CONNECT tunnel failed, response 403
+
+here — re-measured 2026-08-26, eleven days after §2a first recorded it, with
+`pypi.org` answering 200 in the same sweep.  `pip install docling` therefore
+succeeds and the *first parse* is what fails.  That makes Docling a
+workstation/CI stage whose artefacts get committed (§10 Stage 3), and makes
+this the rung that runs in the sandboxed sessions where most agent work
+happens.  Both backends below are pure-Python-plus-wheels: no weights, no
+egress at all after the install.
+
+THE AMBIGUITY THIS EXISTS TO KILL.  An empty `tables[]` has three completely
+different meanings — "this document has no tables", "no backend was
+installed", and "this is a scan, so its tables are pixels" — and §5's contract
+is *absent tool => n/a, never a false pass*.  So they are three different exit
+codes, and in the artefact they are three different **shapes**:
+
+    "tables": []      the backend looked and found none      status "ok"
+    "tables": null    nothing looked                         status "n/a-*"
+
+`null` is not `[]`.  A consumer that forgets to check `status` still cannot
+read an unparsed document as an empty one, which is the whole point.
+
+TWO BACKENDS, BOTH DELIBERATE.
+
+  * **pdfplumber** (MIT) — the default.  Small, and it is already the tool
+    `skills/authoring-who-smart-guidelines/smart-base-tools.md` depends on, so
+    it is not a new dependency for this platform so much as a second use of an
+    existing one.
+  * **camelot-py** (MIT) — preferred when installed.  Camelot **2.0** dropped
+    Ghostscript to an optional extra (`camelot-py[ghostscript]`); the base
+    install is numpy/pandas/opencv-headless/pypdfium2/playa-pdf and nothing
+    else, verified importing and extracting offline here on 2026-08-26.  Its
+    advantage over pdfplumber is not accuracy on a ruled grid — measured on the
+    two-page fixture in `scripts/tests/pdf-tables.test.py` both return
+    identical cells and identical column edges — but that it reports a
+    per-table `parsing_report.accuracy`.  That number lands in `confidence`,
+    and a consumer can weight by it.  pdfplumber offers no equivalent, so
+    `confidence` is `null` there rather than invented.
+
+STITCHING IS OURS, NOT THE BACKEND'S.  A table continuing across a page break
+is extracted by every tool as two tables, because that is what is on the two
+pages.  Rejoining them is a judgement about column geometry, and it is made
+here — over `col_edges`, which both backends report identically — so it works
+the same whichever backend ran.  Three guards, because a wrong stitch welds two
+unrelated tables into one and is worse than not stitching:
+
+  1. consecutive pages only;
+  2. same column count, every edge within `--col-tol` points;
+  3. a continuation that carries its own `Table N` caption with a *different*
+     N is a new table, and is never stitched however well its columns line up.
+
+A repeated header row on the continuation is dropped, and `stitched_from`
+records what was merged so the decision is auditable rather than invisible.
+
+WHAT IT DOES NOT DO.  It does not caption vector art it cannot name: a cluster
+of drawing primitives is emitted as `kind: "vector-cluster"` with a primitive
+count, explicitly a *candidate*, because deciding that fourteen curves are one
+figure is exactly the judgement Docling's layout model exists to make.  It does
+not read a scan.  It does not classify figures.  Those are Stage 3's, and the
+capability probe in `.claude/skills/capabilities/docling.json` is what lets a
+consumer see that Stage 3 has not run instead of guessing.
+
+Usage:
+    pdf-tables.py FILE.pdf -o uploads/<doc-id>/
+    pdf-tables.py FILE.pdf --backend camelot     # force a backend
+    pdf-tables.py FILE.pdf --no-stitch           # keep page-split tables apart
+    pdf-tables.py --check                        # which backends are present
+
+Exit codes:
+    0  artefact written (`tables` may legitimately be `[]`)
+    2  no text layer -- the tables here are pixels; use OCR or Docling
+    3  a backend was present and failed
+    4  bad usage / unreadable file
+    5  no backend installed -- artefact written as n/a, `tables` is null
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+from typing import Any, Iterable
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _pypdf_compat import import_pdfplumber  # noqa: E402
+
+SCHEMA = "pdf-tables/v1"
+
+# A page yielding fewer characters than this is treated as having no text
+# layer. Same rationale as pdf-extract.py's floor: scanned pages emit a
+# handful of stray characters from page furniture, and counting those as text
+# is how a pipeline "reads" an empty document.
+MIN_CHARS_PER_PAGE = 40
+
+# How far above/below a table or figure to look for its caption, in points.
+CAPTION_BAND_PT = 72.0
+
+# Default tolerance when comparing column edges across a page break, in points.
+# Ruled grids reproduce edges exactly; 2pt absorbs rounding without being loose
+# enough to match two genuinely different layouts.
+COL_TOL_PT = 2.0
+
+CAPTION_RE = re.compile(
+    r"^\s*(?P<kind>table|tab\.|figure|fig\.?|chart|exhibit)\s*"
+    r"(?P<num>[0-9]+(?:\.[0-9]+)*|[IVXLC]+|[A-Z](?:\.[0-9]+)?)?\s*[.:)—-]?\s*(?P<rest>.*)$",
+    re.IGNORECASE,
+)
+
+
+# ------------------------------------------------------------------ pure bits
+# Everything below this line takes plain data and returns plain data, so
+# scripts/tests/pdf-tables.test.py can exercise it with neither backend
+# installed -- which is the state CI runs in.
+
+
+def normalize_rows(rows: Iterable[Iterable[Any]]) -> list[list[str]]:
+    """Cell matrix -> rectangular matrix of clean strings.
+
+    Backends return `None` for a cell an extraction missed and embed the
+    newlines of a wrapped cell verbatim. Both reach the artefact and then the
+    Markdown, where a raw newline silently breaks the pipe table.
+    """
+    out: list[list[str]] = []
+    for row in rows:
+        out.append([re.sub(r"\s+", " ", (c or "")).strip() for c in row])
+    while out and not any(out[-1]):
+        out.pop()
+    while out and not any(out[0]):
+        out.pop(0)
+    if not out:
+        return []
+    width = max(len(r) for r in out)
+    for r in out:
+        r.extend([""] * (width - len(r)))
+    # Drop trailing columns that are empty in every row.
+    while width > 1 and all(not r[width - 1] for r in out):
+        for r in out:
+            r.pop()
+        width -= 1
+    return out
+
+
+def to_gfm(rows: list[list[str]]) -> str:
+    """Render a cell matrix as a GFM pipe table.
+
+    GFM specifically, and not CSV, because `content/pipeline/render-latex.ts`
+    already converts a GFM table node to `\\begin{tabular}` with booktabs. So a
+    table extracted here can be pasted into a content block and rendered by
+    machinery that exists, with no new converter in between.
+    """
+    if not rows:
+        return ""
+    esc = lambda c: c.replace("\\", "\\\\").replace("|", "\\|")  # noqa: E731
+    head, *body = rows
+    lines = ["| " + " | ".join(esc(c) for c in head) + " |",
+             "|" + "|".join("---" for _ in head) + "|"]
+    for r in body:
+        lines.append("| " + " | ".join(esc(c) for c in r) + " |")
+    return "\n".join(lines)
+
+
+def detect_caption(
+    lines: list[tuple[str, float, float]],
+    bbox: tuple[float, float, float, float],
+    band: float = CAPTION_BAND_PT,
+) -> tuple[str | None, str]:
+    """Find the caption for a region.
+
+    `lines` is `(text, top, bottom)` in PDF-viewer coordinates (top-down, as
+    pdfplumber reports them). `bbox` is `(x0, top, x1, bottom)`.
+
+    Below is checked before above, because that is where table and figure
+    captions overwhelmingly sit in the journal and guideline PDFs this corpus
+    is made of. A line only counts as a caption if it *starts* with a caption
+    word -- a body-text line that happens to mention "Table 3" is a reference
+    to a table, not the caption of this one.
+    """
+    x0, top, x1, bottom = bbox
+    below = [(t, tp) for (t, tp, bt) in lines if bottom <= tp <= bottom + band]
+    above = [(t, tp) for (t, tp, bt) in lines if top - band <= bt <= top]
+    for cand, where in ((sorted(below, key=lambda p: p[1]), "below"),
+                        (sorted(above, key=lambda p: -p[1]), "above")):
+        for text, _ in cand:
+            if CAPTION_RE.match(text) and text.strip():
+                return text.strip(), where
+    return None, "none"
+
+
+def caption_number(caption: str | None) -> str | None:
+    """The `N` of `Table N` — used to refuse a stitch across a caption change."""
+    if not caption:
+        return None
+    m = CAPTION_RE.match(caption)
+    if not m:
+        return None
+    num = m.group("num")
+    return num.upper() if num else None
+
+
+def columns_compatible(a: list[float], b: list[float], tol: float = COL_TOL_PT) -> bool:
+    """Do two tables share a column layout?"""
+    if not a or not b or len(a) != len(b):
+        return False
+    return all(abs(x - y) <= tol for x, y in zip(a, b))
+
+
+def looks_like_repeated_header(first: list[str], header: list[str]) -> bool:
+    """Is this continuation's first row a repeat of the header above it?"""
+    if not first or not header or len(first) != len(header):
+        return False
+    norm = lambda r: [c.strip().casefold() for c in r]  # noqa: E731
+    return norm(first) == norm(header)
+
+
+def stitch(tables: list[dict[str, Any]], tol: float = COL_TOL_PT) -> list[dict[str, Any]]:
+    """Rejoin tables split by a page break. See the module docstring's three guards."""
+    if not tables:
+        return []
+    # `_sort_y` and not `bbox[1]`: pdfplumber reports top-down coordinates and
+    # camelot bottom-up, so ordering on the raw bbox would read one of the two
+    # backends' pages upwards -- and a mis-ordered page is a mis-stitched table.
+    ordered = sorted(tables, key=lambda t: (min(t["pages"]), t.get("_sort_y", t["bbox"][1])))
+    out: list[dict[str, Any]] = []
+    # Each fragment is compared against the last table emitted, and that is
+    # sufficient rather than lazy: only the *last* table on a page can continue
+    # onto the next, because anything below it on that page would be after the
+    # continuation. So the sort above is what makes this correct, and getting
+    # the sort wrong is what makes it silently wrong.
+    for t in ordered:
+        prev = out[-1] if out else None
+        if (
+            prev is not None
+            and max(prev["pages"]) + 1 == min(t["pages"])
+            and columns_compatible(prev.get("col_edges") or [], t.get("col_edges") or [], tol)
+            # Guard 3: a continuation naming a different table is a new table.
+            and not (
+                caption_number(t.get("caption"))
+                and caption_number(prev.get("caption"))
+                and caption_number(t.get("caption")) != caption_number(prev.get("caption"))
+            )
+        ):
+            rows = list(t["rows"])
+            if rows and looks_like_repeated_header(rows[0], prev["rows"][0] if prev["rows"] else []):
+                rows = rows[1:]
+            prev["rows"] = prev["rows"] + rows
+            prev["pages"] = sorted(set(prev["pages"]) | set(t["pages"]))
+            prev["stitched_from"] = prev.get("stitched_from", [prev["id"]]) + [t["id"]]
+            prev["n_rows"] = len(prev["rows"])
+            if not prev.get("caption") and t.get("caption"):
+                prev["caption"], prev["caption_source"] = t["caption"], t["caption_source"]
+            continue
+        out.append(dict(t))
+    return out
+
+
+def cluster_boxes(
+    boxes: list[tuple[float, float, float, float]], pad: float = 6.0
+) -> list[tuple[tuple[float, float, float, float], int]]:
+    """Group overlapping (or near-touching) boxes into connected components.
+
+    Returns `(merged_bbox, n_primitives)` per component. Union-find over
+    `pad`-expanded boxes: two drawing primitives belong to the same figure when
+    their ink is adjacent, which is a weaker claim than "these form a chart"
+    and is exactly why the output is labelled a candidate.
+    """
+    n = len(boxes)
+    parent = list(range(n))
+
+    def find(i: int) -> int:
+        while parent[i] != i:
+            parent[i] = parent[parent[i]]
+            i = parent[i]
+        return i
+
+    def union(i: int, j: int) -> None:
+        ri, rj = find(i), find(j)
+        if ri != rj:
+            parent[rj] = ri
+
+    def touches(a: tuple[float, ...], b: tuple[float, ...]) -> bool:
+        return not (
+            a[2] + pad < b[0] or b[2] + pad < a[0] or a[3] + pad < b[1] or b[3] + pad < a[1]
+        )
+
+    for i in range(n):
+        for j in range(i + 1, n):
+            if touches(boxes[i], boxes[j]):
+                union(i, j)
+
+    groups: dict[int, list[int]] = {}
+    for i in range(n):
+        groups.setdefault(find(i), []).append(i)
+
+    out = []
+    for members in groups.values():
+        xs0 = min(boxes[i][0] for i in members)
+        ts = min(boxes[i][1] for i in members)
+        xs1 = max(boxes[i][2] for i in members)
+        bs = max(boxes[i][3] for i in members)
+        out.append(((xs0, ts, xs1, bs), len(members)))
+    return sorted(out, key=lambda g: (g[0][1], g[0][0]))
+
+
+def section_for_page(sections: list[dict[str, Any]], page: int) -> str | None:
+    """Which `structure.json` section contains this page."""
+    for s in sections:
+        ps, pe = s.get("page_start"), s.get("page_end")
+        if ps is None:
+            continue
+        if ps <= page <= (pe if pe is not None else ps):
+            return s.get("id")
+    return None
+
+
+# ---------------------------------------------------------------- backends
+
+
+def sha256_of(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def import_camelot():
+    """Return the camelot module, or None. Never fatal — it is the optional rung."""
+    try:
+        import camelot
+        return camelot
+    except BaseException:
+        # camelot drags numpy/opencv; a broken native wheel there raises things
+        # that are not ImportError, and this rung is optional either way.
+        return None
+
+
+def available_backends() -> dict[str, str | None]:
+    pp = import_pdfplumber()
+    cm = import_camelot()
+    return {
+        "pdfplumber": getattr(pp, "__version__", "present") if pp else None,
+        "camelot": getattr(cm, "__version__", "present") if cm else None,
+    }
+
+
+def extract_pdfplumber(
+    pdfplumber, path: str
+) -> tuple[list[dict], list[dict], dict, dict[int, dict]]:
+    """pdfplumber backend: ruled grids first, then alignment for borderless ones.
+
+    Returns the per-page line geometry as a fourth value. That is not for this
+    backend's own use -- it already has it -- but for the camelot path, which
+    models cells and never looks at page text, and so cannot caption anything
+    without borrowing this.
+    """
+    tables: list[dict] = []
+    figures: list[dict] = []
+    stats = {"pages": 0, "text_chars": 0, "pages_with_text": 0}
+    geometry: dict[int, dict] = {}
+
+    with pdfplumber.open(path) as pdf:
+        stats["pages"] = len(pdf.pages)
+        for pn, page in enumerate(pdf.pages, 1):
+            text = page.extract_text() or ""
+            stats["text_chars"] += len(text)
+            if len(text.strip()) >= MIN_CHARS_PER_PAGE:
+                stats["pages_with_text"] += 1
+
+            lines = [
+                (ln["text"], float(ln["top"]), float(ln["bottom"]))
+                for ln in page.extract_text_lines()
+            ] if hasattr(page, "extract_text_lines") else []
+            geometry[pn] = {"lines": lines, "height": float(page.height)}
+
+            found: list[Any] = []
+            for strategy, settings in (
+                ("lines", {"vertical_strategy": "lines", "horizontal_strategy": "lines"}),
+                ("text", {"vertical_strategy": "text", "horizontal_strategy": "text"}),
+            ):
+                try:
+                    ts = page.find_tables(settings)
+                except Exception:
+                    ts = []
+                for t in ts:
+                    # A `text`-strategy hit covering the same ground as a
+                    # `lines` hit is the same table found twice, and the ruled
+                    # reading is the better one. Keep the first.
+                    if any(_overlaps(t.bbox, o.bbox) for o in found):
+                        continue
+                    found.append(t)
+                    rows = normalize_rows(t.extract() or [])
+                    if not rows:
+                        continue
+                    bbox = tuple(float(v) for v in t.bbox)
+                    caption, csrc = detect_caption(lines, bbox)
+                    tables.append({
+                        "id": f"tab-p{pn:03d}-{len(tables) + 1:03d}",
+                        "pages": [pn],
+                        "bbox": [round(v, 1) for v in bbox],
+                        "bbox_origin": "top-left",
+                        "col_edges": sorted({round(float(c[0]), 1) for c in t.cells}),
+                        "n_rows": len(rows),
+                        "n_cols": len(rows[0]),
+                        "strategy": strategy,
+                        "confidence": None,   # pdfplumber reports none; see docstring
+                        "rows": rows,
+                        "caption": caption,
+                        "caption_source": csrc,
+                        "_sort_y": round(bbox[1], 1),
+                    })
+
+            for im in page.images:
+                bbox = (float(im["x0"]), float(im["top"]), float(im["x1"]), float(im["bottom"]))
+                caption, csrc = detect_caption(lines, bbox)
+                figures.append({
+                    "id": f"fig-p{pn:03d}-{len(figures) + 1:03d}",
+                    "page": pn, "bbox": [round(v, 1) for v in bbox],
+                    "bbox_origin": "top-left", "kind": "raster", "n_primitives": 1,
+                    "caption": caption, "caption_source": csrc,
+                })
+
+            prims = [
+                (float(o["x0"]), float(o["top"]), float(o["x1"]), float(o["bottom"]))
+                for o in (page.curves + page.rects)
+            ]
+            # Rules that belong to a table are not figure ink.
+            prims = [p for p in prims if not any(_overlaps(p, tuple(t["bbox"])) for t in tables
+                                                 if t["pages"] == [pn])]
+            for bbox, count in cluster_boxes(prims):
+                if count < 4 or (bbox[2] - bbox[0]) * (bbox[3] - bbox[1]) < 2000:
+                    continue
+                caption, csrc = detect_caption(lines, bbox)
+                figures.append({
+                    "id": f"fig-p{pn:03d}-{len(figures) + 1:03d}",
+                    "page": pn, "bbox": [round(v, 1) for v in bbox],
+                    "bbox_origin": "top-left", "kind": "vector-cluster", "n_primitives": count,
+                    "caption": caption, "caption_source": csrc,
+                })
+    return tables, figures, stats, geometry
+
+
+def extract_camelot(camelot, path: str) -> tuple[list[dict], dict]:
+    """camelot backend: lattice, then stream for borderless. Carries `accuracy`."""
+    tables: list[dict] = []
+    seen: list[tuple[int, tuple]] = []
+    for flavor, strategy in (("lattice", "lines"), ("stream", "text")):
+        try:
+            found = camelot.read_pdf(path, pages="all", flavor=flavor)
+        except Exception:
+            continue
+        for t in found:
+            page = int(t.page)
+            # camelot bbox is (x0, y0, x1, y1) bottom-up; convert to top-down.
+            x0, y0, x1, y1 = (float(v) for v in t._bbox)
+            bbox_bt = (x0, y0, x1, y1)
+            if any(p == page and _overlaps(bbox_bt, b) for p, b in seen):
+                continue
+            seen.append((page, bbox_bt))
+            rows = normalize_rows(t.df.values.tolist())
+            if not rows:
+                continue
+            tables.append({
+                "id": f"tab-p{page:03d}-{len(tables) + 1:03d}",
+                "pages": [page],
+                # Recorded bottom-up, as camelot reports it, and labelled so.
+                "bbox": [round(v, 1) for v in bbox_bt],
+                "bbox_origin": "bottom-left",
+                "col_edges": sorted({round(float(c[0]), 1) for c in t.cols}),
+                "n_rows": len(rows), "n_cols": len(rows[0]),
+                "strategy": strategy,
+                "confidence": round(float(t.parsing_report.get("accuracy", 0.0)), 1),
+                "rows": rows, "caption": None, "caption_source": "none",
+                "_sort_y": round(-y1, 1),
+            })
+    # camelot never walks pages it found no table on, so it cannot report page
+    # counts. `None` and not `0`: a zero here would read as a measured fact.
+    return tables, {"pages": None, "text_chars": None, "pages_with_text": None}
+
+
+def caption_camelot_tables(tables: list[dict], geometry: dict[int, dict]) -> None:
+    """Caption bottom-up camelot bboxes using pdfplumber's top-down line geometry.
+
+    The flip is `top = height - y1`, and getting it backwards does not error --
+    it silently searches the mirror-image band on the other end of the page and
+    reports "no caption", which is why the fixture asserts a caption is found.
+    """
+    for t in tables:
+        if t.get("bbox_origin") != "bottom-left":
+            continue
+        geo = geometry.get(min(t["pages"]))
+        if not geo:
+            continue
+        x0, y0, x1, y1 = t["bbox"]
+        h = geo["height"]
+        caption, csrc = detect_caption(geo["lines"], (x0, h - y1, x1, h - y0))
+        if caption:
+            t["caption"], t["caption_source"] = caption, csrc
+
+
+def _overlaps(a: tuple[float, ...], b: tuple[float, ...]) -> bool:
+    return not (a[2] <= b[0] or b[2] <= a[0] or a[3] <= b[1] or b[3] <= a[1])
+
+
+# -------------------------------------------------------------------- main
+
+
+def load_structure(outdir: str) -> tuple[str | None, list[dict]]:
+    """Read a sibling `structure.json` so tables can name the section they sit in."""
+    p = os.path.join(outdir, "structure.json")
+    if not os.path.exists(p):
+        return None, []
+    try:
+        with open(p) as fh:
+            art = json.load(fh)
+        return art.get("doc_id"), art.get("sections") or []
+    except Exception:
+        return None, []
+
+
+def build(path: str, outdir: str, backend: str, do_stitch: bool, col_tol: float) -> tuple[dict, int]:
+    avail = available_backends()
+    doc_id, sections = load_structure(outdir)
+    base: dict[str, Any] = {
+        "_schema": SCHEMA,
+        "doc_id": doc_id or os.path.splitext(os.path.basename(path))[0],
+        "source": {
+            "file": os.path.basename(path),
+            "sha256": sha256_of(path),
+            "bytes": os.path.getsize(path),
+        },
+        "producer": {"backend": None, "backend_version": None,
+                     "backends_available": {k: v for k, v in avail.items() if v}},
+    }
+
+    chosen = backend
+    if chosen == "auto":
+        chosen = "camelot" if avail["camelot"] else ("pdfplumber" if avail["pdfplumber"] else "none")
+    if chosen != "none" and not avail.get(chosen):
+        base["status"] = "n/a-no-backend"
+        base["tables"], base["figures"] = None, None
+        base["diagnostics"] = {"looked": False,
+                               "reason": f"backend '{chosen}' requested but not installed"}
+        return base, 5
+    if chosen == "none":
+        base["status"] = "n/a-no-backend"
+        base["tables"], base["figures"] = None, None
+        base["diagnostics"] = {
+            "looked": False,
+            "reason": "no table backend installed",
+            "install": "pip install pdfplumber   # or: pip install camelot-py",
+        }
+        return base, 5
+
+    base["producer"]["backend"] = chosen
+    base["producer"]["backend_version"] = avail[chosen]
+
+    if chosen == "pdfplumber":
+        pp = import_pdfplumber()
+        tables, figures, stats, _ = extract_pdfplumber(pp, path)
+    else:
+        cm = import_camelot()
+        tables, stats = extract_camelot(cm, path)
+        figures = []
+        # camelot models cells, not page ink. Figures and captions both need
+        # the pdfplumber pass; without it camelot's tables stay uncaptioned,
+        # which is recorded rather than papered over.
+        if avail["pdfplumber"]:
+            _, figures, stats, geometry = extract_pdfplumber(import_pdfplumber(), path)
+            caption_camelot_tables(tables, geometry)
+
+    # Unknown page counts (camelot with no pdfplumber alongside) cannot support
+    # a scan verdict, so none is made -- rather than defaulting to "not a scan".
+    known = stats["pages"] is not None and stats["pages_with_text"] is not None
+    scanned = bool(known and stats["pages"] > 0
+                   and stats["pages_with_text"] < stats["pages"] * 0.5)
+    if scanned and not tables:
+        base["status"] = "n/a-no-text-layer"
+        base["tables"], base["figures"] = None, None
+        base["diagnostics"] = {
+            "looked": True, "reason": "no text layer -- the tables here are pixels",
+            "pages": stats["pages"], "pages_with_text": stats["pages_with_text"],
+            "next": "scripts/pdf-ocr.py, or Docling where egress allows",
+        }
+        return base, 2
+
+    if do_stitch:
+        tables = stitch(tables, col_tol)
+
+    for t in tables:
+        t["section_id"] = section_for_page(sections, min(t["pages"])) if sections else None
+        t["markdown"] = to_gfm(t["rows"])
+        t.pop("_sort_y", None)
+    for f in figures:
+        f["section_id"] = section_for_page(sections, f["page"]) if sections else None
+
+    base["status"] = "ok"
+    base["tables"] = tables
+    base["figures"] = figures
+    base["diagnostics"] = {
+        "looked": True,
+        "pages": stats["pages"],
+        "pages_with_text": stats["pages_with_text"],
+        "likely_scanned": scanned if known else None,
+        "tables": len(tables),
+        "tables_stitched": sum(1 for t in tables if len(t.get("stitched_from", [])) > 1),
+        "tables_multipage": sum(1 for t in tables if len(t["pages"]) > 1),
+        "figures": len(figures),
+        "captioned_tables": sum(1 for t in tables if t.get("caption")),
+        "sections_source": "structure.json" if sections else "absent",
+    }
+    return base, 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(prog="pdf-tables.py", description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("pdf", nargs="?", help="the PDF to read")
+    ap.add_argument("-o", "--outdir", default=None,
+                    help="where tables.json goes (default: beside the PDF)")
+    ap.add_argument("--backend", choices=["auto", "pdfplumber", "camelot"], default="auto")
+    ap.add_argument("--no-stitch", action="store_true",
+                    help="keep page-split tables as separate tables")
+    ap.add_argument("--col-tol", type=float, default=COL_TOL_PT,
+                    help=f"column-edge tolerance in points when stitching (default {COL_TOL_PT})")
+    ap.add_argument("--json", action="store_true", help="artefact to stdout instead of a file")
+    ap.add_argument("--check", action="store_true", help="report which backends are present")
+    args = ap.parse_args()
+
+    if args.check:
+        avail = available_backends()
+        for name, ver in avail.items():
+            print(f"{name:12} {'present ' + str(ver) if ver else 'ABSENT'}")
+        if not any(avail.values()):
+            print("\nNo table backend. Install either:")
+            print("  pip install pdfplumber      # smaller; the default")
+            print("  pip install camelot-py      # adds a per-table accuracy score")
+            return 5
+        return 0
+
+    if not args.pdf:
+        ap.error("a PDF is required (or --check)")
+    if not os.path.isfile(args.pdf):
+        print(f"pdf-tables.py: not a file: {args.pdf}", file=sys.stderr)
+        return 4
+
+    outdir = args.outdir or os.path.dirname(os.path.abspath(args.pdf))
+    try:
+        artefact, rc = build(args.pdf, outdir, args.backend, not args.no_stitch, args.col_tol)
+    except Exception as exc:  # a present backend that fell over
+        print(f"pdf-tables.py: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 3
+
+    if args.json:
+        print(json.dumps(artefact, indent=2))
+    else:
+        os.makedirs(outdir, exist_ok=True)
+        dest = os.path.join(outdir, "tables.json")
+        with open(dest, "w") as fh:
+            json.dump(artefact, fh, indent=2)
+        d = artefact["diagnostics"]
+        print(f"{dest}  status={artefact['status']}", file=sys.stderr)
+        if artefact["status"] == "ok":
+            print(f"  tables={d['tables']} (multipage {d['tables_multipage']}, "
+                  f"captioned {d['captioned_tables']})  figures={d['figures']}", file=sys.stderr)
+        else:
+            print(f"  {d['reason']}", file=sys.stderr)
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/pdf-tables.test.py
+++ b/scripts/tests/pdf-tables.test.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""
+Regression test for `pdf-tables.py`'s judgement layer.
+
+The extraction itself belongs to pdfplumber or camelot and is not retested
+here. What *is* this repo's is everything decided after a backend hands back
+cells: whether two page-split fragments are one table, which line is a
+caption, how a cell matrix becomes a GFM table that
+`content/pipeline/render-latex.ts` can turn into a `tabular`. Those are the
+decisions that can be silently wrong, and a wrong one is expensive in a
+specific way — **a bad stitch welds two unrelated tables into a single
+plausible-looking one**, and nothing downstream can detect that the rows
+under a header did not come from under that header.
+
+So the cases below are the refusals as much as the successes. Every guard in
+`stitch()` has a case that would pass without it:
+
+  * consecutive pages only        -> `stitch refuses a one-page gap`
+  * column geometry must match    -> `stitch refuses different column counts`
+                                     and `... edges beyond tolerance`
+  * a differently-numbered caption
+    means a new table             -> `stitch refuses across a caption change`
+
+`reading order is not bbox[1]` is the one that guards a bug already made
+once: pdfplumber reports top-down coordinates and camelot bottom-up, so
+ordering fragments on the raw bbox reads a camelot page upwards and stitches
+the last table on a page onto the first of the next.
+
+Standalone by design — it execs the script's pure section rather than
+importing it, so it runs with neither backend installed, which is the state
+CI runs in (`code-quality-gates.yml`, "Python tests").
+
+Run: python3 scripts/tests/pdf-tables.test.py
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from typing import Any, Iterable
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCRIPT = os.path.join(os.path.dirname(HERE), "pdf-tables.py")
+
+
+def load() -> dict:
+    src = open(SCRIPT, encoding="utf-8").read()
+    start = src.index("MIN_CHARS_PER_PAGE = ")
+    end = src.index("# ---------------------------------------------------------------- backends")
+    ns: dict = {"re": re, "Any": Any, "Iterable": Iterable, "annotations": None}
+    exec(compile(src[start:end], SCRIPT, "exec"), ns)
+    return ns
+
+
+M = load()
+
+FAILED: list[str] = []
+RAN = 0
+
+
+def check(what: str, got: Any, want: Any) -> None:
+    global RAN
+    RAN += 1
+    if got == want:
+        print(f"  ok   {what}")
+    else:
+        FAILED.append(what)
+        print(f"  FAIL {what}")
+        print(f"         got:  {got!r}")
+        print(f"         want: {want!r}")
+
+
+def table(tid: str, page: int, rows: list[list[str]], edges: list[float],
+          caption: str | None = None, sort_y: float = 100.0,
+          bbox: list[float] | None = None) -> dict:
+    """A backend's output for one table.
+
+    `bbox` defaults to a top-down box agreeing with `sort_y`, which is the
+    pdfplumber shape. The reading-order case passes a bottom-up `bbox` that
+    *disagrees* with `sort_y` — that disagreement is the entire camelot
+    hazard, and a fixture where the two agree cannot detect it.
+    """
+    return {"id": tid, "pages": [page],
+            "bbox": bbox if bbox is not None else [60.0, sort_y, 552.0, sort_y + 80],
+            "col_edges": edges, "rows": rows, "n_rows": len(rows),
+            "n_cols": len(rows[0]) if rows else 0, "caption": caption,
+            "caption_source": "below" if caption else "none", "_sort_y": sort_y}
+
+
+HDR = ["Date", "Description", "Debit", "Credit"]
+P1 = [HDR, ["2026-01-01", "Payment 1", "10.00", "0.00"]]
+P2 = [HDR, ["2026-02-01", "Transfer 1", "0.00", "7.00"]]
+EDGES = [60.0, 200.0, 330.0, 450.0]
+
+
+# ------------------------------------------------------------------ cleaning
+
+# `None` is what every backend returns for a cell it could not read, and a
+# wrapped cell carries the newline that wrapped it. Both reach the Markdown,
+# where a raw newline ends the pipe row early and silently reshapes the table.
+check("normalize_rows fills None and flattens wrapped cells",
+      M["normalize_rows"]([["a", None], ["multi\nline", "b  c"]]),
+      [["a", ""], ["multi line", "b c"]])
+
+check("normalize_rows drops an all-empty trailing column",
+      M["normalize_rows"]([["a", "b", ""], ["c", "d", ""]]),
+      [["a", "b"], ["c", "d"]])
+
+check("normalize_rows drops leading and trailing blank rows",
+      M["normalize_rows"]([["", ""], ["a", "b"], [None, None]]),
+      [["a", "b"]])
+
+check("normalize_rows pads a ragged row rather than dropping its cells",
+      M["normalize_rows"]([["a", "b", "c"], ["d"]]),
+      [["a", "b", "c"], ["d", "", ""]])
+
+# A cell containing a pipe is not exotic — units and ranges use them — and an
+# unescaped one adds a column to that row only, so the table renders skewed
+# rather than failing.
+check("to_gfm escapes a pipe inside a cell",
+      M["to_gfm"]([["a|b", "c"], ["d", "e"]]).splitlines()[0],
+      "| a\\|b | c |")
+
+check("to_gfm emits the header separator GFM requires",
+      M["to_gfm"]([["a", "b"], ["c", "d"]]).splitlines()[1],
+      "|---|---|")
+
+check("to_gfm on no rows is empty, not a header of nothing",
+      M["to_gfm"]([]), "")
+
+
+# ------------------------------------------------------------------ captions
+
+LINES = [
+    ("Some body text that refers to Table 3 in passing.", 10.0, 20.0),
+    ("Table 1: Account activity.", 190.0, 200.0),
+    ("Figure 2. A chart of the above.", 400.0, 410.0),
+]
+BBOX = (60.0, 90.0, 552.0, 180.0)   # x0, top, x1, bottom
+
+check("caption is found below the table",
+      M["detect_caption"](LINES, BBOX), ("Table 1: Account activity.", "below"))
+
+# The prose line sits above the table and contains "Table 3". Matching it
+# would caption this table with a reference to a different one.
+check("a body line merely mentioning a table is not its caption",
+      M["detect_caption"]([LINES[0]], BBOX), (None, "none"))
+
+check("caption above is used when there is none below",
+      M["detect_caption"]([("Table 4: Above it.", 40.0, 50.0)], BBOX),
+      ("Table 4: Above it.", "above"))
+
+check("a caption beyond the band is not claimed",
+      M["detect_caption"]([("Table 9: Far below.", 400.0, 410.0)], BBOX),
+      (None, "none"))
+
+check("caption_number reads the numeral", M["caption_number"]("Table 12: x"), "12")
+check("caption_number on an uncaptioned table is None", M["caption_number"](None), None)
+
+
+# ------------------------------------------------------------------ geometry
+
+check("columns_compatible accepts sub-tolerance drift",
+      M["columns_compatible"]([60.0, 200.0], [61.0, 199.5], 2.0), True)
+check("columns_compatible rejects drift beyond tolerance",
+      M["columns_compatible"]([60.0, 200.0], [66.0, 200.0], 2.0), False)
+check("columns_compatible rejects a different column count",
+      M["columns_compatible"]([60.0, 200.0], [60.0, 200.0, 330.0], 2.0), False)
+check("columns_compatible rejects an empty edge list",
+      M["columns_compatible"]([], [], 2.0), False)
+
+
+# ------------------------------------------------------------------ stitching
+
+st = M["stitch"]([table("t1", 1, P1, EDGES, "Table 1: Account activity."),
+                  table("t2", 2, P2, EDGES)])
+check("stitch joins a table continued on the next page", len(st), 1)
+check("stitch drops the header repeated on the continuation",
+      st[0]["rows"], [HDR, P1[1], P2[1]])
+check("stitch records both pages", st[0]["pages"], [1, 2])
+check("stitch records what it merged", st[0]["stitched_from"], ["t1", "t2"])
+check("stitch keeps n_rows consistent with the merged rows", st[0]["n_rows"], 3)
+
+check("stitch refuses a one-page gap",
+      len(M["stitch"]([table("t1", 1, P1, EDGES), table("t2", 3, P2, EDGES)])), 2)
+
+check("stitch refuses different column counts",
+      len(M["stitch"]([table("t1", 1, P1, EDGES),
+                       table("t2", 2, [["a", "b"]], [60.0, 200.0])])), 2)
+
+check("stitch refuses column edges beyond tolerance",
+      len(M["stitch"]([table("t1", 1, P1, EDGES),
+                       table("t2", 2, P2, [90.0, 230.0, 360.0, 480.0])])), 2)
+
+# Identical geometry, but the continuation announces itself as Table 2.
+check("stitch refuses across a caption change",
+      len(M["stitch"]([table("t1", 1, P1, EDGES, "Table 1: First."),
+                       table("t2", 2, P2, EDGES, "Table 2: A different table.")])), 2)
+
+# A continuation whose first row is real data, not a repeated header, keeps it.
+st2 = M["stitch"]([table("t1", 1, P1, EDGES),
+                   table("t2", 2, [["2026-02-01", "Transfer 1", "0.00", "7.00"]], EDGES)])
+check("stitch keeps a continuation's first row when it is data",
+      st2[0]["rows"], [HDR, P1[1], ["2026-02-01", "Transfer 1", "0.00", "7.00"]])
+
+# The bug this guards: camelot reports bottom-up coordinates, so its `_sort_y`
+# is `-y1`. Two tables on page 1 — `upper` with one column layout, `lower`
+# (which runs off the bottom of the page) with another — and a continuation on
+# page 2 carrying `lower`'s layout.
+#
+# Only the *last* table on a page can continue onto the next, because nothing
+# can follow it there. So `stitch` compares a fragment against the last table
+# it emitted, and the whole question is which of `upper`/`lower` that is.
+# Ordered correctly, it is `lower`, and the stitch happens. Ordered on the raw
+# bbox, a bottom-up backend reads the page upwards, `upper` lands last, its
+# columns do not match, and the continuation is stranded as a third table.
+# Bottom-up bboxes, as camelot reports them: y0 grows *upward*, so the table
+# high on the page has the LARGER bbox[1]. `_sort_y` is -y1, which restores
+# reading order. The two disagree, which is what makes this case discriminate.
+upper = table("upper", 1, [["x", "y", "z", "w"]], [10.0, 20.0, 30.0, 40.0],
+              sort_y=-780.0, bbox=[60.0, 700.0, 552.0, 780.0])
+lower = table("lower", 1, P1, EDGES,
+              sort_y=-280.0, bbox=[60.0, 200.0, 552.0, 280.0])
+cont = table("cont", 2, P2, EDGES,
+             sort_y=-780.0, bbox=[60.0, 700.0, 552.0, 780.0])
+stitched = M["stitch"]([lower, cont, upper])
+check("reading order is not bbox[1] — a bottom-up backend still stitches right",
+      (len(stitched), [t["id"] for t in stitched], stitched[-1].get("stitched_from")),
+      (2, ["upper", "lower"], ["lower", "cont"]))
+
+check("stitch on nothing returns nothing", M["stitch"]([]), [])
+
+check("looks_like_repeated_header ignores case and padding",
+      M["looks_like_repeated_header"](["Date ", "DEBIT"], ["date", "Debit"]), True)
+check("looks_like_repeated_header rejects a different width",
+      M["looks_like_repeated_header"](["Date"], ["Date", "Debit"]), False)
+
+
+# ------------------------------------------------------------------ clusters
+
+# Two separated blobs of drawing primitives are two figure candidates, not one
+# bbox spanning the whitespace between them.
+boxes = [(10, 10, 20, 20), (18, 18, 30, 30),        # blob A (touching)
+         (400, 400, 410, 410), (405, 405, 420, 420)]  # blob B
+clusters = M["cluster_boxes"](boxes, 6.0)
+check("cluster_boxes separates two blobs", len(clusters), 2)
+check("cluster_boxes merges the bbox of a blob", clusters[0][0], (10, 10, 30, 30))
+check("cluster_boxes counts the primitives it merged", clusters[0][1], 2)
+check("cluster_boxes on nothing returns nothing", M["cluster_boxes"]([], 6.0), [])
+
+
+# ---------------------------------------------------------------- attribution
+
+SECTIONS = [{"id": "sec-001-intro", "page_start": 1, "page_end": 3},
+            {"id": "sec-002-method", "page_start": 4, "page_end": 9},
+            {"id": "sec-003-last", "page_start": 10, "page_end": None}]
+check("a table is attributed to the section containing its page",
+      M["section_for_page"](SECTIONS, 5), "sec-002-method")
+check("a section with no page_end still claims its start page",
+      M["section_for_page"](SECTIONS, 10), "sec-003-last")
+check("a page past every section is attributed to none, not to the last",
+      M["section_for_page"]([SECTIONS[0]], 99), None)
+
+
+if __name__ == "__main__":
+    print(f"\n  {RAN - len(FAILED)}/{RAN} passed")
+    sys.exit(1 if FAILED else 0)

--- a/skills/folio-paper-adapter/document-intake.md
+++ b/skills/folio-paper-adapter/document-intake.md
@@ -154,6 +154,7 @@ Two failure modes it exists to prevent, both observed in practice:
 | HTML | Readability + turndown |
 | DOCX | Pandoc → markdown |
 | Images | Claude vision API |
+| PDF (tables/figures) | `scripts/pdf-tables.py` → `tables.json` (see Stage 3) |
 
 For scanned documents the script's OCR rung fires automatically **if**
 `tesseract` and `pdftoppm` are installed (`apt-get install -y tesseract-ocr
@@ -197,8 +198,47 @@ domain-specific; record it in `intake.json.classification.normativeLevel`.
 > generic paper adapter. This skill detects the *shape* and hands off the
 > domain-specific mapping rules to the relevant adapter.
 
+#### Tables and figures — run `scripts/pdf-tables.py`
+
+Text extraction destroys tables. A GRADE evidence table or a boxed
+recommendation comes out of Stage 2 as a run of prose that reads exactly like
+prose, and nothing downstream can recover that it was a grid — which matters
+most for precisely the guideline documents this skill exists to process.
+
+```bash
+python3 scripts/pdf-tables.py FILE.pdf -o uploads/<document-id>/
+python3 scripts/pdf-tables.py --check     # which backends are installed
+```
+
+Writes `tables.json` (`pdf-tables/v1`) beside `structure.json`, with each
+table's cell matrix, column edges, caption, containing `section_id`, and a
+**GFM rendering that can be pasted straight into a content block** — the
+LaTeX pipeline already converts a GFM table to `\begin{tabular}`.
+
+Tables split across a page break are rejoined when their column geometry
+matches; `stitched_from` records what was merged, so check it on any table
+whose rows look like two tables.
+
+**Read `status` before you read `tables`.** The three ways to get no tables are
+distinguished on purpose, and `tables` is `null` — not `[]` — whenever nothing
+actually looked:
+
+| `status` | Exit | Means |
+|---|---|---|
+| `ok` | 0 | a backend looked; `tables: []` means the document has none |
+| `n/a-no-backend` | 5 | `pip install pdfplumber` (or `camelot-py`) |
+| `n/a-no-text-layer` | 2 | a scan — its tables are pixels; see Stage 2's OCR route |
+
+Needs `pdfplumber` or `camelot-py`, both pure PyPI installs with no model
+weights. **Docling is the better parser and is not this**: its weights come
+from HuggingFace, which is 403-blocked in sandboxed sessions, so it is a
+workstation/CI stage whose artefacts get committed — the
+`docling` capability probe reports it absent here rather than letting a session
+believe it ran. See `docs/proposals/rag-document-ingestion.md` §12.26.
+
 **Output**: `extracted-blocks.json` — array of detected blocks with
-provisional kinds, titles, and content.
+provisional kinds, titles, and content; `tables.json` for the layout-bearing
+parts that do not survive as text.
 
 ### Stage 4: Mapping (→ `mapped`)
 
@@ -313,6 +353,8 @@ Before marking intake complete:
 - [ ] `intake.json` has complete metadata
 - [ ] `extracted-text.md` reviewed for OCR errors
 - [ ] `extracted-blocks.json` reviewed and confirmed by user
+- [ ] `tables.json` written, `status` checked (not silently `n/a`), and any
+      `stitched_from` table spot-checked against the PDF
 - [ ] All content objects generated with correct builders
 - [ ] Blocks tagged with `["imported", "source:<document-id>"]`
 - [ ] Chapter/section structure matches document


### PR DESCRIPTION
## Why

`pdf-structure/v1`'s `Section` carries no tables, no figures and no bounding boxes — §12 of the ingestion proposal opens by naming that as the schema's central defect. A GRADE evidence table or a boxed WHO recommendation is a *layout* fact, and a text extractor flattens it into prose that reads exactly like prose; once flattened nothing downstream can recover the grid.

Docling is the better parser and is not the fix. Re-measured **2026-08-26**, eleven days after §2a:

| Host | Result |
|---|---|
| `huggingface.co` / `cdn-lfs.huggingface.co` | `CONNECT tunnel failed, response 403` |
| `arxiv.org` | blocked |
| `pypi.org` | **200** |

So `pip install docling` succeeds and the first *parse* is what fails. That keeps Docling a workstation/CI stage (§10 Stage 3). What was missing was any way to *see* that Stage 3 had not run.

## What this adds

**`scripts/pdf-tables.py`** → `pdf-tables/v1` beside `structure.json`: cell matrices, column edges, bboxes, captions and where they were found, `section_id` joined from `structure.json`, and a GFM rendering — GFM because `render-latex.ts` already converts a GFM table to a booktabs `tabular`, so an extracted table is paste-able into a content block with no new converter.

Three decisions worth review:

- **An empty `tables[]` had three unrelated meanings** (no tables / no backend / a scan), so they are three exit codes and two *types*: `[]` when a backend looked, `null` when nothing did. A consumer that forgets to check `status` still cannot read an unparsed document as an empty one — §5's *absent tool ⇒ n/a, never a false pass*.
- **Two backends.** pdfplumber is the default on footprint and because `smart-base-tools.md` already depends on it. camelot-py is preferred when present — not for accuracy (both return identical cells and column edges on the fixture) but because it reports a per-table parsing accuracy, which lands in `confidence` and can be weighted the way `toc_source` already is. The objection that would have excluded Camelot is stale: **2.0 moved Ghostscript to an optional extra**, so the base install is MIT throughout and needs no egress.
- **Stitching a multi-page table is ours, not a backend's**, because a wrong stitch welds two unrelated tables into one plausible-looking one and nothing downstream can detect it. Three guards, each with a test that fails without it: consecutive pages; matching column edges within tolerance; a continuation carrying a *different* `Table N` caption is never stitched.

**Capability probes** for `pdfplumber`, `camelot` and `docling`. The docling probe is deliberately not `import docling` alone — the package importing is not the capability. It asks whether the weights are usable: cached locally, or failing that reachable on a 5-second bound. Cache-first rather than network-first, per `capabilities.ts`'s own rule that a check that hangs is worse than one that abstains; `--check-deps` measures 0.48s.

**Docs**: proposal §12.26 and two rows in the §4.2 options table; `document-intake.md` Stage 3, its routing table and its checklist.

## Verification

1057 TS tests pass / 0 fail; `eslint`, `tsc --noEmit` and `ruff --select F401,F403` clean; 5/5 Python tests; `gen:jsonld:check`, `render:bpmn:check`, `check:workflow-policy` and `check:corpus-gate --since origin/main` all clean.

38 new test cases, standalone so they run with neither backend installed — which is CI's state. The reading-order case was **confirmed to fail when the fix is reverted** rather than passing regardless: the first version derived its bbox from its sort key so the two could not disagree, the same tautology bean `6fnb` found in five other tests, reproduced while writing a test *about* correctness.

## Known limitation, carried deliberately

**Nothing here has run against a corpus.** This repo is the platform and carries no folio, so verification is a synthetic two-page ruled table plus a text-layer-less page. §12.26 states the four numbers a corpus run would settle — lines-vs-text recall, caption miss rate, whether `COL_TOL_PT = 2.0` survives scanned rules, and vector-cluster precision — rather than leaving them to be discovered.

Bean: `folio-assistant-fj94`

---
_Generated by [Claude Code](https://claude.ai/code/session_012YdH9ZaXfMm2ncG7S1Cf18)_