### PR TITLE
Nine pipeline scripts were unrunnable in a multi-paper folio

### DIFF
--- a/content/pipeline/audit-wiring.ts
+++ b/content/pipeline/audit-wiring.ts
@@ -35,7 +35,12 @@ import type { Block } from "../../schemas/types";
 import { requirePaper, findContentRepoRoot } from "./repo-root";
 
 // Was a hardcoded folio paper name in PLATFORM code; see `requirePaper`.
-const PAPER = requirePaper();
+// `--paper <name>` (not a positional): several of these scripts already
+// use argv[2] for an output path or a `--strict` flag, so a positional
+// would collide. Matches `extract-status-sections.ts`.
+const _paperIdx = process.argv.indexOf("--paper");
+const _paperArg = _paperIdx >= 0 ? process.argv[_paperIdx + 1] : undefined;
+const PAPER = requirePaper(_paperArg);
 const PAPER_DIR = join(findContentRepoRoot(), "content", PAPER);
 const OUT_JSON = resolve(__dirname, "../audit-wiring.json");
 

--- a/content/pipeline/conditional-class-banner-audit.ts
+++ b/content/pipeline/conditional-class-banner-audit.ts
@@ -39,7 +39,12 @@ import type { BlockLoadFailure } from "./block-module";
 // `folio-assistant/` symlink to the platform.
 const REPO_ROOT = findContentRepoRoot();
 // Was a hardcoded folio paper name in PLATFORM code; see `requirePaper`.
-const ROOT = join(REPO_ROOT, "content", requirePaper());
+// `--paper <name>` (not a positional): several of these scripts already
+// use argv[2] for an output path or a `--strict` flag, so a positional
+// would collide. Matches `extract-status-sections.ts`.
+const _paperIdx = process.argv.indexOf("--paper");
+const _paperArg = _paperIdx >= 0 ? process.argv[_paperIdx + 1] : undefined;
+const ROOT = join(REPO_ROOT, "content", requirePaper(_paperArg));
 const STRICT = process.argv.includes("--strict");
 
 // Optional baseline-allowlist file (declared before WITNESS_OUT so its

--- a/content/pipeline/conjectural-propagation-audit.ts
+++ b/content/pipeline/conjectural-propagation-audit.ts
@@ -38,8 +38,25 @@ const LOAD_FAILURES: BlockLoadFailure[] = [];
 // `folio-assistant/` symlink to the platform.
 const REPO_ROOT = findContentRepoRoot();
 // Was a hardcoded folio paper name in PLATFORM code; see `requirePaper`.
-const ROOT = join(REPO_ROOT, "content", requirePaper());
-const WITNESS_OUT = process.argv[2] ??
+// `--paper <name>` (not a positional): several of these scripts already
+// use argv[2] for an output path or a `--strict` flag, so a positional
+// would collide. Matches `extract-status-sections.ts`.
+const _paperIdx = process.argv.indexOf("--paper");
+const _paperArg = _paperIdx >= 0 ? process.argv[_paperIdx + 1] : undefined;
+const ROOT = join(REPO_ROOT, "content", requirePaper(_paperArg));
+// First non-flag argument. `process.argv[2]` alone would pick up `--paper`
+// (or its value), which is how this script came to write its witness to a
+// file literally named `--paper`.
+const _positional = (() => {
+  const a = process.argv.slice(2);
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] === "--paper") { i++; continue; }
+    if (a[i].startsWith("--")) continue;
+    return a[i];
+  }
+  return undefined;
+})();
+const WITNESS_OUT = _positional ??
   join(REPO_ROOT, "docs/audits/2026-05-01-p3-1-conjectural-propagation.witness.json");
 
 interface Block {

--- a/content/pipeline/conjectural-propagation-sweep.ts
+++ b/content/pipeline/conjectural-propagation-sweep.ts
@@ -51,7 +51,12 @@ function walk(dir: string) {
   }
 }
 
-walk(join("content", requirePaper()));
+// `--paper <name>` (not a positional): several of these scripts already
+// use argv[2] for an output path or a `--strict` flag, so a positional
+// would collide. Matches `extract-status-sections.ts`.
+const _paperIdx = process.argv.indexOf("--paper");
+const _paperArg = _paperIdx >= 0 ? process.argv[_paperIdx + 1] : undefined;
+walk(join("content", requirePaper(_paperArg)));
 
 const conjectureLabels = new Set<string>();
 for (const b of blocks.values()) if (b.kind === "conjecture") conjectureLabels.add(b.label);
@@ -156,7 +161,19 @@ if (empty.length) {
   reportLines.push("");
 }
 
-const outputPath = process.argv[2] ?? "docs/audits/2026-05-01-conjectural-propagation-sweep.md";
+// First non-flag argument. `process.argv[2]` alone would pick up `--paper`
+// (or its value), which is how this script came to write its witness to a
+// file literally named `--paper`.
+const _positional = (() => {
+  const a = process.argv.slice(2);
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] === "--paper") { i++; continue; }
+    if (a[i].startsWith("--")) continue;
+    return a[i];
+  }
+  return undefined;
+})();
+const outputPath = _positional ?? "docs/audits/2026-05-01-conjectural-propagation-sweep.md";
 mkdirSync(dirname(outputPath), { recursive: true });
 writeFileSync(outputPath, reportLines.join("\n"));
 console.log(`Wrote ${outputPath}`);

--- a/content/pipeline/generate-index.ts
+++ b/content/pipeline/generate-index.ts
@@ -23,11 +23,15 @@ import type { Section, SectionRef } from "../../schemas/types";
 const REPO_ROOT = findContentRepoRoot();
 const CONTENT_ROOT = join(REPO_ROOT, "content");
 // Was a hardcoded folio paper name in PLATFORM code; see `requirePaper`.
-// The bare `requirePaper()` this replaces took no argument, so in a folio with
-// more than one paper it THREW every time and there was no way to name the
-// paper -- qou has five, so its committed definition-index.md could not be
-// regenerated at all. Positional argv matches `find-dangling-remarks.ts`.
-const PAPER_NAME = requirePaper(process.argv[2]);
+// `--paper <name>`, falling back to a positional. The flag is the convention
+// this file's siblings use (`extract-status-sections.ts`), and four of them
+// CANNOT take a positional because their argv[2] is already an output path.
+// The positional fallback is kept because `main` landed that form here and
+// callers may rely on it -- for this script argv[2] is free, so both work.
+const _paperIdx = process.argv.indexOf("--paper");
+const _paperArg =
+  _paperIdx >= 0 ? process.argv[_paperIdx + 1] : process.argv[2];
+const PAPER_NAME = requirePaper(_paperArg);
 const PAPER_DIR = join(CONTENT_ROOT, PAPER_NAME);
 const INDEX_MD = join(PAPER_DIR, "index-of-definitions", "definition-index.md");
 

--- a/content/pipeline/prune-transitive-deps.ts
+++ b/content/pipeline/prune-transitive-deps.ts
@@ -51,7 +51,12 @@ const CONTENT_ROOT = join(REPO_ROOT, "content");
 const args = process.argv.slice(2);
 const APPLY = args.includes("--apply");
 // Was a hardcoded folio paper name in PLATFORM code; see `requirePaper`.
-const PAPER_NAME = requirePaper();
+// `--paper <name>` (not a positional): several of these scripts already
+// use argv[2] for an output path or a `--strict` flag, so a positional
+// would collide. Matches `extract-status-sections.ts`.
+const _paperIdx = process.argv.indexOf("--paper");
+const _paperArg = _paperIdx >= 0 ? process.argv[_paperIdx + 1] : undefined;
+const PAPER_NAME = requirePaper(_paperArg);
 const PAPER_DIR = join(CONTENT_ROOT, PAPER_NAME);
 
 // ── Load all blocks ─────────────────────────────────────────────

--- a/content/pipeline/qa-agent-drain-queue.ts
+++ b/content/pipeline/qa-agent-drain-queue.ts
@@ -38,7 +38,18 @@ import { requirePaper } from "./repo-root";
 // would land inside folio-assistant, not the content repo).
 process.chdir(findContentRepoRoot());
 
-const root = process.argv[2] ?? join("content", requirePaper());
+const _paperIdx = process.argv.indexOf("--paper");
+const _paperArg = _paperIdx >= 0 ? process.argv[_paperIdx + 1] : undefined;
+const _positional = (() => {
+  const a = process.argv.slice(2);
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] === "--paper") { i++; continue; }
+    if (a[i].startsWith("--")) continue;
+    return a[i];
+  }
+  return undefined;
+})();
+const root = _positional ?? join("content", requirePaper(_paperArg));
 const bsIdx = process.argv.indexOf("--batch-size");
 const bsVal =
   bsIdx >= 0 && bsIdx + 1 < process.argv.length

--- a/content/pipeline/validate-references.ts
+++ b/content/pipeline/validate-references.ts
@@ -31,6 +31,9 @@ import { requirePaper } from "./repo-root";
 // `folio-assistant/` symlink to the platform.
 const REPO_ROOT = findContentRepoRoot();
 const args = process.argv.slice(2);
+const _paperIdx = process.argv.indexOf("--paper");
+const _paperArg = _paperIdx >= 0 ? process.argv[_paperIdx + 1] : undefined;
+
 const strict = args.includes("--strict");
 
 // ── Issue tracking ──────────────────────────────────────────────
@@ -127,7 +130,7 @@ const leanCitations = new Set<string>();
 const leanDir = join(REPO_ROOT, "lean");
 const contentDir = join(REPO_ROOT, "content");
 // Was a hardcoded folio paper name in PLATFORM code; see `requirePaper`.
-const leanArchiveDir = join(REPO_ROOT, "content", requirePaper(), "lean");
+const leanArchiveDir = join(REPO_ROOT, "content", requirePaper(_paperArg), "lean");
 
 function scanFilesRecursive(dir: string, ext: string): string[] {
   if (!existsSync(dir)) return [];

--- a/content/pipeline/wall-violations-sweep.ts
+++ b/content/pipeline/wall-violations-sweep.ts
@@ -24,6 +24,19 @@ import { readdirSync, readFileSync, statSync, writeFileSync, mkdirSync } from "f
 import { join, dirname, basename, relative } from "path";
 import { requirePaper } from "./repo-root";
 
+const _paperIdx = process.argv.indexOf("--paper");
+const _paperArg = _paperIdx >= 0 ? process.argv[_paperIdx + 1] : undefined;
+const _positional = (() => {
+  const a = process.argv.slice(2);
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] === "--paper") { i++; continue; }
+    if (a[i].startsWith("--")) continue;
+    return a[i];
+  }
+  return undefined;
+})();
+
+
 type Hit = { file: string; line: number; pattern: string; text: string; triage: "citation" | "tau-side-label" | "appendix-surreals" | "verification-witness" | "candidate" };
 
 const PATTERNS: Array<{ name: string; re: RegExp }> = [
@@ -98,7 +111,7 @@ function walk(dir: string, results: Hit[]) {
 }
 
 const results: Hit[] = [];
-walk(join("content", requirePaper()), results);
+walk(join("content", requirePaper(_paperArg)), results);
 const seen = new Set<string>();
 const unique = results.filter(h => { const k = `${h.file}|${h.line}|${h.pattern}`; if (seen.has(k)) return false; seen.add(k); return true; });
 
@@ -116,7 +129,7 @@ const witness = {
   hits: unique,
 };
 
-const outputPath = process.argv[2] ?? "folio-assistant/computations/wall-violations.witness.json";
+const outputPath = _positional ?? "folio-assistant/computations/wall-violations.witness.json";
 mkdirSync(dirname(outputPath), { recursive: true });
 writeFileSync(outputPath, JSON.stringify(witness, null, 2) + "\n");
 console.log(`Wrote ${outputPath}`);


### PR DESCRIPTION
`requirePaper(explicit?)` throws when a folio holds more than one paper and no name is given. **Nine** pipeline scripts call it bare, so none of them can run in such a folio at all:

```
audit-wiring                     prune-transitive-deps
conditional-class-banner-audit   qa-agent-drain-queue
conjectural-propagation-audit    validate-references
conjectural-propagation-sweep    wall-violations-sweep
generate-index
```

That set includes **both §3b-cond enforcers** — the conjectural-propagation audit and the conditional-class banner audit — plus the bibliography cross-check and the §7c wall sweep. Measured in a five-paper folio (`litlfred/qou`), every one exits non-zero with `5 papers found … name one explicitly`, so those audits had silently not been running there.

## The fix

`--paper <name>` as a **flag**, matching `extract-status-sections.ts` (`requirePaper(get("--paper"))`).

**Deliberately not a positional.** `find-dangling-remarks.ts` uses `requirePaper(process.argv[2])`, and that idiom does not generalise here — `argv[2]` is *already* the output path in `conjectural-propagation-audit`, `conjectural-propagation-sweep`, `qa-agent-drain-queue` and `wall-violations-sweep`, and is a `--strict` flag in `audit-wiring` and `conditional-class-banner-audit`.

I tried the positional first and it broke things in a way worth recording: naming the paper positionally *also redirects the output*, and the propagation audit wrote its 70 KB witness to a file literally named `quantum-observable-universe` at the consuming repo's root.

The flag alone is still not sufficient — with `--paper` present, `argv[2]` becomes `--paper` and the witness lands in a file of *that* name. So the four scripts that take an output path now read the first **non-flag** argument.

## Verification

Run against `litlfred/qou` (five papers), where all nine previously threw:

- `conjectural-propagation-audit --paper quantum-observable-universe` → exit 0, reports `Witness: docs/audits/2026-05-01-p3-1-conjectural-propagation.witness.json`, no stray files. Its first successful run there found **34 violators** and **121 conditional-on-class** blocks.
- `generate-index --paper …` → exit 0.
- `prune-transitive-deps --paper …` → exit 0.

## Compatibility

Single-paper folios are unaffected: with no `--paper`, `requirePaper` still resolves the sole paper, and the output-path arguments still accept a bare positional exactly as before. The change is additive.

## Note for reviewers

I have not regenerated the downstream artifacts in the consuming repo (the definition index and the propagation witness are both stale there, the index by 10 entries). Those regenerations should follow this landing, so their provenance points at a producer that exists on `main` rather than at a local patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K4y5xEFSrp6KwheV9kpPDG

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4y5xEFSrp6KwheV9kpPDG)_