### PR TITLE
fix: `content_validate` reported 0 errors when the pipeline never ran

### DIFF
--- a/.beans/folio-assistant-p9a2--content-validate-reports-0-errors-when-the-pipelin.md
+++ b/.beans/folio-assistant-p9a2--content-validate-reports-0-errors-when-the-pipelin.md
@@ -8,3 +8,61 @@ updated_at: 2026-08-28T20:08:28Z
 ---
 
 Found by authoring real content in folio-test. content_validate resolves validate.ts from the FOLIO's content/pipeline/, which folio_init does not create — so the spawn fails with 'Module not found', stdout is empty, the ✗/⚠ counts are 0, and the tool reports 'Validation: 0 error(s), 0 warning(s)'. A check that never looked, reporting clean.
+
+## Summary of Changes
+
+`content_validate` reported `Validation: 0 error(s), 0 warning(s)` on a
+twelve-block corpus while the pipeline had executed **no checks at all**. The
+stderr — `Module not found ".../content/pipeline/validate.ts"` — was appended
+below the headline, where nothing reads it.
+
+### Two causes
+
+**Resolution.** The tool resolved `validate.ts` from the FOLIO's
+`content/pipeline/`. That directory exists in the `qou` layout, where the
+platform was vendored inside the content repo. It does **not** exist in
+anything `folio_init` scaffolds — those carry `content/schema/` only. So the
+primary validation tool was inert for every folio the scaffolder creates, from
+the moment `fs18` landed. Now prefers the folio's own copy, so a folio that
+deliberately forked the pipeline keeps its fork, and falls back to the
+platform's.
+
+**The false pass.** Nothing distinguished "ran and found nothing" from "never
+started" — counting `✗`/`⚠` over an empty stdout gives zero either way.
+
+### The distinction that was easy to get wrong
+
+`validate.ts` **exits non-zero precisely when it finds problems**. So a
+non-zero status is a normal, informative outcome, and treating it as a failure
+to run would have suppressed every real finding — the same defect pointing the
+other way, and harder to notice. `pipelineFailedToRun` keys on non-zero **with
+no stdout at all**, plus spawn error and death-by-signal. Both directions are
+pinned by test.
+
+A pipeline that did not run now counts as an error in its own right, so the
+headline can never read 0 while a check was skipped, and it is labelled
+INCOMPLETE with the reason directly beneath.
+
+### Measured
+
+Same corpus, same folio, before and after:
+
+    before:  Validation: 0 error(s), 0 warning(s)      (nothing ran)
+    after:   Validation: 0 error(s), 2 warning(s)      (0 errors, 2 real
+             ⚠ lem:euclid-step: no Lean declaration yet
+             ⚠ thm:bezout:      no Lean declaration yet
+
+Gates: 1118 pass / 0 fail, tsc clean, eslint clean.
+
+### How it was found, and what that suggests
+
+Not by reading the code — by authoring real content in a scaffolded folio and
+noticing that a twelve-block corpus with two deliberately-unformalized
+theorems reported nothing at all. The second time this session that using the
+thing found a defect reading it had not (`content_list`'s `unknown` kinds was
+the first, bean `58h0`).
+
+Both were false *negatives* in reporting tools, and both survived because the
+output looked like success. Worth considering a sweep of the remaining tools
+that shell out to a pipeline, asking of each: what does this print if the
+thing it runs is missing?

--- a/.beans/folio-assistant-p9a2--content-validate-reports-0-errors-when-the-pipelin.md
+++ b/.beans/folio-assistant-p9a2--content-validate-reports-0-errors-when-the-pipelin.md
@@ -1,0 +1,10 @@
+---
+# folio-assistant-p9a2
+title: content_validate reports 0 errors when the pipeline never ran
+status: in-progress
+type: bug
+created_at: 2026-08-28T20:08:28Z
+updated_at: 2026-08-28T20:08:28Z
+---
+
+Found by authoring real content in folio-test. content_validate resolves validate.ts from the FOLIO's content/pipeline/, which folio_init does not create — so the spawn fails with 'Module not found', stdout is empty, the ✗/⚠ counts are 0, and the tool reports 'Validation: 0 error(s), 0 warning(s)'. A check that never looked, reporting clean.

--- a/adapters/document/tools/validate.ts
+++ b/adapters/document/tools/validate.ts
@@ -11,9 +11,9 @@
  */
 
 import { z } from "zod";
-import { spawnSync } from "child_process";
+import { spawnSync, type SpawnSyncReturns } from "child_process";
 import { existsSync, readdirSync } from "fs";
-import { join, basename } from "path";
+import { join, basename, resolve } from "path";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { REPO_ROOT, CONTENT_DIR } from "../paths.js";
 import { checkFolioProfile, formatProfileCheck } from "../../../content/pipeline/profile-check.js";
@@ -46,6 +46,51 @@ function findChapterDirs(paperDir: string): string[] {
   return readdirSync(paperDir, { withFileTypes: true })
     .filter(d => d.isDirectory())
     .map(d => d.name);
+}
+
+/**
+ * Where the validation pipeline lives, or `undefined` if it is nowhere.
+ *
+ * Two layouts are in the wild and both are legitimate:
+ *
+ * - the folio carries its own `content/pipeline/` (the `qou` layout, from
+ *   when the platform was vendored inside the content repo), and
+ * - the folio carries only `content/schema/` and reaches the pipeline in the
+ *   platform checkout — which is what `folio_init` scaffolds.
+ *
+ * The folio's own copy wins when present, so a folio that has deliberately
+ * forked the pipeline keeps its fork. Resolving ONLY to the folio's copy is
+ * what made this tool report a clean bill of health on every scaffolded folio
+ * — see {@link runValidatePipeline}.
+ */
+export function resolveValidateScript(): string | undefined {
+  const inFolio = join(CONTENT_DIR, "pipeline", "validate.ts");
+  if (existsSync(inFolio)) return inFolio;
+  // `adapters/document/tools/` -> platform root.
+  const inPlatform = resolve(import.meta.dir, "..", "..", "..", "content", "pipeline", "validate.ts");
+  return existsSync(inPlatform) ? inPlatform : undefined;
+}
+
+/**
+ * Did the pipeline actually run, or did it fail to start?
+ *
+ * The distinction is the whole point of this function. `validate.ts` exits
+ * non-zero when it FINDS problems, so a non-zero status alone is a normal,
+ * informative outcome. What is not normal is exiting non-zero having printed
+ * nothing to stdout: that is the shape of a module-not-found, a syntax error,
+ * or a missing runtime — the pipeline never reached a single check.
+ *
+ * Before this, the caller counted `✗` and `⚠` in an empty stdout, got zero of
+ * each, and reported "Validation: 0 error(s), 0 warning(s)". The stderr was
+ * appended far below the headline. Every folio `folio_init` scaffolds hit
+ * exactly that path, because none of them has `content/pipeline/`.
+ *
+ * "Absent tool ⇒ n/a, never a false pass" is the rule this restores.
+ */
+export function pipelineFailedToRun(r: SpawnSyncReturns<Buffer>, stdout: string): boolean {
+  if (r.error) return true;              // spawn itself failed (no `bun`, timeout)
+  if (r.status === null) return true;    // killed by signal / timed out
+  return r.status !== 0 && stdout.trim() === "";
 }
 
 export function registerValidateTools(server: McpServer): void {
@@ -85,44 +130,51 @@ export function registerValidateTools(server: McpServer): void {
         const results: string[] = [];
         let totalErrors = 0;
         let totalWarnings = 0;
+        /** Set when the pipeline could not be run at all — never a clean report. */
+        let pipelineError: string | undefined;
 
-        if (chapter) {
-          // Validate a single chapter dir
-          const chapterPath = join(paperDir, chapter);
-          if (!existsSync(chapterPath)) {
-            return {
-              content: [{ type: "text" as const, text: `Chapter not found: ${chapterPath}` }],
-            };
-          }
-          const result = spawnSync("bun", [
-            "run", join(CONTENT_DIR, "pipeline/validate.ts"),
-            chapterPath,
-          ], {
-            cwd: CONTENT_DIR,
-            stdio: "pipe",
-            timeout: 60_000,
-          });
-          const output = result.stdout?.toString() || "";
-          const stderr = result.stderr?.toString() || "";
-          results.push(`## ${chapter}\n${output}${stderr ? `\nStderr: ${stderr}` : ""}`);
-          totalErrors += (output.match(/✗/g) || []).length;
-          totalWarnings += (output.match(/⚠/g) || []).length;
-        } else {
-          // Validate whole paper (paper manifest + all chapters)
-          const result = spawnSync("bun", [
-            "run", join(CONTENT_DIR, "pipeline/validate.ts"),
-            paperDir,
-          ], {
-            cwd: CONTENT_DIR,
-            stdio: "pipe",
-            timeout: 120_000,
-          });
-          const output = result.stdout?.toString() || "";
-          const stderr = result.stderr?.toString() || "";
-          results.push(output + (stderr ? `\nStderr: ${stderr}` : ""));
-          totalErrors += (output.match(/✗/g) || []).length;
-          totalWarnings += (output.match(/⚠/g) || []).length;
+        const script = resolveValidateScript();
+        if (chapter && !existsSync(join(paperDir, chapter))) {
+          return {
+            content: [{ type: "text" as const, text: `Chapter not found: ${join(paperDir, chapter)}` }],
+          };
         }
+
+        if (!script) {
+          // Reported as an error, not as a clean run with a footnote. A folio
+          // whose schema and constraint checks did not execute has not been
+          // validated, whatever the block-level checks below say.
+          pipelineError =
+            "Could not locate `content/pipeline/validate.ts` in either this folio " +
+            `(${join(CONTENT_DIR, "pipeline")}) or the platform checkout. ` +
+            "Schema and constraint validation DID NOT RUN.";
+        } else {
+          const target = chapter ? join(paperDir, chapter) : paperDir;
+          const result = spawnSync("bun", ["run", script, target], {
+            cwd: CONTENT_DIR,
+            stdio: "pipe",
+            timeout: chapter ? 60_000 : 120_000,
+          });
+          const output = result.stdout?.toString() || "";
+          const stderr = result.stderr?.toString() || "";
+
+          if (pipelineFailedToRun(result, output)) {
+            pipelineError =
+              `\`${script}\` failed to run (exit ${result.status ?? "signal"}). ` +
+              "Schema and constraint validation DID NOT RUN.\n" +
+              (result.error ? `${result.error.message}\n` : "") +
+              (stderr.trim() ? stderr.trim() : "(no stderr)");
+          } else {
+            const header = chapter ? `## ${chapter}\n` : "";
+            results.push(`${header}${output}${stderr ? `\nStderr: ${stderr}` : ""}`);
+            totalErrors += (output.match(/✗/g) || []).length;
+            totalWarnings += (output.match(/⚠/g) || []).length;
+          }
+        }
+
+        // A pipeline that did not run counts as an error in its own right, so
+        // the headline number can never read 0 while a check was skipped.
+        if (pipelineError) totalErrors += 1;
 
         // Profile conformance runs on every validate rather than as an
         // opt-in tool. It is the one check that knows what *kind* of folio
@@ -132,11 +184,17 @@ export function registerValidateTools(server: McpServer): void {
         const profileResult = checkFolioProfile(REPO_ROOT, paperDir);
         totalErrors += profileResult.violations.length;
 
+        const banner = pipelineError
+          ? `\n\n## ⚠ Pipeline did not run\n\n${pipelineError}\n`
+          : "";
+
         return {
           content: [{
             type: "text" as const,
-            text: `Validation: ${totalErrors} error(s), ${totalWarnings} warning(s)\n\n` +
-              results.join("\n\n") +
+            text: `Validation: ${totalErrors} error(s), ${totalWarnings} warning(s)` +
+              (pipelineError ? " — INCOMPLETE, see below" : "") +
+              banner +
+              (results.length ? `\n\n${results.join("\n\n")}` : "") +
               `\n\n## Profile conformance\n\n${formatProfileCheck(profileResult)}`,
           }],
         };

--- a/scripts/tests/validate-pipeline-guard.test.ts
+++ b/scripts/tests/validate-pipeline-guard.test.ts
@@ -1,0 +1,83 @@
+/**
+ * `content_validate` must never report a clean run when the pipeline did not
+ * run at all.
+ *
+ * The defect this guards against, found by authoring real content in a
+ * scaffolded folio: the tool resolved `validate.ts` from the FOLIO's
+ * `content/pipeline/`, which `folio_init` does not create. The spawn failed
+ * with "Module not found", stdout came back empty, the `✗`/`⚠` counts over
+ * that empty string were both zero, and the headline read
+ *
+ *     Validation: 0 error(s), 0 warning(s)
+ *
+ * with the stderr appended far below it. Every scaffolded folio took exactly
+ * that path — the primary validation tool reporting a clean bill of health
+ * having executed no checks.
+ */
+import { describe, test, expect } from "bun:test";
+import type { SpawnSyncReturns } from "child_process";
+import { existsSync } from "fs";
+
+import {
+  resolveValidateScript,
+  pipelineFailedToRun,
+} from "../../adapters/document/tools/validate";
+
+/** A `spawnSync` result with only the fields the guard reads. */
+function spawnResult(over: Partial<SpawnSyncReturns<Buffer>>): SpawnSyncReturns<Buffer> {
+  return {
+    pid: 1,
+    output: [],
+    stdout: Buffer.from(""),
+    stderr: Buffer.from(""),
+    status: 0,
+    signal: null,
+    ...over,
+  } as SpawnSyncReturns<Buffer>;
+}
+
+describe("pipelineFailedToRun", () => {
+  test("non-zero exit with NO stdout is a failure to run", () => {
+    // The reproduction: `bun run <missing>.ts` exits 1 having printed nothing.
+    expect(pipelineFailedToRun(spawnResult({ status: 1 }), "")).toBe(true);
+  });
+
+  test("non-zero exit WITH findings on stdout is a normal outcome", () => {
+    // `validate.ts` exits non-zero when it finds problems. Treating that as a
+    // failure to run would suppress every real finding the tool exists for —
+    // the opposite error, and just as bad.
+    expect(pipelineFailedToRun(spawnResult({ status: 1 }), "✗ def:x missing .lean\n")).toBe(false);
+  });
+
+  test("a clean run is not a failure", () => {
+    expect(pipelineFailedToRun(spawnResult({ status: 0 }), "all checks passed\n")).toBe(false);
+  });
+
+  test("spawn error (no `bun` on PATH) is a failure to run", () => {
+    expect(pipelineFailedToRun(spawnResult({ error: new Error("ENOENT") }), "")).toBe(true);
+  });
+
+  test("killed by signal / timeout is a failure to run, even with partial stdout", () => {
+    // A timed-out pipeline may have printed some checks before dying; those
+    // are not a verdict on the whole corpus.
+    expect(pipelineFailedToRun(spawnResult({ status: null, signal: "SIGTERM" }), "some output")).toBe(true);
+  });
+
+  test("a clean run that printed nothing is NOT a failure", () => {
+    // Exit 0 is the pipeline's own word that it finished.
+    expect(pipelineFailedToRun(spawnResult({ status: 0 }), "")).toBe(false);
+  });
+});
+
+describe("resolveValidateScript", () => {
+  test("finds a pipeline — here, the platform's own copy", () => {
+    // This test runs with the platform as the repo root, which carries
+    // content/pipeline/validate.ts. The scaffolded-folio case (no
+    // content/pipeline/ at all) resolves to the platform's copy by the same
+    // fallback, which is the fix.
+    const script = resolveValidateScript();
+    expect(script).toBeDefined();
+    expect(existsSync(script!)).toBe(true);
+    expect(script!.endsWith("content/pipeline/validate.ts")).toBe(true);
+  });
+});


### PR DESCRIPTION
Found by authoring real content in a scaffolded folio, not by reading the code.

A twelve-block corpus — including two theorems deliberately left unformalized — came back as:

```
Validation: 0 error(s), 0 warning(s)

Stderr: error: Module not found "/home/user/folio-test/content/pipeline/validate.ts"
```

The pipeline had executed **no checks at all**. The stderr sat below the headline, where nothing reads it.

## Two causes

**Resolution.** The tool resolved `validate.ts` from the **folio's** `content/pipeline/`. That directory exists in the `qou` layout, where the platform was vendored inside the content repo. It does **not** exist in anything `folio_init` scaffolds — those carry `content/schema/` only.

So the primary validation tool has been inert for every folio the scaffolder creates, since the moment `folio_init` landed in #142. It now prefers the folio's own copy — a folio that deliberately forked the pipeline keeps its fork — and falls back to the platform's.

**The false pass.** Nothing distinguished *"ran and found nothing"* from *"never started"*. The tool counts `✗` and `⚠` in stdout; over an empty stdout that is zero of each, either way.

## The distinction that was easy to get wrong

`validate.ts` **exits non-zero precisely when it finds problems.** So a non-zero status is a normal, informative outcome — and treating it as a failure to run would suppress every real finding the tool exists for. That is the same defect pointing the other way, and harder to notice because the output would still look plausible.

`pipelineFailedToRun` therefore keys on non-zero **with no stdout at all**, plus spawn error and death-by-signal. Both directions are pinned by test, including the partial-output timeout case.

A pipeline that did not run now counts as an error in its own right, so the headline can never read 0 while a check was skipped, and it is labelled `INCOMPLETE` with the reason directly beneath rather than in a trailing footnote.

This is the rule the repo already states for absent toolchains — *"absent tool ⇒ n/a, never a false pass"* — applied to the tool that most needed it.

## Measured

Same corpus, same folio, before and after:

| | Result |
|---|---|
| before | `Validation: 0 error(s), 0 warning(s)` — nothing ran |
| after | `Validation: 0 error(s), 2 warning(s)` — 0 real errors, and the two true warnings: `lem:euclid-step` and `thm:bezout` have no Lean declaration |

## Verification

| Gate | Result |
|---|---|
| `bun test` | 1118 pass · 0 fail |
| `tsc --noEmit` | clean |
| `eslint .` | clean |

Seven new tests cover the guard in both directions.

## A pattern worth noting

This is the second defect this session found by *using* the platform rather than reading it — [`content_list` reporting every block as `unknown`](https://github.com/litlfred/folio-assistant/pull/142) was the first.

Both were false negatives in reporting tools, and both survived review because the output looked like success. A sweep of the remaining tools that shell out to a pipeline, asking of each *"what does this print if the thing it runs is missing?"*, would likely find more. Recorded in bean `p9a2`; not done here, to keep this fix minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01US4dUcUDmKXzYVawMPZeV2

---
_Generated by [Claude Code](https://claude.ai/code/session_01US4dUcUDmKXzYVawMPZeV2)_