### PR TITLE
fix(pipeline): audit output belongs in build/, not .beans/ or todos/

### DIFF
--- a/.beans/folio-assistant-bfyw--two-audits-write-into-beans-and-todos-locations-ag.md
+++ b/.beans/folio-assistant-bfyw--two-audits-write-into-beans-and-todos-locations-ag.md
@@ -1,0 +1,66 @@
+---
+# folio-assistant-bfyw
+title: Two audits write into .beans/ and todos/ — locations AGENTS.md forbids
+status: in-progress
+type: bug
+created_at: 2026-08-29T06:32:29Z
+updated_at: 2026-08-29T06:32:29Z
+---
+
+Revived by #144. audit-status-sections defaults to .beans/status-section-audit.json (pollutes the bean store); qa-section-title-audit writes todos/section-title-audit.json (the todos/*.json store AGENTS.md says not to stand up) and its docstring claims it is gitignored, which is false in a folio_init layout.
+
+## Summary of Changes
+
+Found by running the tools `e1f6` had just revived: the first execution in a
+scaffolded folio wrote two files into locations `AGENTS.md` forbids, and my own
+`git add -A` on an unrelated submodule bump swept them into a commit.
+
+    .beans/status-section-audit.json     bulk output in the WORK PLAN store
+    todos/section-title-audit.json       the `todos/*.json` store AGENTS.md
+                                         says not to stand up
+
+Grepping rather than fixing the two observed turned up **four** writers, not
+two:
+
+| script | was | now |
+|---|---|---|
+| `audit-status-sections.ts` | `.beans/status-section-audit.json` | `build/…` |
+| `extract-status-sections.ts` | `.beans/paper-todos.json` | `build/…` |
+| `qa-agent-drain-queue.ts` | `todos/qa-agent-drain-queue.json` | `build/…` |
+| `qa-section-title-audit.ts` | `todos/section-title-audit.json`, **hardcoded** | `build/…`, `--out` added |
+
+`qa-section-title-audit` was the only one with no way to redirect its output,
+and its docstring claimed the path was "gitignored" — true in `qou`, false in
+anything `folio_init` scaffolds, which is exactly where it dirtied the tree.
+
+### Why nobody noticed
+
+Every one of the four was unreachable from a scaffolded folio until `e1f6`
+fixed pipeline resolution. They only ever ran in `qou`, where `todos/` and
+`.beans/` presumably were gitignored. Reviving them made a latent convention
+violation observable on the first run.
+
+### The risk I checked before changing a default
+
+These are not my scripts and `qou` might read their output. Grepped for
+consumers: **none anywhere in this repo** — only the writers and their own
+docstrings. And `audit-status-sections` documents its sibling's output as
+`.beans/qa-agent-drain-queue.json` while that sibling actually wrote to
+`todos/` — an internal contradiction, which is evidence of drift rather than a
+contract.
+
+Mitigation regardless: only the **defaults** moved. `--out` is still honoured
+by all four, so any caller passing an explicit path is unaffected, and anyone
+depending on an old default restores it with one flag. Flagged in the PR as a
+behaviour change.
+
+### Verified
+
+Deleted `todos/` and `build/` in folio-test, re-ran both audits through MCP:
+artifacts landed in `build/` (gitignored) and `git status` showed only the
+submodule — no stray files.
+
+9 tests pin that no script defaults into `.beans/` or `todos/`, that each
+defaults into `build/`, and that the formerly-hardcoded one honours `--out`.
+
+Gates: 1190 pass / 0 fail, tsc clean, eslint clean.

--- a/content/pipeline/audit-status-sections.ts
+++ b/content/pipeline/audit-status-sections.ts
@@ -12,7 +12,7 @@
  * `content/pipeline/qa-checkers-voice.ts`). It walks every content
  * `.md`, captures each flagged section's body, classifies the
  * extraction target, and writes a `.beans/` work-queue (same JSON
- * shape as `.beans/qa-agent-drain-queue.json`) so the cleanup can be
+ * shape as `build/qa-agent-drain-queue.json`) so the cleanup can be
  * drained in reviewable batches.
  *
  * Classification (a hint for the reviewer — adjudicate, don't trust
@@ -31,7 +31,7 @@
  * Usage:
  *   bun run content/pipeline/audit-status-sections.ts
  *   bun run content/pipeline/audit-status-sections.ts --paper quantum-observable-universe
- *   bun run content/pipeline/audit-status-sections.ts --out .beans/status-section-audit.json
+ *   bun run content/pipeline/audit-status-sections.ts --out build/status-section-audit.json
  *
  * @module content/pipeline/audit-status-sections
  */
@@ -126,7 +126,7 @@ function main() {
     args.includes("--paper") ? args[args.indexOf("--paper") + 1] : undefined,
   );
   const out =
-    args.includes("--out") ? args[args.indexOf("--out") + 1] : ".beans/status-section-audit.json";
+    args.includes("--out") ? args[args.indexOf("--out") + 1] : "build/status-section-audit.json";
   const root = join("content", paper);
 
   const mds = walkMd(root);
@@ -184,7 +184,7 @@ function main() {
     total_sections: totalSections,
     by_classification: byClass,
     extraction_targets: {
-      todo: ".beans/ (this directory)",
+      todo: "a bean, via `beans create` — see AGENTS.md",
       authorNotes: "block .ts `authorNotes` field (CLAUDE.md §4d)",
       substantive: "re-head to a scholarly section title; keep the math",
     },

--- a/content/pipeline/extract-status-sections.ts
+++ b/content/pipeline/extract-status-sections.ts
@@ -11,7 +11,7 @@
  *     (CLAUDE.md §4d) and removed from the `.md`. Done ONLY when the `.ts`
  *     is injectable (ends in `});`, no existing `authorNotes`); otherwise
  *     the block is SKIPPED (the `.md` section is left in place) and flagged.
- *   - **todo-class**: the section is appended to `.beans/paper-todos.json`
+ *   - **todo-class**: the section is appended to `build/paper-todos.json`
  *     and removed from the `.md`.
  *   - **substantive-class** (real math under a status header): NEVER
  *     touched — reported for a manual re-heading pass.
@@ -90,7 +90,7 @@ function main() {
   const paper = requirePaper(get("--paper"));
   const chapter = get("--chapter");
   const write = args.includes("--write");
-  const beansTodos = ".beans/paper-todos.json";
+  const beansTodos = "build/paper-todos.json";
 
   let root = join("content", paper);
   if (chapter) root = join(root, chapter);

--- a/content/pipeline/qa-agent-drain-queue.ts
+++ b/content/pipeline/qa-agent-drain-queue.ts
@@ -12,7 +12,7 @@
  *
  *   bun run content/pipeline/qa-agent-drain-queue.ts \
  *     content/quantum-observable-universe [--batch-size 25] \
- *     [--out todos/qa-agent-drain-queue.json]
+ *     [--out build/qa-agent-drain-queue.json]
  *
  * Output (todos/ is gitignored — a runtime artifact, regenerated on
  * demand): { total_gaps, total_blocks, total_batches, batches[] }.
@@ -48,7 +48,7 @@ const bsNum = bsVal && !bsVal.startsWith("-") ? Number(bsVal) : NaN;
 const batchSize = Number.isInteger(bsNum) && bsNum > 0 ? bsNum : 25;
 const outIdx = process.argv.indexOf("--out");
 const out =
-  outIdx >= 0 ? process.argv[outIdx + 1] : "todos/qa-agent-drain-queue.json";
+  outIdx >= 0 ? process.argv[outIdx + 1] : "build/qa-agent-drain-queue.json";
 
 // Agent-only criteria = registry entries with automated === false.
 const AGENT_CRITS = QA_CRITERIA_REGISTRY.filter((c) => !c.automated);

--- a/content/pipeline/qa-section-title-audit.ts
+++ b/content/pipeline/qa-section-title-audit.ts
@@ -26,7 +26,7 @@
  *  2. **Voice / story coherence** (needs an agent): does each title,
  *     read against its responsible parent, follow the narrative and
  *     stand on its own? Emitted as a per-chapter worklist
- *     (`todos/section-title-audit.json`, gitignored) carrying the
+ *     (`build/section-title-audit.json`, gitignored; override with --out) carrying the
  *     parent chain so an agent can adjudicate. Criterion id:
  *     `voice-section-title-coherence` (chapter-scoped; see the note in
  *     `qa-criteria-registry.ts`). This audit is NOT a per-block sweep
@@ -624,9 +624,18 @@ async function main(): Promise<void> {
       flags: flags.filter((f) => f.node === n).map((f) => f.kind),
     })),
   }));
-  writeFileSync("todos/section-title-audit.json", JSON.stringify(
+  // Was hardcoded to `todos/section-title-audit.json` — the one script here
+  // with no way to redirect it, and `todos/*.json` is the separate todo store
+  // AGENTS.md says not to stand up. `build/` is gitignored in every folio
+  // layout, including what `folio_init` scaffolds; `todos/` was not, so the
+  // first run in a scaffolded folio dirtied its git status.
+  const outIdx = process.argv.indexOf("--out");
+  const worklistOut =
+    outIdx >= 0 ? process.argv[outIdx + 1] : "build/section-title-audit.json";
+  mkdirSync(dirname(worklistOut), { recursive: true });
+  writeFileSync(worklistOut, JSON.stringify(
     { generated: new Date().toISOString(), max_len: MAX_LEN, total_titles: allNodes.length, hard_defects: hard.length, soft_warnings: soft.length, structure_findings: structureFlags, chapters: worklist }, null, 2));
-  console.log(`\n  worklist → todos/section-title-audit.json (review each title for conciseness + coherence against its parent)`);
+  console.log(`\n  worklist → ${worklistOut} (review each title for conciseness + coherence against its parent)`);
 
   if (writeSidecar) {
     writeSidecars(allNodes, flags, structureFlags, rawSectionsByChapter, thorough);

--- a/scripts/tests/audit-output-paths.test.ts
+++ b/scripts/tests/audit-output-paths.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Machine-generated audit output must not land in `.beans/` or `todos/`.
+ *
+ * `AGENTS.md` is explicit about both:
+ *
+ * - *"Do not stand up a separate todo store (no API route, dashboard, or
+ *   `todos/*.json` work-plan); beans is it."*
+ * - *"`beans ≠ sidecars`: never `beans create` bulk machine-generated queues
+ *   … keep those as bulk JSON."* — `.beans/` holds the work plan, not bulk
+ *   output.
+ *
+ * Four pipeline scripts defaulted into those two directories anyway. Nothing
+ * noticed, because every one of them was unreachable from a scaffolded folio
+ * until the pipeline-resolution fix; the first run after it dirtied the
+ * folio's git status with two files in forbidden locations.
+ *
+ * `build/` is gitignored in every folio layout, including what `folio_init`
+ * scaffolds — `todos/` was not, which is why the docstring claiming otherwise
+ * was wrong outside the `qou` repo it was written in.
+ */
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const PIPELINE = join(import.meta.dir, "../../content/pipeline");
+
+/** Scripts that write a machine-generated worklist or report. */
+const WRITERS = [
+  "audit-status-sections.ts",
+  "extract-status-sections.ts",
+  "qa-agent-drain-queue.ts",
+  "qa-section-title-audit.ts",
+];
+
+describe("audit output paths", () => {
+  for (const file of WRITERS) {
+    const src = readFileSync(join(PIPELINE, file), "utf-8");
+
+    test(`${file} does not default into .beans/ or todos/`, () => {
+      // String literals only — a path assembled at runtime would slip past
+      // this, but all four spell theirs out, which is what made the drift
+      // invisible and is also what makes it checkable.
+      expect(src).not.toMatch(/"\.beans\/[\w-]+\.json"/);
+      expect(src).not.toMatch(/"todos\/[\w-]+\.json"/);
+    });
+
+    test(`${file} defaults into build/`, () => {
+      expect(src).toMatch(/"build\/[\w-]+\.json"/);
+    });
+  }
+
+  test("qa-section-title-audit honours --out like its three siblings", () => {
+    // It was the only one with a hardcoded path and no way to redirect it.
+    const src = readFileSync(join(PIPELINE, "qa-section-title-audit.ts"), "utf-8");
+    expect(src).toContain('indexOf("--out")');
+  });
+});


### PR DESCRIPTION
Found by running the tools #144 had just revived. Their first execution in a scaffolded folio wrote two files into locations `AGENTS.md` explicitly forbids — and my own `git add -A` on an unrelated submodule bump swept them into a commit before I caught it.

```
.beans/status-section-audit.json    bulk output in the WORK PLAN store
todos/section-title-audit.json      the todos/*.json store AGENTS.md says not to stand up
```

`AGENTS.md` on both:

> Do not stand up a separate todo store (no API route, dashboard, or `todos/*.json` work-plan); beans is it.

> **`beans ≠ sidecars`:** never `beans create` bulk machine-generated queues … keep those as bulk JSON.

## Grepping rather than fixing the two I saw

Four writers, not two:

| script | was | now |
|---|---|---|
| `audit-status-sections.ts` | `.beans/status-section-audit.json` | `build/…` |
| `extract-status-sections.ts` | `.beans/paper-todos.json` | `build/…` |
| `qa-agent-drain-queue.ts` | `todos/qa-agent-drain-queue.json` | `build/…` |
| `qa-section-title-audit.ts` | `todos/section-title-audit.json`, **hardcoded** | `build/…`, `--out` added |

`qa-section-title-audit` was the only one with no way to redirect its output, and its docstring claimed the path was *"gitignored"* — true in `qou`, false in anything `folio_init` scaffolds, which is exactly where it dirtied the working tree.

## Why nobody noticed

Every one of the four was unreachable from a scaffolded folio until #144 fixed pipeline resolution. They only ever ran in `qou`, where `todos/` and `.beans/` were presumably gitignored. Reviving them made a latent convention violation observable on the first run.

## Behaviour change — scoped, and checked first

Only the **defaults** moved. `--out` is still honoured by all four, so a caller passing an explicit path is unaffected and anyone depending on an old default restores it with one flag.

These are not my scripts and `qou` might read their output, so I looked for consumers before touching a default: **none anywhere in this repo** — only the writers and their own docstrings. And `audit-status-sections` documents its sibling's output as `.beans/qa-agent-drain-queue.json` while that sibling actually wrote to `todos/`. An internal contradiction like that reads as drift, not a contract.

If `qou` does depend on an old path, `--out` restores it and I'd rather that were a one-flag fix than leave four scripts writing into the work-plan store.

## Verified

Deleted `todos/` and `build/` in `litlfred/folio-test`, re-ran both audits through MCP:

```
--- git status after ---
 M folio-assistant          ← only the intended change
--- build/ contents ---
section-title-audit.json
status-section-audit.json
```

| Gate | Result |
|---|---|
| `bun test` | 1190 pass · 0 fail |
| `tsc --noEmit` | clean |
| `eslint .` | clean |

Nine new tests pin that no script defaults into `.beans/` or `todos/`, that each defaults into `build/`, and that the formerly-hardcoded one honours `--out`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01US4dUcUDmKXzYVawMPZeV2

---
_Generated by [Claude Code](https://claude.ai/code/session_01US4dUcUDmKXzYVawMPZeV2)_