### PR TITLE
fix(pipeline): the whole QA/audit surface was inert on scaffolded folios

### DIFF
--- a/.beans/folio-assistant-e1f6--sweep-every-tool-that-shells-out-does-it-work-on-a.md
+++ b/.beans/folio-assistant-e1f6--sweep-every-tool-that-shells-out-does-it-work-on-a.md
@@ -1,0 +1,84 @@
+---
+# folio-assistant-e1f6
+title: 'Sweep: every tool that shells out — does it work on a scaffolded folio, and what does it print when its dependency is missing?'
+status: in-progress
+type: task
+created_at: 2026-08-29T02:41:13Z
+updated_at: 2026-08-29T02:41:13Z
+---
+
+Follow-on from p9a2. Two properties per tool: (a) honest reporting when the dependency is absent, (b) actually functional on a folio_init layout.
+
+## Summary of Changes
+
+Follow-on from `p9a2`, which fixed one false pass and suggested asking the same
+question of every tool that shells out. Two properties checked per tool:
+
+- **(a) honest reporting** when the dependency is absent, and
+- **(b) actually functional** on a `folio_init` layout.
+
+### (a) came back clean
+
+`runPipeline` already guards the missing-script case and `asToolText` renders
+it as `⚠️ <error>`. `beans-prime` handles a missing `.beans/`. `check-deps` and
+the capability probes report absence. The render tools probe with `hasCommand`
+before spawning. **`content_validate` was the only false pass**, and `p9a2`
+fixed it. That is a better result than the 2-of-2 base rate suggested.
+
+### (b) was where the damage was
+
+`pipelineScriptPath` resolved `content/pipeline/<script>.ts` against the FOLIO
+only — the `qou` layout, where the platform was vendored into the content repo.
+Nothing `folio_init` scaffolds has that directory. So **the entire QA, audit,
+bibliography and transform surface returned `pipeline script not found`** on
+every scaffolded folio.
+
+Honest, unlike `p9a2`'s defect. Still completely inert.
+
+Measured on folio-test, before → after:
+
+    qa_staleness            script not found  →  exit 2   (its own verdict)
+    section_title_audit     script not found  →  ok
+    defterm_validate        script not found  →  ok
+    value_validate          script not found  →  ok
+    glossary_candidates     script not found  →  exit 2
+    wiring_audit            script not found  →  ok, real report over 12 blocks
+    status_sections_audit   script not found  →  ok
+    prune_deps              script not found  →  ok
+    glossary_check          script not found  →  exit 1
+    content_export          script not found  →  ok, 14.5 KB written
+    qa_sweep                script not found  →  ok, real criteria JSON
+
+The non-zero exits are the scripts' own findings, not resolution failures —
+the distinction `p9a2` built into `pipelineFailedToRun`.
+
+`resolveValidateScript` now delegates to the shared `resolvePipelineScript`;
+they were separate copies of the same fallback for exactly one commit, and a
+test pins their agreement.
+
+### A third defect, found while verifying the second
+
+`content_export` resolved, ran, and **exited 1**. Cause: `references` and
+`referenceMap` are Proxies over an injected registry, so *touching* either
+throws when a folio has not configured one — and the paper-level `references`
+field is assembled last, so the export did all its work and then died.
+
+A folio with no bibliography is the normal case, not an edge one: a new folio
+has no references and `folio_init` scaffolds none.
+
+`validate.ts` already had the right shape — ask `referenceRegistryConfigured()`
+rather than catch, so "this folio has no bibliography" stays distinguishable
+from "the lookup failed". Applied that to both touch points in `export-json`
+(guarding only the one that threw first would have moved the crash to the other
+on any folio whose blocks carry `cites[]`), and it now says what it did not
+resolve rather than exporting an empty list silently.
+
+### Not done
+
+The bibliography tools (`bib_qa`, `bib_validate`, `references_validate`) were
+not exercised — they reach the network and the batch timed out. They go through
+`runPipeline`, so they get the resolution fix; whether they behave sensibly
+against an empty registry is unverified. Worth a follow-up if a folio starts
+carrying references.
+
+Gates: 1181 pass / 0 fail, tsc clean, eslint clean.

--- a/adapters/document/tools/_pipeline.ts
+++ b/adapters/document/tools/_pipeline.ts
@@ -13,7 +13,7 @@
 
 import { spawnSync } from "child_process";
 import { existsSync, readdirSync } from "fs";
-import { join } from "path";
+import { join, resolve } from "path";
 import { get } from "../paths.js";
 
 export interface PipelineResult {
@@ -29,7 +29,53 @@ export interface PipelineResult {
   error?: string;
 }
 
-/** Absolute path to a `content/pipeline/<script>.ts` file. */
+/**
+ * The platform's own `content/pipeline/`.
+ *
+ * `adapters/document/tools/` -> platform root. Computed rather than passed so
+ * that a tool never has to know where it is installed.
+ */
+function platformPipelineDir(): string {
+  return resolve(import.meta.dir, "..", "..", "..", "content", "pipeline");
+}
+
+/**
+ * Absolute path to a `content/pipeline/<script>.ts` file, or `undefined` when
+ * neither the folio nor the platform has one.
+ *
+ * Two layouts are in the wild and both are legitimate:
+ *
+ * - the folio carries its own `content/pipeline/` — the `qou` layout, from
+ *   when the platform was vendored inside the content repo; and
+ * - the folio carries only `content/schema/` and reaches the pipeline in the
+ *   platform checkout, which is what `folio_init` scaffolds.
+ *
+ * Resolving ONLY against the folio meant every pipeline-backed tool — around
+ * twenty-five of them, the whole QA, audit, bibliography and transform surface
+ * — returned `pipeline script not found` on every scaffolded folio. That was
+ * at least honest (see {@link runPipeline}), unlike the same defect in
+ * `content_validate`, which reported a clean run; but honest and inert is
+ * still inert.
+ *
+ * The folio's own copy wins when present, so a folio that has deliberately
+ * forked a pipeline script keeps its fork.
+ */
+export function resolvePipelineScript(script: string): string | undefined {
+  const name = script.endsWith(".ts") ? script : `${script}.ts`;
+  const inFolio = join(get.REPO_ROOT(), "content", "pipeline", name);
+  if (existsSync(inFolio)) return inFolio;
+  const inPlatform = join(platformPipelineDir(), name);
+  return existsSync(inPlatform) ? inPlatform : undefined;
+}
+
+/**
+ * Absolute path to the folio's `content/pipeline/<script>.ts`.
+ *
+ * @deprecated Prefer {@link resolvePipelineScript}, which also finds the
+ * platform's copy. Kept because it is exported and says something true — where
+ * the script would live *in this folio* — but it must not be used to decide
+ * whether a script exists.
+ */
 export function pipelineScriptPath(script: string): string {
   const name = script.endsWith(".ts") ? script : `${script}.ts`;
   return join(get.REPO_ROOT(), "content", "pipeline", name);
@@ -60,15 +106,17 @@ export function runPipeline(
   args: string[] = [],
   opts: { timeoutMs?: number } = {},
 ): PipelineResult {
-  const path = pipelineScriptPath(script);
-  if (!existsSync(path)) {
+  const path = resolvePipelineScript(script);
+  if (!path) {
     return {
       ok: false,
       script,
       exitCode: null,
       stdout: "",
       stderr: "",
-      error: `pipeline script not found: content/pipeline/${script}.ts`,
+      error:
+        `pipeline script not found: content/pipeline/${script}.ts — ` +
+        `looked in this folio and in the platform checkout`,
     };
   }
   const res = spawnSync("bun", ["run", path, ...args], {

--- a/adapters/document/tools/validate.ts
+++ b/adapters/document/tools/validate.ts
@@ -13,7 +13,7 @@
 import { z } from "zod";
 import { spawnSync, type SpawnSyncReturns } from "child_process";
 import { existsSync, readdirSync } from "fs";
-import { join, basename, resolve } from "path";
+import { join, basename } from "path";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { REPO_ROOT, CONTENT_DIR } from "../paths.js";
 import { checkFolioProfile, formatProfileCheck } from "../../../content/pipeline/profile-check.js";
@@ -21,6 +21,7 @@ import {
   readBlockManifest,
   readUnlabelledBlockManifest,
 } from "../../../content/pipeline/qa-utils.js";
+import { resolvePipelineScript } from "./_pipeline.js";
 // Note: paths are resolved from the document adapter's paths module.
 
 /** Find all paper directories under content/. */
@@ -64,11 +65,10 @@ function findChapterDirs(paperDir: string): string[] {
  * — see {@link runValidatePipeline}.
  */
 export function resolveValidateScript(): string | undefined {
-  const inFolio = join(CONTENT_DIR, "pipeline", "validate.ts");
-  if (existsSync(inFolio)) return inFolio;
-  // `adapters/document/tools/` -> platform root.
-  const inPlatform = resolve(import.meta.dir, "..", "..", "..", "content", "pipeline", "validate.ts");
-  return existsSync(inPlatform) ? inPlatform : undefined;
+  // Delegates to the shared resolver so this and every `runPipeline` tool
+  // cannot drift on which layouts they support. They had separate copies of
+  // this logic for exactly one commit, which is one too many.
+  return resolvePipelineScript("validate");
 }
 
 /**

--- a/content/pipeline/export-json.ts
+++ b/content/pipeline/export-json.ts
@@ -28,7 +28,11 @@ import type {
   LeanRef,
 } from "../../schemas/types";
 import type { Data as CSLData } from "csl-json";
-import { references, referenceMap } from "./references-registry-di";
+import {
+  references,
+  referenceMap,
+  referenceRegistryConfigured,
+} from "./references-registry-di";
 import { findContentRepoRoot, findPapers, soleFolioPaper } from "./repo-root";
 import { mergeCitations } from "./citations";
 import { isWitnessed } from "../../scripts/lean-witness";
@@ -306,10 +310,17 @@ async function main() {
         if (b.cites) for (const key of b.cites) chapterCiteKeys.add(key);
       }
     }
-    const bibliography = [...chapterCiteKeys]
-      .sort()
-      .map(key => referenceMap.get(key))
-      .filter((r): r is CSLData => r !== undefined);
+    // Guarded for the same reason as the paper-level `references` below:
+    // `referenceMap` is a Proxy over the injected registry and throws when
+    // none is configured. A block may legitimately carry `cites[]` in a folio
+    // that has not wired a bibliography yet — those keys simply resolve to
+    // nothing, which is what `.filter` already handles.
+    const bibliography = referenceRegistryConfigured()
+      ? [...chapterCiteKeys]
+          .sort()
+          .map((key) => referenceMap.get(key))
+          .filter((r): r is CSLData => r !== undefined)
+      : [];
 
     chapters.push({
       number: ch.number,
@@ -326,7 +337,17 @@ async function main() {
     authors: paper.authors,
     date: paper.date,
     chapters,
-    references,
+    // A folio with no bibliography is a normal folio — a new one has no
+    // references yet, and `folio_init` scaffolds none. `references` is a Proxy
+    // over the injected registry, so touching it at all THROWS when none is
+    // configured, and the export died on the last field it assembles after
+    // doing all the work.
+    //
+    // `validate.ts` already had the right shape for this: ask
+    // `referenceRegistryConfigured()` rather than catch, so "this folio has no
+    // bibliography" stays distinguishable from "the lookup failed". Export an
+    // empty list and say so, rather than refusing to export the document.
+    references: referenceRegistryConfigured() ? references : [],
     macros: paper.macros,
     meta: paper.meta,
     _built: new Date().toISOString(),
@@ -338,6 +359,13 @@ async function main() {
     .slice(0, 12);
 
   const exported: ExportedPaper = { ...result, _hash: hash };
+
+  if (!referenceRegistryConfigured()) {
+    console.log(
+      "  ℹ no reference registry configured — exported with an empty " +
+        "`references` list; cites[] were NOT resolved",
+    );
+  }
 
   const json = JSON.stringify(exported, null, 2);
 

--- a/scripts/tests/export-json-no-registry.test.ts
+++ b/scripts/tests/export-json-no-registry.test.ts
@@ -1,0 +1,48 @@
+/**
+ * `export-json` must export a folio that has no bibliography.
+ *
+ * `references` and `referenceMap` are Proxies over an injected registry, so
+ * *touching* either throws when a folio has not configured one. `export-json`
+ * touched both — once per chapter for the bibliography, and once for the
+ * paper-level `references` field, which is assembled last. So the export did
+ * all its work and then died on the final field, on any folio without a
+ * bibliography. `folio_init` scaffolds none, and a new folio has no references
+ * yet, so that is the normal case rather than an edge one.
+ *
+ * `validate.ts` already had the right shape: ask `referenceRegistryConfigured()`
+ * rather than catch, so "this folio has no bibliography" stays distinguishable
+ * from "the lookup failed".
+ */
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const SRC = join(import.meta.dir, "../../content/pipeline/export-json.ts");
+
+describe("export-json guards every registry touch", () => {
+  const src = readFileSync(SRC, "utf-8");
+
+  test("asks whether a registry is configured rather than catching", () => {
+    expect(src).toContain("referenceRegistryConfigured");
+    // A try/catch around the Proxy would also "work" and would lose the
+    // distinction the predicate exists to preserve.
+    expect(src).not.toMatch(/catch[\s\S]{0,80}referenceMap/);
+  });
+
+  test("the paper-level `references` field is guarded", () => {
+    expect(src).toMatch(/references:\s*referenceRegistryConfigured\(\)\s*\?\s*references\s*:\s*\[\]/);
+  });
+
+  test("the per-chapter bibliography is guarded too", () => {
+    // Both touches matter: guarding only the field that threw first would move
+    // the crash to the other one on any folio whose blocks carry `cites[]`.
+    const bibBlock = src.slice(src.indexOf("const bibliography"), src.indexOf("chapters.push"));
+    expect(bibBlock).toContain("referenceRegistryConfigured()");
+    expect(bibBlock).toContain("referenceMap.get");
+  });
+
+  test("says so in the output rather than exporting an empty list silently", () => {
+    expect(src).toContain("no reference registry configured");
+    expect(src).toContain("cites[] were NOT resolved");
+  });
+});

--- a/scripts/tests/pipeline-resolution.test.ts
+++ b/scripts/tests/pipeline-resolution.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Pipeline scripts must be findable from a folio that does not vendor them.
+ *
+ * `runPipeline` resolved `content/pipeline/<script>.ts` against the FOLIO
+ * only. That directory exists in the `qou` layout, where the platform was
+ * vendored inside the content repo, and does not exist in anything
+ * `folio_init` scaffolds. So roughly twenty-five tools — the whole QA, audit,
+ * bibliography and transform surface — returned `pipeline script not found` on
+ * every scaffolded folio.
+ *
+ * Unlike the sibling defect in `content_validate` (which reported a clean run
+ * having executed nothing), this one was at least honest. But honest and inert
+ * is still inert, and the fix is the same fallback.
+ */
+import { describe, test, expect } from "bun:test";
+import { existsSync } from "fs";
+import { basename } from "path";
+
+import {
+  resolvePipelineScript,
+  runPipeline,
+} from "../../adapters/document/tools/_pipeline";
+import { resolveValidateScript } from "../../adapters/document/tools/validate";
+
+describe("resolvePipelineScript", () => {
+  test("finds a script the platform carries", () => {
+    const p = resolvePipelineScript("qa-sweep");
+    expect(p).toBeDefined();
+    expect(existsSync(p!)).toBe(true);
+    expect(basename(p!)).toBe("qa-sweep.ts");
+  });
+
+  test("accepts a name with or without the .ts suffix", () => {
+    expect(resolvePipelineScript("qa-sweep")).toBe(resolvePipelineScript("qa-sweep.ts"));
+  });
+
+  test("returns undefined — not a bogus path — for a script nobody has", () => {
+    // The caller decides what absence means. Handing back a path that does not
+    // exist is how `runPipeline` would spawn `bun run <missing>` and surface a
+    // module-not-found instead of a clear "no such script".
+    expect(resolvePipelineScript("no-such-pipeline-script-anywhere")).toBeUndefined();
+  });
+});
+
+describe("runPipeline on a missing script", () => {
+  test("reports absence explicitly, and never as a successful run", () => {
+    const r = runPipeline("no-such-pipeline-script-anywhere");
+    expect(r.ok).toBe(false);
+    expect(r.error).toBeDefined();
+    // The message must say BOTH places were checked, or the reader's next move
+    // is to go create the file in the folio — which is not the fix.
+    expect(r.error).toContain("folio");
+    expect(r.error).toContain("platform");
+  });
+});
+
+describe("content_validate shares the resolver", () => {
+  test("resolveValidateScript agrees with resolvePipelineScript('validate')", () => {
+    // These were separate copies of the same fallback for exactly one commit.
+    // Pinning the agreement is cheaper than noticing the day they diverge.
+    expect(resolveValidateScript()).toBe(resolvePipelineScript("validate"));
+  });
+});


### PR DESCRIPTION
The sweep #143 suggested. Two questions, asked of every tool that shells out:

1. **What does it print when the thing it runs is missing?** (false-pass check)
2. **Does it actually work on a `folio_init` layout?** (resolution check)

## Question 1 came back clean

Better than the 2-of-2 base rate suggested. `runPipeline` already guards the missing-script case and `asToolText` renders it as `⚠️ <error>`; `beans-prime` handles a missing `.beans/`; `check-deps` and the capability probes report absence; the render tools probe with `hasCommand` before spawning. `content_validate` was the only false pass, and #143 fixed it.

Worth stating plainly, since I predicted more would turn up.

## Question 2 is where the damage was

`pipelineScriptPath` resolved `content/pipeline/<script>.ts` against the **folio** only — the `qou` layout, where the platform was vendored into the content repo. Nothing `folio_init` scaffolds has that directory.

So the **entire QA, audit, bibliography and transform surface** returned `pipeline script not found` on every scaffolded folio. Honest, unlike #143's defect — and still completely inert.

Measured on `litlfred/folio-test`, before → after:

| Tool | before | after |
|---|---|---|
| `qa_sweep` | script not found | ok — real criteria JSON |
| `wiring_audit` | script not found | ok — real report over 12 blocks |
| `content_export` | script not found | ok — 14.5 KB written |
| `defterm_validate` | script not found | ok |
| `value_validate` | script not found | ok |
| `section_title_audit` | script not found | ok |
| `status_sections_audit` | script not found | ok |
| `prune_deps` | script not found | ok |
| `qa_staleness` | script not found | exit 2 |
| `glossary_candidates` | script not found | exit 2 |
| `glossary_check` | script not found | exit 1 |

The non-zero exits are the scripts' own findings, not resolution failures — the distinction #143 built into `pipelineFailedToRun`.

`resolvePipelineScript` prefers the folio's own copy, so a folio that deliberately forked a script keeps its fork, and falls back to the platform's. `resolveValidateScript` now delegates to it: they were separate copies of the same fallback for exactly one commit, and a test pins their agreement rather than waiting to notice the day they diverge.

## A third defect, found while verifying the second

`content_export` resolved, ran, and **exited 1**.

`references` and `referenceMap` are Proxies over an injected registry, so *touching* either throws when a folio has not configured one — and the paper-level `references` field is assembled last. The export did all its work and then died on the final field.

A folio with no bibliography is the **normal** case, not an edge one: a new folio has no references and `folio_init` scaffolds none.

`validate.ts` already had the right shape — ask `referenceRegistryConfigured()` rather than catch, so *"this folio has no bibliography"* stays distinguishable from *"the lookup failed"*. Both touch points in `export-json` are guarded; guarding only the one that threw first would move the crash to the other on any folio whose blocks carry `cites[]`. It now reports what it did not resolve rather than exporting an empty list silently:

```
Exporting: folio-test
  ℹ no reference registry configured — exported with an empty `references` list; cites[] were NOT resolved
  → build/viewer/paper.json (14.5 KB)
```

## Verification

| Gate | Result |
|---|---|
| `bun test` | 1181 pass · 0 fail |
| `tsc --noEmit` | clean |
| `eslint .` | clean |

Nine new tests across two files, plus the eleven-tool before/after measured over the wire on a real folio.

## Not done

The bibliography tools (`bib_qa`, `bib_validate`, `references_validate`) were **not** exercised — they reach the network and the batch timed out. They go through `runPipeline` so they get the resolution fix, but whether they behave sensibly against an empty registry is unverified. Recorded in bean `e1f6`; worth a follow-up once a folio actually carries references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01US4dUcUDmKXzYVawMPZeV2

---
_Generated by [Claude Code](https://claude.ai/code/session_01US4dUcUDmKXzYVawMPZeV2)_