### PR TITLE
chore(beans): close fj94 — table/figure rung merged as a553883

### DIFF
--- a/.beans/folio-assistant-fj94--pdf-ingestion-deterministic-tablefigure-rung-docli.md
+++ b/.beans/folio-assistant-fj94--pdf-ingestion-deterministic-tablefigure-rung-docli.md
@@ -1,11 +1,11 @@
 ---
 # folio-assistant-fj94
 title: 'PDF ingestion: deterministic table/figure rung + Docling capability probe'
-status: in-progress
+status: completed
 type: task
 priority: normal
 created_at: 2026-08-26T20:40:19Z
-updated_at: 2026-08-26T20:54:31Z
+updated_at: 2026-08-26T21:03:21Z
 ---
 
 Claimed by `claude/pdf-ingestion-pipeline-y6koyj`.
@@ -39,3 +39,7 @@ Claimed by `claude/pdf-ingestion-pipeline-y6koyj`.
   depend on a table backend or reasoning about two SHAs.
 - Not exposed as an MCP tool — the integration point is the skill, matching
   `pdf-extract.py` and `pdf-ocr.py`.
+
+
+Merged as `a553883` via PR #140 with all four CI gates green on `72c6b4d`.
+Follow-up (corpus run) is unclaimed and needs a folio repo — not carried here.


### PR DESCRIPTION
Bookkeeping follow-on to [#140](https://github.com/litlfred/folio-assistant/pull/140), which has merged.

`fj94` was committed to `.beans/` while `in-progress`, so the committed work-plan still reads `in-progress` for finished work. That is the exact signal a sibling session uses to decide an item is already claimed, so leaving it stale is worse than not having recorded it.

One file, status line and a closing note. The corpus run this work identified is deliberately **not** carried on this bean and stays unclaimed — it needs a folio repo, which the platform does not have.

Branch was restarted from `main` after #140 merged rather than stacked on the merged history.

---
_Generated by [Claude Code](https://claude.ai/code/session_012YdH9ZaXfMm2ncG7S1Cf18)_