### PR TITLE
agents: persistent per-subagent memory for boundary, CI-health and pipeline work

### DIFF
--- a/.claude/agent-memory/ci-health-watcher/MEMORY.md
+++ b/.claude/agent-memory/ci-health-watcher/MEMORY.md
@@ -1,0 +1,92 @@
+# ci-health-watcher — memory
+
+Entry types: **STABLE** · **TRAP** · **BASELINE** (re-measure, never quote —
+and here *everything* measured is a live signal that goes stale by design).
+Seeded 2026-08-29 from `AGENTS.md`. Confirm entries as you use them.
+
+---
+
+## STABLE — the check and its three rules
+
+`bun run check:ci-health` reports each workflow's state on the **default
+branch**: consecutive failures, days since the last green, whether it has run
+recently at all. The session-start sweep prints it, so it lands where you
+already look.
+
+1. **"Could not check" is never rendered as green.**
+2. A red that has not re-run in a week is flagged **possibly stale**, not an
+   active fire.
+3. A red whose **workflow file changed after the failing run** is reported
+   `superseded` — a later edit is evidence the failing version is gone, not
+   evidence the new one works. Never green, never a live failure.
+
+## STABLE — why the watchdog exists
+
+`docs-site.yml` fired on every push to `main` and **failed all 30 times over
+two months**. The trigger was fine; the *outcome* was invisible, so the
+published site sat stale and nothing in the repo said so. Bean `xom7`.
+
+**A report is only read by someone in the room.** The session-start sweep
+covers every day somebody is working; the failure being guarded against is a
+quiet stretch with nobody looking — which is exactly the stretch in which no
+session starts either. So `.github/workflows/ci-health.yml` runs the same
+check **weekly** and maintains **one** tracking issue labelled `ci-health`:
+opened when the default branch has a live failure, **edited in place** while
+it persists (an edit does not notify, so a long outage stays one unread
+item), and closed automatically when `main` is clean. Bean `ynu8`.
+
+It deliberately does **not** send another email. GitHub sent 30, and the
+premise of `xom7` is that nobody reads them. The three live badges at the top
+of `README.md` are the same state at the front door.
+
+## TRAP — two workflows fail BY DESIGN here; do not "fix" them by dispatching
+
+`witness-refresh.yml` and `qa-sweep.yml` failed to **parse** on 2026-08-07 —
+which is why GitHub ran them on `push` despite both being
+`workflow_dispatch`-only, and why their runs are named by path rather than by
+`name:`. They were fixed the next day. They only run on dispatch and the
+report only reads the default branch, so nothing will ever run them here
+again. Bean `lq7e`.
+
+Both would fail if you *did* dispatch them, because the platform carries no
+folio: `qa-sweep` preflights on `content/package.json` and `witness-refresh`
+needs `folio-assistant/computations/`.
+
+Without rule 3 these two would be red forever. That is what rule 3 is for.
+
+## STABLE — two load-bearing properties of `ci-health.yml`
+
+Not incidental; do not simplify either away.
+
+- **`fetch-depth: 0`.** The `superseded` rule asks `git log` when a workflow
+  file last changed, and a shallow clone cannot answer — which would
+  resurrect the false fires the rule exists to retire.
+- **On "could not check" (exit 2) it leaves the tracking issue UNTOUCHED and
+  fails the job**, rather than closing it. A watchdog going blind must not
+  read as good news. A red `ci-health.yml` is itself reported by next week's
+  run.
+
+## STABLE — the complement
+
+`ynu8` complements bean `5rfy`, which fixed workflows that never *fire*. This
+is the opposite defect: one that fires constantly and fails every time. When
+triaging, decide which of the two you are looking at first — the remedies are
+unrelated.
+
+## BASELINE — re-measure, always
+
+Nothing about workflow state should ever be quoted from this file. Run
+`bun run check:ci-health` and report what it returns today.
+
+| what | command |
+|---|---|
+| per-workflow state on default branch | `bun run check:ci-health` |
+| workflow trigger policy | `bun run check:workflow-policy` |
+| the tracking issue | issues labelled `ci-health` |
+
+---
+
+## Session log
+
+One line per check: what was red, which of the three rules applied, whether
+it was a fire. Keep under ~200 lines — prune the log, never the TRAPs.

--- a/.claude/agent-memory/content-pipeline-navigator/MEMORY.md
+++ b/.claude/agent-memory/content-pipeline-navigator/MEMORY.md
@@ -1,0 +1,145 @@
+# content-pipeline-navigator — memory
+
+Entry types: **STABLE** · **TRAP** · **BASELINE** (re-measure, never quote).
+Seeded 2026-08-29 from `AGENTS.md` and a listing of `content/pipeline/` +
+`schemas/` at `5aea6cc0`. Confirm entries as you use them.
+
+---
+
+## STABLE — the stages, in order
+
+```
+.ts manifests + .md content
+  → Zod schema validation (shape + types)          schemas/constraints.ts
+  → constraint rules (file existence, cross-refs, lean requirements)
+  → profile check (kind-within-profile)            content/pipeline/profile-check.ts
+  → render (LaTeX or Markdown)                     render-latex.ts / render-markdown.ts
+  → AST validation of the rendered output
+  → chapters/*.tex  or  one assembled .md
+```
+
+## STABLE — who owns which file (the split agents get wrong)
+
+**This repo (the platform)** holds the pipeline that *acts on* content:
+`validate.ts`, `render-latex.ts`, `render-markdown.ts`, `build.ts`,
+`qa-sweep.ts`, `qa-staleness.ts`, `profile-check.ts`, `export-bibtex.ts`,
+`citations.ts`, `build-glossary.ts`, the `validate-*` family, and every
+schema under `schemas/` (`types.ts`, `constraints.ts`, `builders.ts`,
+`block-kinds.ts`, `block-qa.ts`, `lean-packages.ts`).
+
+**A folio** holds its own audit scripts — vacuity/axiom, clarity, orphan,
+trace-convention, and so on — under its own `content/pipeline/`.
+
+A folio reaches the platform through a clone-plus-symlink (in qou,
+`scripts/setup-folio-assistant.sh`), so from inside a folio the platform
+paths are prefixed `folio-assistant/`. **Check which side a script is on
+before invoking it**; qou's own `AGENTS.md` carries this warning because the
+wrong guess is a path that does not exist.
+
+Several convenience aliases were dropped in that migration and not re-wired
+(`validate-refs`, `export-bibtex`, `migrate-lean-refs`). Do not assume a
+`bun run <shortcut>` exists — check `package.json` on the side you are on.
+
+## STABLE — the commands that do exist here
+
+```sh
+bun install
+bun run src/index.ts --http      # the assistant (HTTP); --stdio for stdio MCP
+bun test                         # unit tests
+bunx playwright test             # e2e  (npm script: test:e2e)
+eslint .
+bun run src/index.ts --check-deps   # probe environment capabilities
+bun run init-folio --help           # scaffold a new folio
+bun run readme:sync[:check] | readme:sections
+bun run check:ci-health | check:corpus-gate | check:workflow-policy
+bun run typecheck | lint | gen:jsonld[:check] | render:bpmn[:check]
+```
+
+## STABLE — profiles vs adapters (read before adding a kind)
+
+- **Adapters** (`paper`, `dak`) partition kinds into **disjoint** namespaces;
+  `adapterForKind` is what QA-criterion scoping reads and must stay total and
+  unambiguous.
+- **Profiles** (`document`, `paper`) **nest**: every document kind is also a
+  paper kind. `PaperContentAdapter` extends `DocumentContentAdapter`.
+- `MATH_BLOCK_KINDS` is written out in `schemas/block-kinds.ts`;
+  `DOCUMENT_BLOCK_KINDS` is its **derived** complement, so a kind added to
+  `BLOCK_KINDS` cannot go unclassified. Keep it derived.
+
+Different **code** → adapter. Different **rules** → profile plus a subclass.
+
+## TRAP — the schema cannot catch a profile violation
+
+A `theorem` is a valid `theorem` whatever folio it sits in, and
+`constraints.ts` cannot read `folio.config.json`. `profile-check.ts` runs on
+every `content_validate` and enforces two rules the schema structurally
+cannot: kind-within-profile, and (document only) **no `lean` field and no
+`.lean` sibling** — because `remark`, `example`, `algorithm` and `simulator`
+all *declare* an optional `lean` that the type permits and the profile
+forbids.
+
+## TRAP — adding a block kind is ~30 files, not one
+
+Builder, Zod schema, label prefix, viewer registration, constraint rows, QA
+criteria. **There is no `recommendation` kind**: a normative statement is a
+labelled, titled `prose` block
+(`skills/folio-document-adapter/normative-statements.md`). Enumerate the cost
+before starting rather than half-doing it.
+
+Known-wrong and predating the document profile: `document-intake.md` maps
+guideline recommendations onto `definition`, which is wrong for a document
+folio, where `definition`'s `lean` field is **required**.
+
+## STABLE — the document render path takes no TeX, deliberately
+
+`render-markdown.ts` assembles the folio to one Markdown file;
+`document_render_{md,html,pdf}` take it through pandoc, the PDF via
+weasyprint/prince/wkhtmltopdf. It **never** falls back to `latexmk` — a PDF
+that silently came out of LaTeX would misreport what the folio needs to
+build, and the next person on a clean machine pays for that. Registered for
+**both** content types, because it is the render that works while drafting on
+a machine with no TeX.
+
+## STABLE — QA sidecars
+
+`<block>.qa.json` (block-qa/v1) carries per-criterion reviewer entries;
+`<criterion-id>.script.json` is qa-script/v1. Producing types are
+`schemas/block-qa.ts`. A sidecar is **stale** when the recorded source hashes
+or a reviewer `script_hash` drift from the current file contents; refresh by
+deleting the stale `criteria.<crit>` entry and re-running
+`bun run content/pipeline/qa-sweep.ts <path> --only <crit>`.
+
+`qa-staleness.ts` reports; `qa-sweep.ts` repairs.
+
+**A standalone library `.lean` file has no sidecar** and escapes every
+per-block checker. Nothing but an agent checks it.
+
+## STABLE — `uses[]` is EDITORIAL, and immediate-neighbours only
+
+`uses[]` and `interprets` state what a *reader* must have read to follow a
+block — agent/human maintained, part of the authored content. It lists
+**immediate neighbours only**: if A→B and B→C, A lists only B. It is not the
+import graph and not a transitive closure.
+
+## BASELINE — re-measure, do not quote
+
+| what | command |
+|---|---|
+| the pipeline's actual entrypoints | `ls content/pipeline/` |
+| the scripts that exist on this side | `bun run` with no args, or read `package.json` |
+| block kinds and their classification | read `schemas/block-kinds.ts` |
+| sidecar staleness | `bun run content/pipeline/qa-staleness.ts <path>` |
+
+---
+
+## Corrected invocations
+
+The highest-value entries in this file. Format: *what an agent reached for →
+what is actually right → date*. Append as you find them.
+
+- (none recorded yet)
+
+## Session log
+
+One line per task: what you navigated, what you corrected. Keep under ~200
+lines — prune the log, never the TRAPs.

--- a/.claude/agent-memory/platform-boundary-guard/MEMORY.md
+++ b/.claude/agent-memory/platform-boundary-guard/MEMORY.md
@@ -1,0 +1,175 @@
+# platform-boundary-guard — memory
+
+Entry types: **STABLE** · **TRAP** · **BASELINE** (re-measure, never quote).
+Seeded 2026-08-29 from `AGENTS.md`. Confirm entries as you use them.
+
+---
+
+## STABLE — the shape of every defect here
+
+A folio's specifics written into platform code. It works for exactly one
+consumer and silently damages the rest. Ask of every change: **does this
+name, assume, or default to one folio?**
+
+## STABLE — adapter vs profile: a different axis, and conflating them is costly
+
+- **Adapters** (`paper`, `dak`) partition block kinds into **disjoint**
+  namespaces. `adapterForKind` is what QA-criterion scoping reads, and it
+  must stay **total and unambiguous**.
+- **Profiles** (`document`, `paper`) **nest**: every document kind is also a
+  paper kind.
+
+Making `document` a third adapter would have made `adapterForKind` ambiguous
+on all **eight** shared kinds. When adding a content type, ask whether it
+needs different **code** (adapter) or only different **rules** (profile plus
+a subclass).
+
+`PaperContentAdapter` extends `DocumentContentAdapter`; `MATH_BLOCK_KINDS` is
+written out in `schemas/block-kinds.ts` and `DOCUMENT_BLOCK_KINDS` is its
+**derived** complement, so a kind added to `BLOCK_KINDS` cannot go
+unclassified. Keep that derivation — do not hand-maintain both lists.
+
+## STABLE — what the schema structurally cannot catch
+
+`content/pipeline/profile-check.ts` runs on every `content_validate` and
+catches what Zod cannot: a `theorem` is a valid `theorem` whatever folio it
+sits in, and `constraints.ts` cannot read `folio.config.json`.
+
+Two rules: kind-within-profile, and (document only) **no `lean` field and no
+`.lean` sibling** — because `remark`, `example`, `algorithm` and `simulator`
+all *declare* an optional `lean` that the type permits and the profile
+forbids.
+
+## TRAP — the README generator that replaced the whole file
+
+`scripts/generate-readme.sh` ended in `cp "$OUT" README.md`. It held one
+folio's content **in the platform**: the title `# Quantum Observable
+Universe`, three `litlfred/qou` badges, a Knot Registry of Alexander-Briggs
+indices, a Project Structure table naming
+`content/quantum-observable-universe/lean/`, and a CC BY 4.0 licence block.
+Run it in any other folio and the author loses their README. Only five of its
+sections were derived from the tree at all; the rest was prose, and prose
+about a folio belongs to that folio. Deleted, with
+`scripts/readme-metadata.ts`, its only consumer.
+
+**The replacement inverts the ownership**: `content/pipeline/readme-sections.ts`
+holds a registry (`folio:toc`, `folio:lean-coverage`, `folio:lean-modules`,
+`folio:simulators`, `folio:workflows`) and writes each section **only where
+the README already carries its `<!-- marker:begin -->` / `<!-- marker:end -->`
+pair**. The folio opts in per section; nothing outside a marked region is
+ever touched. Adding a section is one entry in `SECTIONS` — the CLI, the MCP
+tool and the staleness check all read the registry.
+
+`readme_sync` is registered among the **generic** tools: a document folio has
+chapters, simulators and workflows for the same reason a paper folio does,
+and simply never carries the Lean markers.
+
+## TRAP — three literals worth recognising in new code
+
+Each shipped once:
+
+1. **Modules prefixed `QOU.`** regardless of the folio's Lake library. Now
+   read from `lakefile.toml`, and left **unprefixed** when no lakefile names
+   one — *a wrong namespace is worse than none*, because it is what a reader
+   pastes into an `import`.
+2. **Workflow descriptions from a hardcoded map of twelve `qou` filenames**,
+   consulted *before* the workflow's own `name:`. Now always the `name:`.
+3. **The simulator directory as the literal `folio-assistant/simulators`.**
+   Now `folio.config.json`.
+
+## TRAP — "could not determine" is a THIRD state, everywhere
+
+A section that cannot read its source returns `skip` and the region is left
+exactly as it was. Not decoration:
+
+- qou configures its simulators under `folio-assistant/simulators`, which
+  exists only once the platform submodule is checked out. The first version
+  rendered "directory absent" as "this folio has no simulators" — replacing a
+  correct nine-row table with a sentence.
+- A shallow clone with no `gh-pages` must not silently blank a contents table
+  that was right yesterday.
+
+**An empty directory is still a determined empty.** Distinguish absent from
+unreadable, always.
+
+## TRAP — compose nothing; resolve everything
+
+The old contents table built every PDF cell as
+`${PAGES}/papers/<paper>/chapters/<dir>.pdf` — by convention, checked against
+nothing. The folio's `gh-pages` has no `chapters/` directory, so **all
+twenty-three chapter links were 404 and always had been**; three of six
+appendix links happened to resolve. Every PDF cell is now looked up in a real
+`git ls-tree` of the publish ref, and a chapter with no published PDF renders
+`—`.
+
+The same script also **described one folio from inside the platform** (paper
+directory, title, badges and a `PAGES` constant as literals) in a repo whose
+`folio.ts` lists five papers, and resolved its helpers against the folio root
+(`bun run scripts/readme-metadata.ts`) where the platform's scripts are not —
+so it could only run from a platform checkout, which has no papers.
+
+## STABLE — link style: `raw` is not the private-repo answer
+
+A private folio whose README links to `https://<owner>.github.io/...` is
+unreachable for exactly the people who have repository access, and
+`raw.githubusercontent.com` does not fix it — it 404s on a private repo
+without a token, and a browser session cookie does not authenticate it.
+
+Default is **`blob`** (`github.com/<owner>/<repo>/blob/<ref>/<path>`): follows
+the viewer's GitHub session, works public or private, renders PDFs inline.
+`pages` and `raw` remain available under `readme.linkStyle` in
+`folio.config.json`, and each prints a note under the table saying who can
+follow its links.
+
+## STABLE — the builder shim, and why `folio_init` is generic
+
+`bun run init-folio` / the `folio_init` MCP tool writes a folio's `content/`,
+`uploads/`, `library/`, manifests, `folio.config.json`, the `content/schema/`
+builder shim, `AGENTS.md` + `CLAUDE.md`/`GEMINI.md` stubs, `.mcp.json`, the
+session-start hook and the beans store.
+
+- **The builder shim exists so the path to folio-assistant is written down
+  once**: block manifests import `../schema/builders`, never the platform
+  directly, so re-linking is a two-file edit rather than a corpus sweep.
+- **`folio_init` is registered among the generic tools**, not in an adapter,
+  because it runs *before* the folio has a content type. A bare repo falls
+  back to the paper adapter, so an adapter-scoped tool would be unreachable
+  in exactly the case it exists for.
+
+## STABLE — the document render path takes no TeX
+
+`content/pipeline/render-markdown.ts` assembles the folio to one Markdown
+file; `document_render_{md,html,pdf}` take it through pandoc, the PDF via
+weasyprint/prince/wkhtmltopdf. It **never** falls back to `latexmk`,
+deliberately — a PDF that silently came out of LaTeX would misreport what the
+folio needs to build, and the next person on a clean machine pays for that.
+Registered for **both** content types, because it is the render that works
+while drafting on a machine with no TeX.
+
+## STABLE — there is no `recommendation` block kind
+
+A normative statement is a labelled, titled `prose` block; the convention and
+its limits are in `skills/folio-document-adapter/normative-statements.md`. A
+real kind means a builder, a Zod schema, a label prefix, viewer registration,
+constraint rows and QA criteria — about **thirty files** — and is tracked
+separately rather than half-done.
+
+Known-wrong and predating the document profile: `document-intake.md` maps
+guideline recommendations onto `definition`, which is wrong for a document
+folio, where `definition`'s `lean` field is required.
+
+## BASELINE — re-measure, do not quote
+
+| what | command |
+|---|---|
+| folio-specific literals in platform code | grep the change for a paper dir, a title, an owner/repo, a Lake prefix, a workflow filename |
+| README sections a folio can opt into | `bun run readme:sections` |
+| README staleness | `bun run readme:sync:check` |
+| block-kind classification totality | read `schemas/block-kinds.ts`; `DOCUMENT_BLOCK_KINDS` must stay derived |
+
+---
+
+## Session log
+
+One line per review: what you checked, any literal you caught, any TRAP you
+added. Keep under ~200 lines — prune the log, never the TRAPs.

--- a/.claude/agents/ci-health-watcher.md
+++ b/.claude/agents/ci-health-watcher.md
@@ -1,0 +1,45 @@
+---
+name: ci-health-watcher
+description: Reads whether this repo's workflows are actually working on the default branch. Use for "is CI green", "why is this workflow red", "did the site publish", "check the workflows", or before trusting any workflow's outcome. Knows the three reporting rules and which workflows fail by design here.
+tools: Read, Grep, Glob, Bash, ToolSearch
+memory: project
+---
+
+# ci-health-watcher
+
+A red workflow looks exactly like a green one from inside the repo. Your job
+is to make the difference visible and to not manufacture false fires.
+
+`docs-site.yml` fired on every push to `main` and **failed all 30 times over
+two months**. The trigger was fine; the *outcome* was invisible, so the
+published site sat stale and nothing in the repo said so. Bean `xom7`.
+
+## What you do
+
+Run `bun run check:ci-health` — each workflow's state on the default branch:
+consecutive failures, days since the last green, whether it has run recently
+at all. Follow its three rules yourself when reading or reporting:
+
+1. **"Could not check" is never rendered as green.**
+2. A red that has not re-run in a week is **possibly stale**, not an active
+   fire.
+3. A red whose **workflow file changed after the failing run** is
+   `superseded` — the version that failed is gone, so the verdict is stale.
+   `superseded` is never green and never counted as a live failure.
+
+Then check the workflows this repo knows fail by design before reporting
+anything as a fire — see memory.
+
+## What you do not do
+
+Do not "fix" a red by dispatching a workflow that cannot succeed here, and
+do not close a tracking issue on a blind check. A watchdog going blind must
+not read as good news.
+
+## Memory discipline
+
+Memory at `.claude/agent-memory/ci-health-watcher/`. Entries are **STABLE**
+(a workflow's real trigger and owner) / **TRAP** (a red that is not a fire,
+or a green that is not evidence) / **BASELINE** (a run count or date —
+re-measure, never quote; this is a live signal and every number in it goes
+stale by design).

--- a/.claude/agents/content-pipeline-navigator.md
+++ b/.claude/agents/content-pipeline-navigator.md
@@ -1,0 +1,40 @@
+---
+name: content-pipeline-navigator
+description: Knows the content pipeline — validate, render, build, qa-sweep, schemas, block kinds, QA sidecars. Use for "validate the content", "render this chapter", "which script does X", "why did validation fail", "add a block kind", or when a pipeline invocation is about to be guessed. Knows which stage owns which file and which repo hosts which script.
+tools: Read, Grep, Glob, Bash, Edit, Write, ToolSearch
+memory: project
+---
+
+# content-pipeline-navigator
+
+You are the map of `content/pipeline/` and `schemas/`. The failure you exist
+to prevent is a guessed invocation — an agent running a standard command
+instead of the one this pipeline actually uses, or reaching for a script
+that lives in the other repo.
+
+## What you do
+
+1. **Name the exact command** before anything runs it, and say which stage
+   it belongs to: schema validation → constraint rules → LaTeX/Markdown
+   render → AST validation → output.
+2. **Say which repo hosts the script.** The platform holds
+   validate/render/build/qa-sweep; a folio holds its own audit scripts. An
+   agent that assumes one tree holds both invokes a path that does not
+   exist.
+3. **For a new block kind or content type**, enumerate the real cost —
+   builder, Zod schema, label prefix, viewer registration, constraint rows,
+   QA criteria — rather than half-doing it.
+4. **Read the profile rules**, not just the schema. A `theorem` is a valid
+   `theorem` whatever folio it sits in; `constraints.ts` cannot see
+   `folio.config.json`, so `content/pipeline/profile-check.ts` is what
+   catches a math block in a document folio.
+
+## Memory discipline
+
+Memory at `.claude/agent-memory/content-pipeline-navigator/`. Entries are
+**STABLE** (a command, a file's owner, a stage boundary) / **TRAP** (a
+plausible invocation that is wrong, or a rule the schema cannot enforce) /
+**BASELINE** (a count — re-measure, never quote).
+
+The single highest-value thing to record is a **corrected invocation**: the
+command an agent reached for, and the one that is actually right.

--- a/.claude/agents/platform-boundary-guard.md
+++ b/.claude/agents/platform-boundary-guard.md
@@ -1,0 +1,48 @@
+---
+name: platform-boundary-guard
+description: Keeps folio-specific content out of the platform and platform code out of folios. Use when adding or editing anything under src/, content/pipeline/, schemas/ or scripts/ — "is this generic", "should this be an adapter or a profile", "where does this belong", "which repo owns this script", or when a literal names one folio. Knows the qou↔platform split and the genericity failures already paid for.
+tools: Read, Grep, Glob, Bash, Edit, Write, ToolSearch
+memory: project
+---
+
+# platform-boundary-guard
+
+This repo is the **platform**; a folio (qou and others) is a separate repo
+that consumes it. Almost every defect this file records has one shape: a
+folio's specifics written into platform code, where it works for exactly one
+consumer and silently damages the rest.
+
+## The question you ask about every change
+
+**Does this name, assume, or default to one folio?** A paper directory, a
+title, a badge URL, a Lake library prefix, a workflow filename, a simulator
+path, a licence block. If yes, it belongs in that folio's config or its
+tree — not here.
+
+Then: **does this need different code, or only different rules?** Different
+code → an adapter. Different rules → a **profile plus a subclass**. Getting
+that backwards is expensive; see memory.
+
+And: **is there a third state?** "Could not determine" is not "absent".
+A section that cannot read its source returns `skip` and leaves the region
+exactly as it was.
+
+## What you do
+
+1. Read the change for folio-specific literals, and name each one.
+2. Say which side of the qou↔platform split each touched path is on —
+   agents invoke the wrong side of this regularly (see memory).
+3. For a new content type or block kind, decide adapter-vs-profile
+   explicitly and say why.
+4. For generated output into a folio's files, check it writes **only**
+   inside its markers and handles the unreadable-source case as a third
+   state.
+
+## Memory discipline
+
+Memory at `.claude/agent-memory/platform-boundary-guard/`. Entries are
+**STABLE** (a rule, a path, a registry) / **TRAP** (a genericity failure and
+what it cost) / **BASELINE** (a count — store the command and the date;
+re-measure, never quote).
+
+The TRAPs are the point. Every one here was paid for once already.

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,7 @@ content/schema/
 # source (block-qa.ts, lean-packages.ts, ...) and ignoring it wholesale
 # would silence `git add` on all of it.
 /schemas/references.ts
+
+# Per-machine subagent memory (`memory: local` scope). The committed
+# `project` scope lives at .claude/agent-memory/ and is tracked.
+.claude/agent-memory-local/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,6 +305,46 @@ than closing it: the watchdog going blind must not read as good news, and a red
 Complements `5rfy`, which fixed workflows that never *fire*. This is the
 opposite defect — one that fires constantly and fails every time.
 
+## Subagents with persistent memory (`.claude/agents/`)
+
+Three subagents are defined under [`.claude/agents/`](.claude/agents/), each
+carrying `memory: project` in its frontmatter. That gives the agent its own
+directory under `.claude/agent-memory/<agent-name>/`; the first 200 lines (or
+25 KB) of that directory's `MEMORY.md` are injected into the subagent's system
+prompt when it starts, and it reads and writes the directory as it works.
+
+| agent | owns |
+|---|---|
+| `platform-boundary-guard` | keeping folio specifics out of platform code; adapter-vs-profile; the qou↔platform split |
+| `ci-health-watcher` | whether a workflow is actually working on the default branch |
+| `content-pipeline-navigator` | validate / render / build / qa-sweep, schemas, block kinds, script ownership |
+
+Each `MEMORY.md` labels every entry as exactly one of:
+
+- **STABLE** — a path, a command, a rule. Trustworthy.
+- **TRAP** — a specific way the task goes wrong, with the evidence that
+  established it. The reason to have memory at all: every genericity failure
+  in this document was paid for once, and a TRAP is what stops it being paid
+  for twice.
+- **BASELINE** — a measured number, stored **with the command that produced it
+  and the date, and never quoted as a current answer.** `ci-health-watcher`'s
+  memory takes this furthest and holds no workflow state at all, because every
+  such number is a live signal that goes stale by design.
+
+**Maintaining them is part of the work.** A session that establishes a durable
+fact in one of these areas adds it as a TRAP in the same PR; a session that
+re-measures a BASELINE updates the entry with the fresh number and date. A
+memory file that only accretes becomes the thing it exists to prevent.
+
+`MEMORY.md` is the injected entry point, so keep it under 200 lines — split
+detail into sibling files the agent reads on demand. `memory: project` writes
+under `.claude/agent-memory/`, which is **committed**; `memory: local` writes
+under `.claude/agent-memory-local/`, gitignored, for anything per-machine.
+
+The agents defer to this file and to `skills/` as the source of truth. Memory
+summarises; the skill governs. Where the two disagree, the skill wins and the
+memory entry is wrong — fix it.
+
 ## At session start
 
 Surface the work-plan before starting: run `beans prime` (and `beans list`), or


### PR DESCRIPTION
Adds `.claude/agents/` with three subagent definitions, each carrying
`memory: project` in its frontmatter. That gives each agent its own directory
under `.claude/agent-memory/<name>/`, whose `MEMORY.md` is injected into that
subagent's system prompt when it starts — so it does not re-derive the same
facts about this repo every session.

Companion work on the qou side is litlfred/qou#5997.

## The agents

| agent | owns |
|---|---|
| `platform-boundary-guard` | keeping folio specifics out of platform code; adapter-vs-profile; the qou↔platform split |
| `ci-health-watcher` | whether a workflow is actually working on the default branch |
| `content-pipeline-navigator` | validate / render / build / qa-sweep, schemas, block kinds, and which repo hosts which script |

## What went into the memory, and why

`AGENTS.md` already records these lessons; what it cannot do is put them in
front of a subagent that starts cold. Each seed is drawn from it — nothing
here is newly asserted. The entries that earn their place:

- **The README generator that ended in `cp "$OUT" README.md`** — one folio's
  title, badges, knot registry and licence held inside the platform, so
  running it in any other folio destroyed the author's README. Plus the three
  literals that went with it, each of which is easy to write again: `QOU.`
  module prefixes, workflow descriptions from a hardcoded map of twelve
  filenames, and the literal `folio-assistant/simulators`.
- **"Could not determine" is a third state, everywhere** — the version that
  rendered "directory absent" as "this folio has no simulators", replacing a
  correct nine-row table with a sentence.
- **Compose nothing, resolve everything** — twenty-three chapter PDF links
  built by convention and 404 since the day they were written.
- **The two workflows that fail here by design** (`witness-refresh.yml`,
  `qa-sweep.yml`), and the `superseded` rule that stops them reading as a
  live fire forever.
- **Adapter vs profile** — why making `document` a third adapter would have
  made `adapterForKind` ambiguous on all eight shared kinds.

## The entry discipline

Each `MEMORY.md` labels every entry as exactly one of:

- **STABLE** — a path, a command, a rule. Trustworthy.
- **TRAP** — a specific way the task goes wrong, with the evidence. Durable,
  and the reason to have memory at all.
- **BASELINE** — a measured number, stored **with the command and the date
  and never quoted as a current answer**. It tells the agent what to measure
  and how, never what the answer is. `ci-health-watcher`'s memory takes this
  furthest: it holds no workflow state at all, because every such number is a
  live signal that goes stale by design.

## Notes

- `MEMORY.md` injection is capped at the first 200 lines / 25 KB; all three
  seeds are well under it.
- `memory: project` writes under `.claude/agent-memory/`, intended to be
  committed and shared. `local` scope (`.claude/agent-memory-local/`,
  gitignored) is available if an agent should keep per-machine state instead;
  none here does.
- Each agent's body defers to `AGENTS.md` and the relevant skill as the
  source of truth — memory summarises, the skill governs.

## Verification

Markdown only: no `src/`, `schemas/`, `content/pipeline/`, workflow or
`package.json` changes, so nothing in this diff is reachable by `typecheck`,
`lint` or the test suites. The observable check on the frontmatter shape is
that agents defined this way register as available agent types — confirmed on
the qou side of this pair, where two of the five were picked up by the running
session immediately after their first commit landed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9XTWrESNxGvxvVcizyBwE)_