### PR TITLE
qa: the vacuity axis — four criteria for claims that pass by construction

### DIFF
--- a/.beans/folio-assistant-gx86--pdf-structure-titleauthor-split-fails-on-single-au.md
+++ b/.beans/folio-assistant-gx86--pdf-structure-titleauthor-split-fails-on-single-au.md
@@ -1,11 +1,11 @@
 ---
 # folio-assistant-gx86
 title: pdf-structure title/author split fails on single-author bylines
-status: todo
+status: completed
 type: task
 priority: normal
 created_at: 2026-08-24T17:28:23Z
-updated_at: 2026-08-24T17:28:42Z
+updated_at: 2026-08-24T19:48:24Z
 ---
 
 Found while ingesting qou's 9 un-ingested uploads (2026-08-24). **1 of 9 titles came out correct.** That is far below the 96.7% the whole-corpus run in folio-assistant-p2en reported, so either the rate is uneven by layout or the corpus figure counts 'non-null' rather than 'correct'.
@@ -43,3 +43,47 @@ The mangled title is what library/INDEX.md shows and what is injected as doc_tit
 A byline is better identified positively than by punctuation: a short line of capitalised name-like tokens, no verb, no title-case function words, optionally attested by the running heads / bibliography via the `vocab` Counter that `rejoin_caps` already builds. Any change re-titles ~373 documents, so it needs a before/after diff reviewed as its own pass, not a drive-by.
 
 Interim: the 9 titles were corrected as data in the qou repo, and a pdf-structure.py re-run will revert them until this is fixed.
+
+
+---
+
+## Fixed and measured — 432f8b7, 2026-08-24
+
+`looks_like_byline` no longer identifies a byline by punctuation alone. Three
+changes, each isolated by a corpus-wide A/B over all 382 library documents:
+
+- a **name-shape route** for the single-author byline that carries no
+  punctuation, gated by an **abstract veto** (a line whose capitalised words are
+  mostly already in the abstract is title text);
+- `RE_SPLIT_CAP` now requires the *tail* to be unattested as well as the join,
+  because gating on the join alone welded "A long" into "Along" — `along` is on
+  every page of a symplectic paper;
+- `RE_TITLE_STOP` plus book-division furniture ("Chapter 5") stops a title that
+  no byline stops.
+
+Two scoping decisions came out of the A/B and were wrong first: the abstract
+veto applies to the punctuation route **only when there is no comma** (vetoing
+the comma case cost 40 titles their stopping point), and the <=8-token cap applies
+to the shape route **only** (real bylines are messy — "Ma..ite Dupuis1,* and
+Florian Girelli 2, 1,+" is nine tokens of kerning damage and affiliation
+markers).
+
+**Final A/B over 382 documents: 46 titles improved, 8 regressed; 73 bylines
+recovered, 7 lost.** An earlier measurement reporting 88 regressions was wrong —
+it compared fresh extraction against *stored* titles, many of which are
+hand-curated and no extractor ever produced them. Do not re-derive the baseline
+that way.
+
+## Closing this, and what carries on
+
+The titled defect — single-author bylines never recognised — is fixed and
+measured net-positive, so this bean is done.
+
+The residue is **not** dropped. `folio-assistant-whwf` carries it, with the 7
+lost bylines enumerated: 2 are actually corrections (the old "byline" was title
+text, so the true score is 73 recovered / 5 lost), 5 are genuine regressions on
+comma-less multi-author bylines, 2 of those 5 have a confirmed cause in the
+abstract veto, and 3 do not yet. It also records the operational point this bean
+raised and could not close: **qou's `library/*/structure.json` still holds
+pre-fix output**, so the 9 hand-corrected titles are still hand-corrected and
+the 5 regressions are latent until someone re-runs the extractor.

--- a/.beans/folio-assistant-gx86--pdf-structure-titleauthor-split-fails-on-single-au.md
+++ b/.beans/folio-assistant-gx86--pdf-structure-titleauthor-split-fails-on-single-au.md
@@ -1,0 +1,45 @@
+---
+# folio-assistant-gx86
+title: pdf-structure title/author split fails on single-author bylines
+status: todo
+type: task
+priority: normal
+created_at: 2026-08-24T17:28:23Z
+updated_at: 2026-08-24T17:28:42Z
+---
+
+Found while ingesting qou's 9 un-ingested uploads (2026-08-24). **1 of 9 titles came out correct.** That is far below the 96.7% the whole-corpus run in folio-assistant-p2en reported, so either the rate is uneven by layout or the corpus figure counts 'non-null' rather than 'correct'.
+
+## One predicate causes both failure directions
+
+scripts/pdf-structure.py:119
+
+    RE_AUTHOR_HINT = re.compile(r"(,\s|\band\b|\&)", re.I)
+
+parse_front_matter() only treats a line as the byline when it contains a comma-space, the word 'and', or an ampersand. So:
+
+**(a) Single-author bylines are never recognised** — no comma, no 'and' — and get appended to the title. 6 of 9:
+  - 'FLOER COHOMOLOGY AND PENCILS OF QUADRICS IV AN SMITH'  (Ivan Smith)
+  - 'FLOER COHOMOLOGY AND HIGHER MUTATIONS SOHAM CHANDA'
+  - 'Floer cohomology , singularities, and birational geometry Mark McLean'
+  - 'Along exact sequence for symplectic Floer cohomology Paul Seidel'
+  - 'A FOURIER-FREE DENSITY-INCREMENT PROOF OF ROTH'S THEOREM MARK LEWKO'
+  - 'On the generalisation of Roth's theorem Paolo Dolce Francesco Zucconi 0 Introduction 1 0.1 History . . .' (two authors, no comma/and — then ran on into the TOC)
+
+**(b) A title continuation containing 'and' is misread AS the byline**, truncating the title. 1 of 9:
+  - arxiv-1109.3255v2 title='FLOER COHOMOLOGY IN THE MIRROR OF THE PROJECTIVE', authors_raw='PLANE AND A BINODAL CUBIC CURVE'
+  The real title is 'Floer cohomology in the mirror of the projective plane and a binodal cubic curve'; the byline (James Pascaleff) was lost entirely.
+
+**(c) Body text swallowed** where there is no byline at all: roth-lemma title is a whole paragraph ('Chapter 5 ROTH'S LEMMA 1. Introduction Roth bases the proof...').
+
+Correct: noniterativeroth2 only — 'ERNIE CROOT AND OLOF SISASK' contains 'AND', so the hint fired.
+
+## Why it matters beyond cosmetics
+
+The mangled title is what library/INDEX.md shows and what is injected as doc_title into every sections/*.md front-matter, i.e. into the contextual-retrieval tier. 'Along exact sequence for symplectic Floer cohomology' hid Paul Seidel's long-exact-sequence paper from exactly the arc that went looking for long exact sequences (qou bean qou-fngs).
+
+## Fix direction (not attempted here — corpus-wide blast radius)
+
+A byline is better identified positively than by punctuation: a short line of capitalised name-like tokens, no verb, no title-case function words, optionally attested by the running heads / bibliography via the `vocab` Counter that `rejoin_caps` already builds. Any change re-titles ~373 documents, so it needs a before/after diff reviewed as its own pass, not a drive-by.
+
+Interim: the 9 titles were corrected as data in the qou repo, and a pdf-structure.py re-run will revert them until this is fixed.

--- a/.beans/folio-assistant-ilbh--vacuity-detector-sees-constant-data-only-it-misses.md
+++ b/.beans/folio-assistant-ilbh--vacuity-detector-sees-constant-data-only-it-misses.md
@@ -1,0 +1,70 @@
+---
+# folio-assistant-ilbh
+title: Vacuity detector sees constant data only — it misses definitional laundering
+status: todo
+type: bug
+priority: normal
+created_at: 2026-08-24T19:37:43Z
+updated_at: 2026-08-24T19:37:43Z
+---
+
+`content/pipeline/qa-checkers-vacuity.ts` — `checkNoVacuousInstanceData`.
+
+## The measurement that exposed it
+
+A hand-read pass over the qou corpus on 2026-08-24 produced **8** vacuity
+findings. Running the detector over the same corpus the same day produced **25**
+hits. The overlap is **zero**. Both lists are real; they are different defects.
+
+The detector's model is stated in its own docstring and is *constant data*:
+
+```ts
+const DEGENERATE_VALUE =
+  /^(?:0|1|_|T|0|PUnit\.unit|Unit\.unit|\(\)|default|True|trivial|Nat\.zero|List\.nil|\[\]|Finset\.empty|Classical\.arbitrary\b.*)$/;
+```
+
+A field is degenerate only if its value is *literally* one of those tokens.
+
+## The shape it misses: definitional laundering
+
+The data field is a real, non-constant expression — and is still chosen so the
+propositional field closes by `rfl`. Five of the eight findings are this:
+
+| decl | data field | why the detector passes it |
+|---|---|---|
+| `BraidKnot/CrystalRMatrixSubLemma.lean:188 canonical` | `poleIndicator := fun rho => decide (rho <= -1)` | not a degenerate token; fields are in a tactic `exact { ... }`, not a `where` |
+| `Archimedean/BorromeanQuark.lean:124 canonical` | `topological_mass := fun q => borromean_volume / (1 - 1/q)^2` | the value *is* the claim's RHS, verbatim |
+| `Mathlib/ArchimedeanRealization.lean:120 canonical` | `q0 := q_zero` | a named constant, not a literal |
+| `MassTheory/CableWidthBraneTowerLift.lean:73 colorRule` | `w := fun _ => cableWidthColor` | ditto — constant *behind a name* |
+| `Machinery/KashiwaraCrystalBasic.lean:215 instSl2DemazureSubcrystal` | `member := fun _ => True` | `True` is in the token list; `fun _ => True` is not |
+
+The last row is the cheapest fix and the most telling: the regex is anchored
+`^...$`, so a constant hidden behind one lambda defeats it. So does a constant
+hidden behind one `def`.
+
+## Three separable improvements, cheapest first
+
+1. **Unwrap trivial lambdas.** Match `fun _ => <degenerate>` (any arity of
+   wildcards) as degenerate. One-line regex change; catches
+   `instSl2DemazureSubcrystal` and `colorRule`-style fields directly.
+2. **Resolve module-local constants one hop.** `q0 := q_zero` where
+   `def q_zero : R := ...` — a name whose definition is a literal is as
+   degenerate as the literal. Bounded: one hop, same file, no import following.
+3. **Definitional laundering proper** — data field's RHS is syntactically the
+   expression the Prop field compares against. This is the real prize and the
+   hardest: it needs the class *declaration* as well as the instance body, so
+   the checker has to read the `class ... where` block that the instance
+   inhabits. Worth scoping before building.
+
+## Do not treat the count as the finding
+
+The corpus-wide number moved 26 -> 25 in a day under an unrelated agent's
+demotions, and neither number is the population of the defect. Report what a
+read confirms, not what the checker totals.
+
+## Consumers
+
+qou beans `qou-09mr` (CrystalRMatrixSubLemma), `qou-7nbx` (ArchimedeanRealizationFunctor),
+`qou-2y13` (SubstrateWidthRule), `qou-uno5` (instSl2DemazureSubcrystal),
+`qou-znut` (BorromeanQuark) each record that this detector will NOT
+regress-guard their fix.

--- a/.beans/folio-assistant-ilbh--vacuity-detector-sees-constant-data-only-it-misses.md
+++ b/.beans/folio-assistant-ilbh--vacuity-detector-sees-constant-data-only-it-misses.md
@@ -1,11 +1,11 @@
 ---
 # folio-assistant-ilbh
 title: Vacuity detector sees constant data only — it misses definitional laundering
-status: todo
+status: completed
 type: bug
 priority: normal
 created_at: 2026-08-24T19:37:43Z
-updated_at: 2026-08-24T19:37:43Z
+updated_at: 2026-08-24T21:03:03Z
 ---
 
 `content/pipeline/qa-checkers-vacuity.ts` — `checkNoVacuousInstanceData`.
@@ -68,3 +68,87 @@ qou beans `qou-09mr` (CrystalRMatrixSubLemma), `qou-7nbx` (ArchimedeanRealizatio
 `qou-2y13` (SubstrateWidthRule), `qou-uno5` (instSl2DemazureSubcrystal),
 `qou-znut` (BorromeanQuark) each record that this detector will NOT
 regress-guard their fix.
+
+
+---
+
+## Closed 2026-08-24 on `claude/gracious-dijkstra-0ijp2l`
+
+New criterion **`lean-no-definitional-laundering`** in
+`content/pipeline/qa-checkers-vacuity.ts`, registered in
+`qa-criteria-registry.ts` (`automated: true`, `critical`) and wired into
+`VACUITY_AUTOMATED_CHECKERS`. `lean-no-vacuous-instance-data` is untouched: its
+conjunction is precise and that precision is why it has near-zero false
+positives. Its loop body was lifted into `vacuousDataConjunction()` so the new
+criterion can *skip* any decl the old one already flags — the two lists stay
+disjoint by construction, not by luck. The refactor is proved
+behaviour-preserving: HEAD's checker and the refactored one emit identical hit
+lists on the same corpus snapshot.
+
+### Three detections, against the bean's three proposals
+
+1. **Argument-ignoring body** — `def F (args…) : Prop := True | False`, after
+   discarding `let` bindings whose results are dropped. Catches
+   `ToroidalHarmonicODE`, `WeberODE`, and the pre-`opaque` `InTensorSpan`.
+   Requires ≥ 1 parameter: an argument-free `def X : Prop := True`
+   (`beta3IsLChi4_3`, `qou-35zi`) is `proof-no-trivial-true`'s
+   `def-disguised-true`, already in the registry.
+2. **Lambda-wrapped constant** — proposal 1, `fun _ … => <degenerate>` beside a
+   reflexivity discharge. Catches `instSl2DemazureSubcrystal` (`qou-uno5`) and
+   `ClassicalLimitStpart.canonical`.
+3. **Definitional identity** — proposal 3, and it did not need scoping to be
+   affordable. The class field's *conclusion* (binders stripped, hypotheses
+   split off) is matched as `data args = RHS`; the instance's `data` is compared
+   to that RHS up to alpha-renaming of its binders. Catches `poleIndicator`
+   (`qou-09mr`), `BorromeanQuark` (`qou-znut`), `ArchimedeanRealizationFunctor`
+   (`qou-7nbx`), `SubstrateWidthRule` (`qou-2y13`), plus four sites the hand
+   pass had not named.
+
+**Proposal 2 (one-hop constant resolution) was NOT built, and should not be.**
+Both sites that motivated it — `q0 := q_zero`, `w := fun _ => cableWidthColor` —
+turn out to be detection-3 shapes: the named constant *is* the class field's
+RHS. Following the name buys nothing they do not already report, and following
+it in general fires on every instance that uses a named constant correctly.
+
+### Detection 3 grades `warn`, not `fail`
+
+Pinning a field to a formula and observing the law then holds by `rfl` is a
+legitimate way to exhibit a model. Whether the class field was a *constraint*
+the instance had to meet or a *definition* it was entitled to make is a question
+about what the class was for, and no regex answers it. Those hits say "REVIEW
+(not a verdict)" in their own evidence and name the disputing docstring when
+there is one — `BorromeanQuark.canonical` argues the identity IS the content.
+
+### Corpus
+
+25 → 26 for the old criterion (sibling-agent churn during the session, not this
+change) and **9** for the new one, disjoint. The first sweep returned 26; all
+were read and five vetoes came out of the wrong ones, each documented at its
+definition: a discharge lambda that names its binders is a proof not a
+reflexivity; a decl where some law needed real tactic work is a model doing
+work; one real proof among the name-matched claims means the constants are a
+corner; a declared inhabitation witness is the prescribed remedy; a `theorem`
+exhibiting a record proves an existential.
+
+**Do not quote 9.** Four of the eight hand-audit sites were repaired by a
+sibling agent *while this was being written* — `CrystalRMatrixSubLemma`,
+`ArchimedeanRealization` and `CableWidthBraneTowerLift` took the
+parameterise-the-class remedy, `AlgebraicPrimality` took `opaque`. The criterion
+passes every one of the repaired forms, and each repair is pinned as a NEGATIVE
+test beside the defect it fixed: a criterion that still fires after its own
+prescribed remedy is worse than no criterion.
+
+### Not built, deliberately
+
+- **Semantic constancy** (`w A := 3 * A * 0`). Needs `whnf`. That is the
+  elaborator's job and no regex reaches it.
+- **Cross-file classes.** Detection 3 needs the `class … where` block, so it
+  reads only same-file classes. Resolving imports to guess at one produces a
+  confident false report about a decl the checker never read.
+
+Tests: `scripts/tests/qa-checkers-vacuity.test.ts`; suite 810 → 843, 0 fail.
+Every fixture is a real qou declaration quoted from the state the hand audit
+read it in. Each negative pin was mutation-checked — minimally perturbed into
+its positive and confirmed to fire — which is how a nested-`∀` conclusion gap
+and an alpha-rename placeholder collision (`y → x` routed through `" 0 "`
+rewrites `g 0 y` to `g x x`) were both found.

--- a/.beans/folio-assistant-k94j--vacuity-criteria-collided-with-the-fixes-they-aske.md
+++ b/.beans/folio-assistant-k94j--vacuity-criteria-collided-with-the-fixes-they-aske.md
@@ -1,0 +1,87 @@
+---
+# folio-assistant-k94j
+title: 'vacuity criteria collided with the fixes they asked for: one false positive, one unclearable fail'
+status: completed
+type: task
+priority: normal
+created_at: 2026-08-24T21:15:22Z
+updated_at: 2026-08-24T21:15:51Z
+---
+
+
+
+## What happened (2026-08-24)
+
+Two agents landed inside the same hour. `fa/ilbh` shipped
+`lean-no-definitional-laundering` (`d8d586d`, folio-assistant). `qou-09mr/7nbx/
+2y13/uno5` repaired four one-model classes (`ca23d591c76`, qou). Neither could
+see the other: the checker lives in folio-assistant, the corpus in qou, and the
+qou content gate does not run the vacuity criteria. Running the new checker
+against the repaired corpus produced two hits, both wrong in different ways.
+
+## 1. `lean-no-vacuous-instance-data` fired on the fix — FIXED
+
+`sl3DemazureLevelOne` (`QOU/Machinery/KashiwaraCrystalBasic.lean:285`) is the
+three-vertex crystal written *specifically* to give
+`DemazureSubcrystal.demazure_closure` teeth: a proper sub-crystal `{0,1}` whose
+closure is checked by exhaustion. The conjunction fired because
+
+- `highest := 0` matched `DEGENERATE_VALUE` — there it is a **vertex index**
+- `highest_mem := by decide` matched `TRIVIAL_DISCHARGE` — there it evaluates
+  `0 ≠ 2`
+
+and the criterion required only *one* degenerate data field, ignoring the
+sibling `member := fun v => v ≠ 2`.
+
+Firing on the declaration written to fix the defect is this criterion's worst
+failure mode: it reads as evidence the fix did not take.
+
+**Fix.** A data field that reads a non-wildcard binder it declares vetoes the
+conjunction — constant data is the whole mechanism of the defect, so a field
+that computes from its arguments cannot be part of it.
+
+**Rejected first.** Reusing the sibling criterion's `doesRealWork` veto looked
+like the obvious move and was measured wrong: on the qou corpus it takes the
+criterion from **26 hits to 6**, and the 20 it drops are overwhelmingly true
+positives — `triv_hecke` survives it on `carrier_addCommGroup := by
+infer_instance`, `witnessR5Full_deuterium_placeholder` on a `by simp` carrying
+an inline comment. `isSubstantiveDischarge` is calibrated for a population whose
+fields are already known non-constant; on this one it is a `by`-detector.
+Argument-dependence removes **exactly one** hit and leaves the sibling
+criterion's list byte-identical.
+
+## 2. Detection 2 graded `fail` on correct mathematics — FIXED
+
+`instSl2DemazureSubcrystal` has `member := fun _ => True`, and that is the
+**value the mathematics forces**: `sl₂` has one simple root, so `B(Λ₁)` has
+exactly two Demazure sub-crystals and the level-1 one is the whole two-vertex
+crystal. The `qou-uno5` agent established this and rewrote the docstring to
+concede the exact vacuity the checker reports — the claim fields carry no force —
+while keeping the value.
+
+So the finding is real and there is no edit that clears it. A `critical`
+criterion that cannot be satisfied by correct content gets switched off, not
+obeyed.
+
+**Fix.** `hard = constant_prop_defs` only. Detection 1
+(`def F args : Prop := True`) stays `fail` — a tautology is wrong whatever the
+author meant. Detections 2 and 3 grade `warn` and both now open
+"REVIEW (not a verdict)", because they turn on the same non-syntactic question:
+was the constant forced, or arranged? Detection 3 always said so; detection 2
+shipped claiming more than it can know.
+
+Worth noting `ilbh` had already considered this declaration and judged it "a
+real finding", writing into `INHABITATION_WITNESS` that *"'genuine' is NOT a
+trigger — `instSl2DemazureSubcrystal` calls itself 'a genuine
+`DemazureSubcrystal`' and is a real finding."* That was correct against the
+docstring it read, which asserted closure had been checked. `qou-uno5` replaced
+that docstring with one that concedes it. The veto comment is now describing a
+file that no longer says what it quotes.
+
+## Still open — the coordination gap, not the two bugs
+
+The qou content gate does not run the vacuity criteria, so nothing in either
+repo's CI would have caught this. Both defects were found by hand, by running
+the checker against the corpus after the fact. Until the criteria run over the
+Lean tree on a gate, "the checker agrees with the corpus" is an assertion
+someone has to re-establish by hand every time either side moves.

--- a/.beans/folio-assistant-p2en--formal-rag-document-ingestion-layer-options-assess.md
+++ b/.beans/folio-assistant-p2en--formal-rag-document-ingestion-layer-options-assess.md
@@ -1022,3 +1022,35 @@ published authoring standards rather than from what a corpus happens to contain
 there: the unenforceable "exactly one of" constraint in every `*Source`, and the
 official `.xlsx` component templates that bound the deferred workbook reader.
 
+Pre-existing unrelated failure found while running the suite: folio-assistant-zevm.
+
+
+---
+
+## Status audit 2026-08-24 — staying in-progress, and why
+
+Stage 1 (`scripts/pdf-structure.py`) is built, run corpus-wide, and now
+**repaired**: the title/byline split defect it shipped with is
+`folio-assistant-gx86`, fixed in 432f8b7 and measured (46 titles improved, 8
+regressed; 73 bylines recovered, 7 lost over 382 documents). Residue tracked as
+`folio-assistant-whwf`.
+
+The downstream consumer arrived and worked end to end: qou `qou-qad3` ingested
+nine PDFs through this pipeline into `library/<doc-id>/` with all five artefacts
+and then registered all nine in `references.ts` — closed today. That is the
+first full acquire -> parse -> index -> cite round trip this proposal specified,
+which is worth recording as evidence the contract holds.
+
+**Open, and the reason this bean stays in-progress:**
+
+- Stage 2 (network acquire) and Stage 3 (Docling) are both **egress-blocked**
+  in a sandbox — arxiv.org, api.openalex.org, huggingface.co and cdn-lfs all
+  return 403 policy denials. Unchanged today. The proposal's answer is that
+  Stage 3 is a workstation/CI stage: run where egress allows, commit artefacts,
+  let sandboxed sessions consume them. Nobody has done that run.
+- The ~20 residue documents (7 no-TOC, 17 unsectioned, 7 likely-scanned) that
+  define Stage 3's value are still unaddressed.
+- Proposal 11 Q1-Q3 are still unanswered by the author, and 10 still needs a
+  stage picked.
+
+None of that is blocked on this repo, which is exactly why it has not moved.

--- a/.beans/folio-assistant-sbd6--qa-criterion-hash-docstring-names-an-exported-auto.md
+++ b/.beans/folio-assistant-sbd6--qa-criterion-hash-docstring-names-an-exported-auto.md
@@ -1,0 +1,42 @@
+---
+# folio-assistant-sbd6
+title: qa-criterion-hash docstring names an exported *_AUTOMATED_CHECKERS record the code never looks for
+status: completed
+type: bug
+priority: low
+created_at: 2026-08-24T19:37:21Z
+updated_at: 2026-08-24T19:37:21Z
+---
+
+`content/pipeline/qa-criterion-hash.ts`, module docstring, section "What is hashed".
+
+It said the criterion's dispatch entry is *"its property in the exported
+`*_AUTOMATED_CHECKERS` record"*. The code has never cared about the record's
+name, nor whether it is exported. `findCriterionEntry` walks the whole source
+file and takes the first `PropertyAssignment` whose **key** equals the criterion
+id, in any object literal at any depth:
+
+```ts
+if (ts.isPropertyAssignment(node) && keyText(node.name) === criterionId) {
+  found = node;
+```
+
+## Why the sentence was expensive
+
+A session (2026-08-24) chasing a hash question read that sentence as a contract,
+went looking for which module exported a `*_AUTOMATED_CHECKERS` record, and
+audited naming conventions that carry no weight. The real behaviour has two
+consequences the old sentence hid, and both matter:
+
+- a dispatch table named anything at all is found, so there is no convention to
+  keep;
+- a property with that key **somewhere else in the module** would be found
+  first, since the walk stops at the first match. That is the actual sharp edge,
+  and the docstring pointed away from it.
+
+## Fixed
+
+Docstring corrected on `claude/gracious-dijkstra-0ijp2l`, including an explicit
+note that the old wording was wrong so the next reader does not re-derive it
+from an old checkout. Code unchanged. Gate: `./scripts/tests/run-tests.sh`
+**808 pass, 0 fail** — the documented baseline, unchanged.

--- a/.beans/folio-assistant-whwf--the-gx86-abstract-veto-loses-5-comma-less-multi-au.md
+++ b/.beans/folio-assistant-whwf--the-gx86-abstract-veto-loses-5-comma-less-multi-au.md
@@ -1,0 +1,109 @@
+---
+# folio-assistant-whwf
+title: The gx86 abstract veto loses 5 comma-less multi-author bylines — and the corpus has not been re-run
+status: todo
+type: bug
+priority: normal
+created_at: 2026-08-24T19:48:09Z
+updated_at: 2026-08-24T19:48:09Z
+---
+
+Residue from `folio-assistant-gx86`, whose fix landed in 432f8b7 with a measured
+A/B: **46 titles improved, 8 regressed; 73 bylines recovered, 7 lost.** The 73
+and the 46 are the reason to keep the change. This bean is the 7.
+
+## The 7 lost bylines, enumerated — and 2 of them are wins
+
+Derived mechanically from the A/B rows (`old_a` non-empty, `new_a` empty):
+
+**Not regressions — the old "byline" was title text, and losing it is correct:**
+
+| doc | old_a |
+|---|---|
+| `arxiv-1604.01247v2` | `AND PARTICLE PHYSICS` |
+| `gambaudo-ghys-braids-signatures-2005` | `BRAIDS AND SIGNATURES` |
+
+So the honest score is **73 recovered / 5 lost**, not 7, and the headline
+understates the fix.
+
+**Genuine regressions (5).** In every one the byline text is now *inside the
+title* — nothing stopped the title, so the byline was never offered:
+
+| doc | byline lost | title now ends |
+|---|---|---|
+| `arxiv-hep-th-0001202v2` | `D. J. Broadhurst 1) and D. Kreimer 2)` | `...rooted trees D. J. Broadhurst 1) and D. Kreimer 2)` |
+| `arxiv-hep-th-9811173v1` | `J. M. Borwein a) and D. J. Broadhurst b)` | `...knots and links J. M. Borwein a) and D. J. Broadhurst b)` |
+| `arxiv-hep-th-9310164v2` | `John W. Barrett & Bruce W. Westbury` | `SPHERICAL CATEGORIES John W. Barrett & Bruce W. Westbury` |
+| `arxiv-math-0304010v1` | `Vladimir Ivanov and Grigori Olshanski` | `...ON YOUNG DIAGRAMS Vladimir Ivanov and Grigori Olshanski In memory of Sergei Kerov (1946-2000)` |
+| `arxiv-2607.29018v1` | `Chenhui Lv*1 and Sanming Zhou 2` | `...symmetric groups Chenhui Lv*1 and Sanming Zhou 2 1School of Mathematical Sciences...` |
+
+All five are **comma-less multi-author bylines joined by "and"/"&"** — the most
+common two-author form there is.
+
+## Confirmed cause for 2 of the 5, and it falsifies the veto's premise
+
+`looks_like_byline`, route 1:
+
+```python
+if RE_AUTHOR_HINT.search(line):
+    if in_abstract and "," not in line:
+        return False
+    return True
+```
+
+with
+
+```python
+in_abstract = bool(abstract_words and words and
+                   sum(1 for w in words if w in abstract_words) * 2 >= len(words))
+```
+
+Two problems, both visible in `arxiv-hep-th-0001202v2`:
+
+1. **"Majority" collapses to "any single hit" on a two-name byline.**
+   `D. J. Broadhurst 1) and D. Kreimer 2)` yields `words = ['broadhurst',
+   'kreimer']` — initials and digits are filtered by the `len >= 3` test — so
+   one match satisfies `1 * 2 >= 2`. The docstring's defence, *"Majority rather
+   than any single hit, so a paper whose author shares a surname with its
+   subject ... is not derailed by one coincidence"*, is true for a long byline
+   and false for exactly the short one this case is.
+2. **Authors ARE named in their own abstracts.** The premise is *"an author is
+   rarely named in their own abstract"*. In `hep-th/0001202` the abstract names
+   **both** Broadhurst and Kreimer; in `hep-th/9811173` it names Broadhurst.
+   Self-reference in a physics abstract is ordinary, not exotic.
+
+The comment above the veto states the assumption that fails: *"a genuine
+multi-author byline separates with commas."* Two-author bylines conventionally
+do not.
+
+## Unexplained: 3 of the 5
+
+Replaying the veto against the stored `authors_raw` for `hep-th-9310164v2`,
+`math-0304010v1` and `2607.29018v1` gives `in_abstract = False`, so the veto is
+**not** what dropped them. Another gate did — candidates in
+`parse_front_matter`: `RE_AUTHORS.match`, the `len(l) < 120` cap,
+`RE_TITLE_STOP` breaking early, or `rejoin_caps` altering the line before
+`looks_like_byline` sees it. Instrument, do not guess: the line reaching
+`looks_like_byline` is not the stored `authors_raw`.
+
+## The operational fact that makes this urgent-ish
+
+**The corpus has not been re-run.** `library/*/structure.json` in qou still holds
+pre-fix output, and for all five of these it holds the *correct* byline. So the
+regression is latent: it appears the moment someone re-runs `pdf-structure.py`
+over `library/`. Fix this before that re-run, or the re-run trades 5 correct
+bylines for the 73.
+
+## Suggested fix order
+
+1. Require **at least two** abstract hits before the veto fires, i.e.
+   `hits >= 2 and hits * 2 >= len(words)`. Cheap, and it retires both confirmed
+   cases without touching the title-continuation case the veto exists for
+   (`PLANE AND A BINODAL CUBIC CURVE` has four content words, none of them
+   names).
+2. Then instrument the remaining three.
+3. Re-run the full 382-document A/B before and after; the numbers in gx86 are
+   the baseline to beat.
+
+Reproduce: `scripts/pdf-structure.py` over qou `library/`, diff `metadata.title`
+and `metadata.authors_raw` against the committed `structure.json`.

--- a/.beans/folio-assistant-whwf--the-gx86-abstract-veto-loses-5-comma-less-multi-au.md
+++ b/.beans/folio-assistant-whwf--the-gx86-abstract-veto-loses-5-comma-less-multi-au.md
@@ -1,11 +1,11 @@
 ---
 # folio-assistant-whwf
 title: The gx86 abstract veto loses 5 comma-less multi-author bylines — and the corpus has not been re-run
-status: todo
+status: completed
 type: bug
 priority: normal
 created_at: 2026-08-24T19:48:09Z
-updated_at: 2026-08-24T19:48:09Z
+updated_at: 2026-08-24T20:47:45Z
 ---
 
 Residue from `folio-assistant-gx86`, whose fix landed in 432f8b7 with a measured
@@ -107,3 +107,38 @@ bylines for the 73.
 
 Reproduce: `scripts/pdf-structure.py` over qou `library/`, diff `metadata.title`
 and `metadata.authors_raw` against the committed `structure.json`.
+
+CLOSED 2026-08-24. Fixed in 6a52432; measured by a full 382-document A/B of the old extractor against the new, on the same PDFs.
+
+## Result
+
+                     before(gx86)   after(whwf)
+  titles improved         46            47
+  titles regressed         8             2
+  bylines gained          73            75
+  bylines lost             7             1
+
+The single remaining byline "loss" is `arxiv-1604.01247v2: AND PARTICLE PHYSICS` — one of the two this bean already identified as NOT a regression, because the old "byline" was title text. So genuine byline regressions are now **zero**, and the other pseudo-loss (`gambaudo-ghys`) is handled correctly too.
+
+## Root cause was a third one, not in the original diagnosis
+
+The bean named two causes and marked 3 of the 5 losses "unexplained". Those three share a cause that turns out to be the root:
+
+**The abstract window was a raw 2000-character slice from the word "Abstract".** It routinely overruns into the body, the author addresses and the bibliography, so "named in the abstract" silently became "named anywhere on page 1" — which every author is. `arxiv-math-0304010v1` lost its byline because all four of Vladimir/Ivanov/Grigori/Olshanski were found in that window, firing the veto at full strength on a line that is nothing but names.
+
+`parse_front_matter` already computes the real abstract by cutting at the first section heading; it simply was not using the same cut for the veto. It does now, so the two cannot disagree about what the abstract IS.
+
+The two causes the bean did name are also fixed: strict majority with a floor of 2 hits (`>= half` collapses to "any single hit" once initials and digits are filtered from a two-name byline), and a byline-marker escape for initials / affiliation superscripts / footnote daggers, which outrank the abstract heuristic — whose premise is false in physics, as this bean showed.
+
+## Residue: 2 NEW title regressions, recorded not hidden
+
+Both are title run-ons, not byline losses, and both are new relative to gx86:
+
+* `arxiv-math-0305423v3` — the title absorbs a "Running head: ..." line before reaching the byline. The byline IS found (`By Jason Fulman`); "Running head:" is unrecognised furniture.
+* `arxiv-q-alg-9504015v2` — takes `Physics Department, University of Miami` as the byline. An affiliation carries a comma, so route 1 fires on it.
+
+Cheap fixes for both are obvious — treat "Running head:" as furniture, and reject lines containing Department/University/Institute as bylines. They are NOT applied here, because "obviously correct" is what the previous two rounds of this fix assumed and both were wrong on measurement. Anything touching this predicate needs its own A/B.
+
+## Operational
+
+The corpus was never re-run, so nothing was damaged and nothing needs repair. `pdf-structure.py` over `library/` is now unblocked — but a re-run will re-title ~145 documents, so it should be a deliberate, reviewed pass, not a side effect of ingesting one new upload.

--- a/.beans/folio-assistant-zevm--qa-criterion-hash-fixture-drifted-bare-automated-c.md
+++ b/.beans/folio-assistant-zevm--qa-criterion-hash-fixture-drifted-bare-automated-c.md
@@ -1,11 +1,11 @@
 ---
 # folio-assistant-zevm
-title: 'qa-criterion-hash fixture drifted: bare AUTOMATED_CHECKERS not matched'
-status: todo
+title: qa-criterion-hash real-module guard anchored its path at process.cwd(), which run-tests.sh moves
+status: completed
 type: task
 priority: normal
 created_at: 2026-08-24T17:25:12Z
-updated_at: 2026-08-24T17:25:27Z
+updated_at: 2026-08-24T19:08:36Z
 ---
 
 Pre-existing failure, surfaced while running the suite for the pypdf_safe work on branch claude/gracious-dijkstra-0ijp2l. Not caused by that change (its diff touches only PDF scripts and a skill doc).
@@ -17,3 +17,50 @@ Both keys DO exist in that module (lines 1167 and 1173), inside the record expor
 Likely cause, not yet confirmed: qa-criterion-hash.ts documents itself as finding an exported '*_AUTOMATED_CHECKERS' record, but qa-checkers-voice.ts exports a bare 'AUTOMATED_CHECKERS' with no prefix, and that record leads with spreads of the sub-registries. The test's own comment says it exists to guard the fixture shape 'against drifting from how checkers are really written' — so the test is doing its job and the fixture is what drifted.
 
 Consequence while open: every criterion in that module silently falls back to the whole-file hash, so any edit anywhere in a 1200-line file invalidates every criterion's cached QA result.
+
+
+## Resolved — the stated cause and consequence were both wrong
+
+Root cause is the TEST's path, not checker shape and not module shape. The
+guard built `join(process.cwd(), "content/pipeline/qa-checkers-voice.ts")`, but
+`scripts/tests/run-tests.sh` does `cd "$SCRIPT_DIR"` before `bun test`. Under
+the canonical runner cwd is `scripts/tests/`, so it opened
+`scripts/tests/content/pipeline/qa-checkers-voice.ts`, which does not exist.
+`criterionSourceHash` returns null at the FIRST of its three exits —
+`parseFile`'s `readFileSync` throws ENOENT and is swallowed — never reaching
+`findCriterionEntry`. The test passed from the repo root and failed under the
+runner; both were the same code.
+
+Refuted: the bare-`AUTOMATED_CHECKERS` / leading-spread hypothesis.
+`findCriterionEntry` walks every object literal in the module and matches on the
+property KEY, so the record's name is irrelevant (`*_AUTOMATED_CHECKERS` in the
+module docstring is prose, not a constraint), and the six spreads are trailing
+and never consulted — the hashed entry is one property assignment. Given a
+correct absolute path both ids resolve to distinct per-criterion hashes:
+`voice-scholarly-default` 7e311e463351, `wall-side-correct` 37b3fa59a3bc, vs a
+whole-file hash of 6c2d94255398.
+
+Refuted: "every criterion in that module silently falls back to the whole-file
+hash". Production never took that path. Both callers of
+`computeCriterionScriptHashes` (`qa-sweep.ts`, `script-sweep.ts`) pass an
+explicit `REPO_ROOT` derived from the module's own `__filename`, not cwd.
+Verified by running the real sweep call from two different cwds: identical
+per-criterion hashes both times, neither equal to the whole-file hash. The
+cache churn described here was never happening; it was confined to the test.
+
+Fix, both sides being well-formed: anchor the guard at
+`resolve(import.meta.dir, "..", "..")` — the repo's documented idiom for a
+PLATFORM path, and the one that survives a folio embedding this repo by symlink.
+Added `expect(existsSync(...)).toBe(true)` so a wrong path names itself instead
+of arriving as a null that reads exactly like the shape drift the guard exists
+to catch. Assertions unchanged and unweakened; under the runner the guard now
+exercises the real module for the first time.
+
+Regression guard in `infrastructure.test.ts`: no `.ts` under `scripts/tests/`
+may build a path with `join`/`resolve(process.cwd(), ...)` or `process.cwd() +`
+(comments masked via `maskComments`; opt out with `allow-cwd-anchored-paths`).
+Verified it flags the pre-fix source at line 114 and nothing in the current tree
+(70 files scanned). Bare `process.cwd()` stays legal — several tests save and
+restore it around `process.chdir`.
+
+765 pass / 40 skip / 0 fail via `./scripts/tests/run-tests.sh`; eslint clean.

--- a/.beans/folio-assistant-zevm--qa-criterion-hash-fixture-drifted-bare-automated-c.md
+++ b/.beans/folio-assistant-zevm--qa-criterion-hash-fixture-drifted-bare-automated-c.md
@@ -1,0 +1,19 @@
+---
+# folio-assistant-zevm
+title: 'qa-criterion-hash fixture drifted: bare AUTOMATED_CHECKERS not matched'
+status: todo
+type: task
+priority: normal
+created_at: 2026-08-24T17:25:12Z
+updated_at: 2026-08-24T17:25:27Z
+---
+
+Pre-existing failure, surfaced while running the suite for the pypdf_safe work on branch claude/gracious-dijkstra-0ijp2l. Not caused by that change (its diff touches only PDF scripts and a skill doc).
+
+scripts/tests/qa-criterion-hash.test.ts:110 'resolves criteria in the real voice checker module' fails: criterionSourceHash() returns null for both 'voice-scholarly-default' and 'wall-side-correct' against content/pipeline/qa-checkers-voice.ts. 744 pass / 1 fail.
+
+Both keys DO exist in that module (lines 1167 and 1173), inside the record exported at line 1139. The other tests in the file, which run against a synthetic fixture, pass — so parseFile() works and it is findCriterionEntry() that misses on the real module.
+
+Likely cause, not yet confirmed: qa-criterion-hash.ts documents itself as finding an exported '*_AUTOMATED_CHECKERS' record, but qa-checkers-voice.ts exports a bare 'AUTOMATED_CHECKERS' with no prefix, and that record leads with spreads of the sub-registries. The test's own comment says it exists to guard the fixture shape 'against drifting from how checkers are really written' — so the test is doing its job and the fixture is what drifted.
+
+Consequence while open: every criterion in that module silently falls back to the whole-file hash, so any edit anywhere in a 1200-line file invalidates every criterion's cached QA result.

--- a/content/pipeline/qa-checkers-python.ts
+++ b/content/pipeline/qa-checkers-python.ts
@@ -1049,3 +1049,119 @@ export function checkUsesLibraryFrameworkAppropriately(
     hits,
   };
 }
+
+// ─── assertions_are_falsifiable ────────────────────────────────
+
+/**
+ * An `add_assertion(...)` call whose `computed` and `expected` are the SAME
+ * expression, so the assertion holds by construction.
+ *
+ * `allPassed: true` is what a block's `computation.status: "verified"` rests
+ * on. Where the assertion compares an expression to itself, `verified` means
+ * the script ran — not that anything it produced was checked. The corpus case
+ * that motivated this: `universal-ilp.py` asserted
+ * `computed=sel[0], expected=sel[0]` at all five levels, so its witness
+ * recorded `"computed": "sigma_1", "expected": "sigma_1"` and passed
+ * regardless of what the script computed (bean `qou-v5fp`). An AST census then
+ * found 266 of 3,482 such calls across 195 files (bean `qou-26f2`).
+ *
+ * ## Why regex and not AST
+ *
+ * Same trade-off as the rest of this module — no Python runtime in the QA
+ * sweep. Measured against the AST census on the qou corpus, the regex finds
+ * 240 of the 266 (90% recall) at 100% precision on the sampled hits. It
+ * **under**-reports, which is the right direction for a `fail`-grade
+ * criterion: a missed tautology stays a bean item, whereas a false one costs
+ * an author an argument with the checker.
+ *
+ * The known recall gap is calls spanning many lines with the two keywords far
+ * apart; `ASSERT_CALL_RE` bounds the window rather than matching greedily to
+ * the next `)`, which a nested call would otherwise swallow.
+ */
+/** Triple-quoted Python blocks — docstrings and block comments. */
+const PY_TRIPLE_QUOTED_RE = /"""[\s\S]*?"""|'''[\s\S]*?'''/g;
+
+const ASSERT_CALL_RE = /add_assertion\s*\(([\s\S]{0,600}?)\)\s*(?:$|[,\n])/gm;
+const KW_COMPUTED_RE = /(?:^|[\s,(])computed\s*=\s*([^,)]+)/;
+const KW_EXPECTED_RE = /(?:^|[\s,(])expected\s*=\s*([^,)]+)/;
+
+/**
+ * Normalise an argument expression for comparison: collapse whitespace, drop a
+ * trailing comment. Deliberately NOT semantic — `len(xs)` beside
+ * `len(list(xs))` is just as vacuous and is not caught. See the caveat on
+ * `qou-26f2`: this count is a lower bound.
+ */
+function normArg(s: string): string {
+  return s.replace(/#.*$/, "").replace(/\s+/g, " ").trim();
+}
+
+/**
+ * `assertions_are_falsifiable` — a witness assertion must be able to fail.
+ *
+ * Fires when `computed` and `expected` are textually the same expression.
+ * Both keyword form (`computed=x, expected=x`) and the positional form
+ * (`add_assertion(name, x, x)`) are checked.
+ */
+export function checkAssertionsAreFalsifiable(scriptPath: string): CheckerResult {
+  if (!existsSync(scriptPath)) return { result: "n/a", hits: [] };
+  let src: string;
+  try {
+    src = readFileSync(scriptPath, "utf-8");
+  } catch {
+    return { result: "n/a", hits: [] };
+  }
+  if (!src.includes("add_assertion")) return { result: "n/a", hits: [] };
+
+  // Blank out triple-quoted blocks, preserving newlines so reported line
+  // numbers stay true. `witness.py`'s own module docstring illustrates the API
+  // with `computed=2.0298, expected=2.0298`, and firing on the documentation
+  // of the function under test was the one false positive the first corpus run
+  // produced.
+  //
+  // Only TRIPLE-quoted strings are blanked, not every string literal: a number
+  // of genuine tautologies pass string values (`expected="0"`), and stripping
+  // those would trade one false positive for a batch of missed real ones.
+  const scan = src.replace(PY_TRIPLE_QUOTED_RE, (block) =>
+    block.replace(/[^\n]/g, " "),
+  );
+
+  const hits: CheckerHit[] = [];
+  for (const m of scan.matchAll(ASSERT_CALL_RE)) {
+    const body = m[1];
+    const c = body.match(KW_COMPUTED_RE);
+    const e = body.match(KW_EXPECTED_RE);
+    let computed: string | undefined;
+    let expected: string | undefined;
+    if (c && e) {
+      computed = normArg(c[1]);
+      expected = normArg(e[1]);
+    } else if (!c && !e) {
+      // Positional: add_assertion(name, computed, expected, …). Only consider
+      // it when there is no keyword form at all, so a half-keyword call is
+      // skipped rather than mis-parsed.
+      const parts = body.split(",");
+      if (parts.length < 3) continue;
+      computed = normArg(parts[1]);
+      expected = normArg(parts[2]);
+    } else {
+      continue;
+    }
+    if (!computed || !expected || computed !== expected) continue;
+    const line = scan.slice(0, m.index ?? 0).split("\n").length;
+    hits.push({
+      file: scriptPath,
+      line,
+      text:
+        `\`add_assertion\` compares \`${computed}\` to itself — ` +
+        `\`computed\` and \`expected\` are the same expression, so this ` +
+        `assertion holds by construction and \`allPassed\` says nothing ` +
+        `about what the script produced. Supply the value the assertion is ` +
+        `meant to check. If no independent expected value exists yet, assert ` +
+        `a different property that CAN fail rather than a longer tautology ` +
+        `— re-deriving the computation under test is the same defect spelled ` +
+        `out (bean \`qou-26f2\`).`,
+    });
+  }
+
+  return { result: hits.length > 0 ? "fail" : "pass", hits };
+}

--- a/content/pipeline/qa-checkers-vacuity.ts
+++ b/content/pipeline/qa-checkers-vacuity.ts
@@ -60,6 +60,16 @@ interface FieldAssign {
   name: string;
   value: string;
   line: number;
+  /**
+   * Whatever stood between the field name and `:=`.
+   *
+   * For `poleIndicator rho := decide (rho ≤ -1)` this is `rho` — the binders
+   * the author wrote on the left. For `d : ∀ c, … := 0` it is a type
+   * ascription and starts with `:`. `checkNoDefinitionalLaundering` uses it to
+   * recover binder names when the field was written point-full rather than as
+   * a lambda; every other reader ignores it.
+   */
+  binders: string;
 }
 
 /**
@@ -124,7 +134,7 @@ export function parseFieldAssigns(body: string, startLine: number): FieldAssign[
       value += " " + nxt.trim();
       j++;
     }
-    out.push({ name, value: value.trim(), line: startLine + i });
+    out.push({ name, value: value.trim(), line: startLine + i, binders: m[2].trim() });
   }
   return out;
 }
@@ -184,6 +194,36 @@ export function parseDecls(src: string): Decl[] {
  * zero object); a `rfl` discharge alone is often fine (a real reflexivity).
  * Together they mean the claim was arranged away rather than proved.
  */
+/**
+ * The sibling criterion's conjunction, as a predicate on one declaration.
+ *
+ * Factored out because `lean-no-definitional-laundering` needs to know whether
+ * this check already fires on a decl: the two criteria are meant to partition
+ * the defect, not to double-report it. Behaviour is unchanged — this is the
+ * body of the loop below, lifted.
+ */
+function vacuousDataConjunction(
+  d: Decl,
+): { degenerateData: FieldAssign[]; trivialClaims: FieldAssign[] } | null {
+  if (d.kind !== "instance" && d.kind !== "def") return null;
+  // `where` is tested against the whole declaration, not just its first
+  // line: a real instance signature wraps, and the motivating case put
+  // `where` three lines down after the instance binders. Requiring it in the
+  // header alone missed every multi-line declaration — which is most of them.
+  if (!/\bwhere\b/.test(d.header + "\n" + d.body)) return null;
+  const fields = parseFieldAssigns(d.body, d.line);
+  if (fields.length < 2) return null;
+
+  const degenerateData = fields.filter(
+    (f) => !isClaimField(f.name) && DEGENERATE_VALUE.test(f.value),
+  );
+  const trivialClaims = fields.filter(
+    (f) => isClaimField(f.name) && TRIVIAL_DISCHARGE.test(f.value),
+  );
+  if (degenerateData.length === 0 || trivialClaims.length === 0) return null;
+  return { degenerateData, trivialClaims };
+}
+
 export function checkNoVacuousInstanceData(leanPath?: string): CheckerResult {
   if (!leanPath || !existsSync(leanPath)) return { result: "n/a", hits: [] };
   let src: string;
@@ -191,22 +231,9 @@ export function checkNoVacuousInstanceData(leanPath?: string): CheckerResult {
 
   const hits: CheckerHit[] = [];
   for (const d of parseDecls(src)) {
-    if (d.kind !== "instance" && d.kind !== "def") continue;
-    // `where` is tested against the whole declaration, not just its first
-    // line: a real instance signature wraps, and the motivating case put
-    // `where` three lines down after the instance binders. Requiring it in the
-    // header alone missed every multi-line declaration — which is most of them.
-    if (!/\bwhere\b/.test(d.header + "\n" + d.body)) continue;
-    const fields = parseFieldAssigns(d.body, d.line);
-    if (fields.length < 2) continue;
-
-    const degenerateData = fields.filter(
-      (f) => !isClaimField(f.name) && DEGENERATE_VALUE.test(f.value),
-    );
-    const trivialClaims = fields.filter(
-      (f) => isClaimField(f.name) && TRIVIAL_DISCHARGE.test(f.value),
-    );
-    if (degenerateData.length === 0 || trivialClaims.length === 0) continue;
+    const conj = vacuousDataConjunction(d);
+    if (!conj) continue;
+    const { degenerateData, trivialClaims } = conj;
 
     // An unconditional `instance` is the severe form: typeclass resolution
     // supplies it everywhere, so downstream hypotheses stop being hypotheses.
@@ -311,10 +338,610 @@ export function checkDocstringHonesty(leanPath?: string): CheckerResult {
   return { result: hits.length ? "fail" : "pass", hits };
 }
 
+/* ------------------------------------------------------------------ *
+ * `lean-no-definitional-laundering`
+ *
+ * The sibling criterion above models vacuity as CONSTANT data. That model is
+ * exact and it is narrow. A hand pass over the qou corpus on 2026-08-24 found
+ * eight laundering sites and the detector found twenty-five — with a zero
+ * overlap. Both lists are real; they are different defects.
+ *
+ * What the constant model cannot see is data that is not constant and is still
+ * *chosen so the claim becomes `rfl`*:
+ *
+ *     class SubstrateWidthRule where
+ *       w        : ℕ → ℕ
+ *       is_color : ∀ A, w A = cableWidthColor     -- the claim
+ *
+ *     instance colorRule : SubstrateWidthRule where
+ *       w        := fun _ => cableWidthColor      -- …defined to BE the claim's RHS
+ *       is_color := fun _ => rfl
+ *
+ * `cableWidthColor` is not a degenerate token, the field is not `_ := 0`, and
+ * `DEGENERATE_VALUE` — anchored `^…$` — cannot see through the lambda either.
+ * Three separate reasons the old check passes it.
+ *
+ * This criterion adds three detections, all syntactic, all conjunctive:
+ *
+ *   1. CONSTANT-`Prop` DEFINITION. `def F (args…) : Prop := True` (or `False`),
+ *      possibly after `let`-bindings whose results are discarded. Every claim
+ *      stated in terms of `F` is free, and no instance is needed to launder it.
+ *      Requires ≥ 1 parameter: an argument-free `def X : Prop := True` is a
+ *      named tautology, which is `proof-no-trivial-true`'s `def-disguised-true`
+ *      pattern, not this one. Reporting it here would duplicate that criterion
+ *      without adding signal.
+ *
+ *   2. LAMBDA-WRAPPED CONSTANT FIELD. `member := fun _ => True` beside a
+ *      reflexivity discharge — the sibling criterion's exact conjunction, with
+ *      the constant hidden behind one lambda so its anchored regex misses it.
+ *      Every binder must be a wildcard; `fun n => 0` is a constant function
+ *      someone may have meant.
+ *
+ *   3. DEFINITIONAL IDENTITY (the `poleIndicator` shape). The class declares
+ *      `claim : ∀ …, data args = RHS`; the instance assigns `data := fun … =>
+ *      RHS` with the SAME RHS, and discharges `claim` by reflexivity. This one
+ *      needs the `class … where` block, so it is bounded to classes declared in
+ *      the same file — no import following.
+ *
+ * ## Detection 3 is a reading, not a verdict
+ *
+ * A definitional identity is sometimes exactly the content: pinning a field to
+ * a formula and observing that the law then holds by `rfl` is a legitimate way
+ * to exhibit a model. Whether the class field was a CONSTRAINT the instance was
+ * supposed to meet or a DEFINITION the instance was entitled to make is not a
+ * syntactic question — it is about what the class was for. So detection 3 hits
+ * are reported as `warn` (the schema's "borderline; reviewer flags but does not
+ * block"), never as an assertion of defect, and when the author's docstring
+ * disputes the reading the hit says so. `BorromeanQuark.canonical` is the
+ * worked example: its docstring argues the mass-calibration identity IS the
+ * content. It is still worth surfacing — but as a question.
+ *
+ * ## What is deliberately NOT here
+ *
+ * - **One-hop constant resolution** (`q0 := q_zero` where `def q_zero := …`).
+ *   Both corpus sites that motivated it (`ArchimedeanRealizationFunctor`,
+ *   `SubstrateWidthRule`) turn out to be detection-3 shapes — the named
+ *   constant is the class field's RHS — so following the name buys nothing
+ *   they do not already report, and following it in general would fire on
+ *   every instance that uses a named constant correctly.
+ * - **Semantic constancy.** `w A := 3 * A * 0` is constant and unreachable
+ *   from here. That needs `whnf`, i.e. the elaborator. See the note on the
+ *   sibling criterion; this file does not pretend to cover it.
+ * - **Cross-file classes.** Detection 3 needs the `class` block. Resolving an
+ *   imported class means resolving imports, and a wrong resolution produces a
+ *   confident false positive about a decl the checker never read.
+ *
+ * ## Tightened against
+ *
+ * The first corpus sweep returned 26. Every one was read, and five vetoes came
+ * out of the ones that were wrong — recorded here because the next person to
+ * loosen this check should know what each veto is holding back:
+ *
+ * - A discharge lambda that NAMES its binders is a proof, not a reflexivity
+ *   (`ti_eq := fun w => by simp [Equiv.punitProd]`) — see `REFL_DISCHARGE`.
+ * - A decl in which some law needed real tactic work is a model doing work —
+ *   see `isSubstantiveDischarge`.
+ * - Not every field a NAME calls a claim need be trivially discharged; one real
+ *   proof among them means the constants are a corner, not the whole model.
+ * - A declared inhabitation witness is the prescribed remedy, not the defect —
+ *   see `INHABITATION_WITNESS`.
+ * - A `theorem` exhibiting a record proves an existential; that is not this
+ *   criterion's business.
+ * ------------------------------------------------------------------ */
+
+/** Strip Lean block comments (docstrings included) and line comments. */
+function stripLeanComments(src: string): string {
+  return src.replace(/\/-[\s\S]*?-\//g, "").replace(/--.*$/gm, "");
+}
+
+/** Collapse whitespace so two spellings of one expression compare equal. */
+function normExpr(s: string): string {
+  let t = s.replace(/\s+/g, " ").trim();
+  // Peel parentheses that wrap the whole expression: `(f x)` vs `f x`.
+  while (t.startsWith("(") && t.endsWith(")")) {
+    let depth = 0;
+    let wraps = true;
+    for (let i = 0; i < t.length; i++) {
+      if (t[i] === "(") depth++;
+      else if (t[i] === ")") {
+        depth--;
+        if (depth === 0 && i < t.length - 1) { wraps = false; break; }
+      }
+    }
+    if (!wraps) break;
+    t = t.slice(1, -1).trim();
+  }
+  return t;
+}
+
+const OPENERS = "([{⟨⦃";
+const CLOSERS = ")]}⟩⦄";
+
+/** Index of the first `,` at bracket depth 0, or -1. */
+function topLevelComma(s: string, from: number): number {
+  let depth = 0;
+  for (let i = from; i < s.length; i++) {
+    const c = s[i];
+    if (OPENERS.includes(c)) depth++;
+    else if (CLOSERS.includes(c)) depth--;
+    else if (c === "," && depth === 0) return i;
+  }
+  return -1;
+}
+
+/** Split on `→` / `->` at bracket depth 0. */
+function splitArrows(s: string): string[] {
+  const out: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (OPENERS.includes(c)) depth++;
+    else if (CLOSERS.includes(c)) depth--;
+    else if (depth === 0 && (c === "→" || (c === "-" && s[i + 1] === ">"))) {
+      out.push(s.slice(start, i));
+      i += c === "→" ? 0 : 1;
+      start = i + 1;
+    }
+  }
+  out.push(s.slice(start));
+  return out.map((x) => x.trim()).filter((x) => x.length > 0);
+}
+
+/** Drop leading `∀ …,` / `Π …,` binder groups to expose the conclusion. */
+function stripBinders(s: string): string {
+  let t = s.trim();
+  for (let guard = 0; guard < 16; guard++) {
+    if (!/^[∀Π]/.test(t)) return t;
+    const idx = topLevelComma(t, 1);
+    if (idx < 0) return t;
+    t = t.slice(idx + 1).trim();
+  }
+  return t;
+}
+
+/**
+ * The conclusion of a field's type: what it asserts once every binder and
+ * hypothesis is discharged.
+ *
+ * Alternating `stripBinders` / `splitArrows` to a fixed point, because binders
+ * and hypotheses interleave: `∀ i, i < level → ∀ v w, member v = f w` puts a
+ * second `∀` AFTER a hypothesis arrow, and stripping only the outer one leaves
+ * the conclusion unreached.
+ */
+function conclusionOf(type: string): string {
+  let t = type.trim();
+  for (let guard = 0; guard < 8; guard++) {
+    const pieces = splitArrows(stripBinders(t));
+    const last = pieces[pieces.length - 1] ?? "";
+    if (last === t) return t;
+    t = last;
+  }
+  return t;
+}
+
+/** A field declared inside a `class`/`structure` body. */
+export interface StructField {
+  name: string;
+  type: string;
+}
+
+/** A `class`/`structure` declaration and the fields it declares. */
+export interface StructDecl {
+  kind: "class" | "structure";
+  name: string;
+  line: number;
+  fields: StructField[];
+}
+
+const STRUCT_HEAD =
+  /^(?:@\[[^\]]*\]\s*)?(?:noncomputable\s+|private\s+|protected\s+|scoped\s+)*(class|structure)\s+([A-Za-z_][A-Za-z0-9_'.!?]*)/;
+
+/**
+ * Split a Lean file into its `class` / `structure` declarations.
+ *
+ * Separate from `parseDecls`, which treats a `class` line as a body terminator
+ * and never looks inside one. Detection 3 needs what the class DECLARES — an
+ * instance body alone cannot say which of its fields is the claim.
+ */
+export function parseStructureDecls(src: string): StructDecl[] {
+  const lines = src.split("\n");
+  const out: StructDecl[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(STRUCT_HEAD);
+    if (!m) continue;
+    const declLines = [lines[i]];
+    let j = i + 1;
+    while (j < lines.length) {
+      if (
+        /^(?:@\[|\/-|noncomputable\s|private\s|protected\s|instance\s|def\s|theorem\s|abbrev\s|structure\s|class\s|opaque\s|axiom\s|inductive\s|example\s|end\s|namespace\s|section\s)/.test(
+          lines[j],
+        )
+      ) break;
+      declLines.push(lines[j]);
+      j++;
+    }
+    i = j - 1;
+    const text = stripLeanComments(declLines.join("\n"));
+    const w = text.match(/\bwhere\b/);
+    if (!w || w.index === undefined) continue;
+    const bodyText = text.slice(w.index + w[0].length);
+    out.push({
+      kind: m[1] as StructDecl["kind"],
+      name: m[2],
+      line: i + 1,
+      fields: parseStructFields(bodyText),
+    });
+  }
+  return out;
+}
+
+/** `name : type` entries in a class body, absorbing wrapped types. */
+function parseStructFields(body: string): StructField[] {
+  const fields: StructField[] = [];
+  const lines = body.split("\n");
+  for (let k = 0; k < lines.length; k++) {
+    const raw = lines[k];
+    if (!raw.trim()) continue;
+    const fm = raw.match(/^(\s+)([A-Za-z_][A-Za-z0-9_'!?]*)\s*:(?!=)\s*(.*)$/);
+    if (!fm) continue;
+    const indent = fm[1].length;
+    let type = fm[3].trim();
+    let k2 = k + 1;
+    while (k2 < lines.length) {
+      const nxt = lines[k2];
+      if (!nxt.trim()) { k2++; continue; }
+      if (nxt.length - nxt.trimStart().length <= indent) break;
+      type += " " + nxt.trim();
+      k2++;
+    }
+    fields.push({ name: fm[2], type: type.trim() });
+    k = k2 - 1;
+  }
+  return fields;
+}
+
+/**
+ * A class field whose type says "this other field equals THIS expression".
+ *
+ * `is_color : ∀ A, w A = cableWidthColor` yields
+ * `{ claim: "is_color", data: "w", args: ["A"], rhs: "cableWidthColor" }`.
+ */
+interface DefinitionalClaim {
+  claim: string;
+  data: string;
+  args: string[];
+  rhs: string;
+}
+
+/**
+ * The equation must be the field's CONCLUSION, not any `=` anywhere in its
+ * type. `demazure_closure : ∀ i, i < level → ∀ v w, member v → G.f i v = some
+ * w → member w` contains an `=`, and reading it as the field's claim would
+ * invent an RHS the author never wrote. Binders are stripped and the type is
+ * split on top-level `→` so only the final conclusion is matched.
+ */
+const EQ_CONCLUSION =
+  /^([A-Za-z_][A-Za-z0-9_'!?₀-₉]*)\s*([^=]*?)(?<![<>!:≤≥≠~])=(?![=>])\s*(.+)$/;
+
+/** Args must be plain binder names for the alpha-rename below to be sound. */
+const SIMPLE_ARGS = /^[A-Za-z0-9_'!?₀-₉\s]*$/;
+
+function definitionalClaims(cls: StructDecl): DefinitionalClaim[] {
+  const names = new Set(cls.fields.map((f) => f.name));
+  const out: DefinitionalClaim[] = [];
+  for (const f of cls.fields) {
+    const concl = conclusionOf(f.type);
+    if (!concl) continue;
+    const m = concl.match(EQ_CONCLUSION);
+    if (!m) continue;
+    const data = m[1];
+    if (data === f.name || !names.has(data)) continue;
+    if (!SIMPLE_ARGS.test(m[2])) continue;
+    out.push({
+      claim: f.name,
+      data,
+      args: m[2].trim().split(/\s+/).filter(Boolean),
+      rhs: normExpr(m[3]),
+    });
+  }
+  return out;
+}
+
+/** `fun a b => body` / `λ a b ↦ body` → binders + body. */
+function splitLambda(value: string): { binders: string[]; body: string } | null {
+  const m = value.match(/^(?:fun|λ)\s+([^=↦]*?)\s*(?:=>|↦)\s*([\s\S]*)$/);
+  if (!m) return null;
+  const binders = m[1].trim().split(/\s+/).filter(Boolean);
+  if (!binders.every((b) => /^[A-Za-z_][A-Za-z0-9_'!?₀-₉]*$/.test(b))) return null;
+  return { binders, body: m[2].trim() };
+}
+
+/**
+ * Rename the instance's binders to the class's argument names, positionally.
+ *
+ * `poleIndicator := fun x => decide (x ≤ -1)` must compare equal to the class's
+ * `poleIndicator rho = decide (rho ≤ -1)`. Two phases so a rename cannot
+ * capture a name a later rename is about to introduce.
+ */
+function alphaRename(body: string, from: string[], to: string[]): string {
+  if (from.length !== to.length || from.length === 0) return body;
+  // NUL-delimited, and written as an escape rather than typed as a raw byte:
+  // a PRINTABLE placeholder collides with the source. Routing `y → x` through
+  // `" 0 "` would rewrite `g 0 y` to `g x x`, manufacturing a match out of a
+  // numeral the author wrote.
+  const hole = (i: number) => `\u0000${i}\u0000`;
+  let t = body;
+  for (let i = 0; i < from.length; i++) {
+    if (from[i] === "_") continue;
+    t = t.replace(new RegExp(`(?<![A-Za-z0-9_'])${escapeRe(from[i])}(?![A-Za-z0-9_'])`, "g"), hole(i));
+  }
+  for (let i = 0; i < to.length; i++) t = t.split(hole(i)).join(to[i]);
+  return t;
+}
+
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Reflexivity discharges, including multi-binder lambdas.
+ *
+ * Wider than `TRIVIAL_DISCHARGE` above on purpose, and kept separate on
+ * purpose: `volume_calibrates_mass := fun _ _ => rfl` has TWO wildcard binders
+ * and the sibling criterion's `fun\s+_+\s*=>` matches only one. Widening the
+ * shared constant would loosen a check whose precision is the reason it has
+ * near-zero false positives.
+ *
+ * The binders must be WILDCARDS. `ti_eq := fun w => by simp [Equiv.punitProd]`
+ * names its argument and rewrites with a named lemma; reading that as a
+ * reflexivity discharge produced four of the first sweep's false positives
+ * (`HeckeCommutingCellReduction`, `HeckeDihedralBraidReduction`). A discharge
+ * that IGNORES its arguments is the signal; one that uses them is a proof.
+ */
+const REFL_DISCHARGE =
+  /^(?:(?:fun|λ)\s+(?:_[A-Za-z0-9_'!?]*\s+)*(?:=>|↦)\s*)?(?:rfl|Iff\.rfl|Eq\.refl\b.*|trivial|True\.intro|\.intro|⟨⟩|by\s+(?:rfl|trivial|simp\s*\[[^\]]*\]|simp|norm_num|decide|positivity|constructor|exact\s+rfl|exact\s+Iff\.rfl))\s*$/;
+
+/**
+ * A field discharged by real work rather than by reflexivity.
+ *
+ * Used as a whole-declaration veto for detection 2. A decl in which SOME law
+ * needed a genuine tactic proof is a small model doing work, not a laundering:
+ * the constant fields are the model's degenerate corner, and the class is being
+ * shown satisfiable. `verlindeData_two` (`D_sq := by rw […]; rw […]; norm_num`),
+ * `spectralData_zero` (`rank`, `decomp`) and `localization_two`
+ * (`globalDim_ne`) are all this shape and all were false positives.
+ *
+ * Purely structural — no docstring involved, so it cannot be talked around.
+ */
+function isSubstantiveDischarge(value: string): boolean {
+  const v = value.trim();
+  if (REFL_DISCHARGE.test(v)) return false;
+  return /(?:^|\s)by\b/.test(v);
+}
+
+/**
+ * A docstring declaring the decl to be an inhabitation / non-vacuity witness.
+ *
+ * This IS a gameable escape hatch, and it is here for the same reason
+ * `NEGATED_HONESTY_CLAIM` is: the registry's own remedy for
+ * `lean-no-vacuous-instance-data` tells authors to write exactly this
+ * declaration — "one instance at the trivial datum showing the hypothesis is
+ * satisfiable" — so firing on it punishes the prescribed fix. `rtData_two` is
+ * the corpus case the structural vetoes above do not reach: every one of its
+ * fields is a one-liner, so nothing marks it as doing work, and the only thing
+ * separating it from a laundering is the stated intent.
+ *
+ * Kept narrow on purpose. "genuine" is NOT a trigger — `instSl2DemazureSubcrystal`
+ * calls itself "a genuine `DemazureSubcrystal`" and is a real finding.
+ */
+const INHABITATION_WITNESS =
+  /\b(?:non-?vacuity|not\s+vacuous|is\s+inhabited|inhabitation|satisfiab|not\s+conditional-on-`?False)/i;
+
+/** `fun _ _ => <constant>` — every binder a wildcard. */
+const WILDCARD_LAMBDA =
+  /^(?:fun|λ)\s+((?:_[A-Za-z0-9_'!?]*\s+)+)(?:=>|↦)\s*([\s\S]+)$/;
+
+/** Heads `parseFieldAssigns` picks up from tactic blocks that are not fields. */
+const NOT_A_FIELD = new Set([
+  "let", "have", "set", "show", "suffices", "obtain", "calc", "fun", "match",
+  "by", "exact", "refine", "apply", "use", "intro", "intros", "simp", "rw",
+  "case", "next", "with", "do", "if", "then", "else", "try", "all_goals",
+]);
+
+/** Trim a decl body at the first line that opens an unrelated declaration. */
+const FOREIGN_DECL = /^(?:opaque|axiom|inductive|example)\s/;
+
+function declText(d: Decl): string {
+  const kept: string[] = [];
+  for (const l of d.body.split("\n")) {
+    if (FOREIGN_DECL.test(l)) break;
+    kept.push(l);
+  }
+  return d.header + "\n" + kept.join("\n");
+}
+
+/**
+ * `lean-no-definitional-laundering` — data chosen so the claim is `rfl`, in the
+ * three shapes the constant model cannot see. See the block comment above.
+ */
+export function checkNoDefinitionalLaundering(leanPath?: string): CheckerResult {
+  if (!leanPath || !existsSync(leanPath)) return { result: "n/a", hits: [] };
+  let src: string;
+  try { src = readFileSync(leanPath, "utf8"); } catch { return { result: "n/a", hits: [] }; }
+
+  const hits: CheckerHit[] = [];
+  const metrics = { constant_prop_defs: 0, lambda_constant_fields: 0, definitional_identities: 0 };
+  const classes = parseStructureDecls(src);
+  const claimIndex = classes.map((c) => ({ cls: c, claims: definitionalClaims(c) }));
+
+  for (const d of parseDecls(src)) {
+    // Report only what the sibling criterion cannot see. The two lists were
+    // measured disjoint on the qou corpus and that is the point of splitting
+    // them; a decl already flagged there does not need a second, weaker
+    // description of the same defect.
+    if (vacuousDataConjunction(d)) continue;
+    const whole = declText(d);
+
+    // ── 1. `def F (args…) : Prop := True` ────────────────────────────
+    if (d.kind === "def" || d.kind === "abbrev") {
+      const constProp = constantPropBody(whole, d.name);
+      if (constProp) {
+        metrics.constant_prop_defs++;
+        hits.push({
+          file: leanPath,
+          line: d.line,
+          text:
+            `\`${d.name}\` takes ${constProp.arity} argument group${constProp.arity === 1 ? "" : "s"} ` +
+            `and its body is the constant \`${constProp.value}\`. It is a name reserved for a claim, ` +
+            `not the claim: it is equal to every other tautology, so anything stated in terms of it — ` +
+            `an iff, a hypothesis, a downstream theorem — is discharged by \`${constProp.value === "True" ? "Iff.rfl` / `trivial" : "not_false"}\` ` +
+            `and constrains nothing. Seal the body (\`opaque\`) or state the real proposition with a ` +
+            `\`sorry\` so \`#print axioms\` can see the gap.`,
+        });
+      }
+    }
+
+    // Detections 2 and 3 read a structure-instance body. A `theorem` that
+    // builds a record inside its proof — `⟨{ traceValue := ∏ …, factorization
+    // := rfl }, rfl, rfl, rfl⟩` in `markov_trace_product` — is exhibiting a
+    // witness for an existential, which is how one proves `∃`. Theorem-shaped
+    // vacuity belongs to `proof-no-self-assuming-projection` /
+    // `proof-no-trivial-true`.
+    if (d.kind === "theorem") continue;
+
+    const fields = parseFieldAssigns(d.body, d.line).filter((f) => !NOT_A_FIELD.has(f.name));
+    if (fields.length < 2) continue;
+    const byName = new Map(fields.map((f) => [f.name, f]));
+
+    // ── 2. `data := fun _ => <degenerate>` + a reflexivity discharge ──
+    //
+    // Three vetoes, all learned from the first corpus sweep: the decl must do
+    // no substantive proof work anywhere, EVERY field its name marks as a
+    // claim must be trivially discharged (one real proof among them means the
+    // constants are a corner of a working model), and it must not declare
+    // itself an inhabitation witness.
+    const lambdaConst = fields.filter((f) => {
+      if (isClaimField(f.name)) return false;
+      const m = f.value.match(WILDCARD_LAMBDA);
+      return !!m && DEGENERATE_VALUE.test(m[2].trim());
+    });
+    const claimFields = fields.filter((f) => isClaimField(f.name));
+    const trivialClaims = claimFields.filter((f) => REFL_DISCHARGE.test(f.value));
+    const doesRealWork =
+      fields.some((f) => isSubstantiveDischarge(f.value)) ||
+      trivialClaims.length !== claimFields.length ||
+      INHABITATION_WITNESS.test(d.docstring);
+    if (lambdaConst.length && trivialClaims.length && !doesRealWork) {
+      metrics.lambda_constant_fields += lambdaConst.length;
+      for (const c of trivialClaims) {
+        hits.push({
+          file: leanPath,
+          line: c.line,
+          text:
+            `${d.kind} \`${d.name}\`: claim field \`${c.name} := ${c.value}\` is discharged by ` +
+            `reflexivity, and the data it constrains is a constant behind a lambda ` +
+            `(${lambdaConst.map((f) => `${f.name} := ${f.value}`).join(", ")}). Same defect as ` +
+            `\`lean-no-vacuous-instance-data\`, one \`fun _ =>\` deeper than its anchored ` +
+            `degenerate-value match can reach.`,
+        });
+      }
+    }
+
+    // ── 3. data defined to BE the claim's right-hand side ─────────────
+    for (const { cls, claims } of claimIndex) {
+      for (const dc of claims) {
+        const dataField = byName.get(dc.data);
+        const claimField = byName.get(dc.claim);
+        if (!dataField || !claimField) continue;
+        if (!REFL_DISCHARGE.test(claimField.value)) continue;
+        const lam = splitLambda(dataField.value);
+        const binders = lam ? lam.binders : dataField.binders.startsWith(":") ? [] : dataField.binders.split(/\s+/).filter(Boolean);
+        const rawBody = lam ? lam.body : dataField.value;
+        if (normExpr(alphaRename(rawBody, binders, dc.args)) !== dc.rhs) continue;
+        metrics.definitional_identities++;
+        const disputed = DISPUTED_DEFINITIONAL.test(d.docstring);
+        hits.push({
+          file: leanPath,
+          line: dataField.line,
+          text:
+            `REVIEW (not a verdict) — ${d.kind} \`${d.name}\` assigns \`${dc.data} := ${dataField.value}\`, ` +
+            `which is exactly the right-hand side of \`${cls.name}.${dc.claim}\` ` +
+            `(\`${dc.data}${dc.args.length ? " " + dc.args.join(" ") : ""} = ${dc.rhs}\`), and then discharges ` +
+            `that field by \`${claimField.value}\`. The claim holds by definition because the data was defined ` +
+            `to make it hold. Whether that is laundering or content depends on what the class field was FOR — ` +
+            `a constraint the instance had to meet, or a definition it was entitled to make — and that is not ` +
+            `a syntactic question. Decide, and record the decision.` +
+            (disputed
+              ? ` The docstring disputes this reading; treat it as answered unless the class field was meant as a constraint.`
+              : ""),
+        });
+      }
+    }
+  }
+
+  const hard = metrics.constant_prop_defs + metrics.lambda_constant_fields;
+  return {
+    result: hits.length === 0 ? "pass" : hard > 0 ? "fail" : "warn",
+    hits,
+    metrics,
+  };
+}
+
+/**
+ * Docstring phrasing that argues the definitional identity is the content.
+ *
+ * Mirrors `NEGATED_HONESTY_CLAIM`'s role for `lean-docstring-honesty`: the
+ * checker still reports, but it must not assert a defect over the author's
+ * stated reasoning.
+ */
+const DISPUTED_DEFINITIONAL =
+  /\b(?:genuine\s+(?:content|instance|input)|non-?vacuous|not\s+(?:a\s+)?vacuous|holds?\s+definitionally|definitional(?:ly)?\s+(?:identity|content)|not\s+chosen(?:\s+to)?|\*derived\*)\b/i;
+
+/**
+ * `def F (args…) : Prop := True | False`, allowing discarded `let`/`have`.
+ *
+ * The remainder after the `let`s must be EXACTLY `True` or `False`. Anything
+ * else is a real proposition and the check declines to guess — a body it
+ * cannot read in full is a body it must not report on.
+ */
+function constantPropBody(
+  whole: string,
+  declName: string,
+): { value: "True" | "False"; arity: number } | null {
+  const text = stripLeanComments(whole);
+  const at = text.search(/:\s*Prop\s*:=/);
+  if (at < 0) return null;
+  const sig = text.slice(0, at).replace(
+    new RegExp(`^[\\s\\S]*?\\b(?:def|abbrev)\\s+${escapeRe(declName)}`),
+    "",
+  );
+  // Top-level groups only. A binder whose TYPE has parentheses —
+  // `(f : (ℕ → ℕ))` — is one argument group, not two, and the count is quoted
+  // back to the reader.
+  let arity = 0;
+  let depth = 0;
+  for (const c of sig) {
+    if (OPENERS.includes(c)) { if (depth === 0) arity++; depth++; }
+    else if (CLOSERS.includes(c)) depth--;
+  }
+  if (arity === 0) return null;
+  const after = text.slice(at).replace(/^:\s*Prop\s*:=/, "");
+  const rest = after
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0 && !/^(?:let|have|set)\b/.test(l))
+    .join(" ")
+    .trim();
+  if (rest === "True" || rest === "False") return { value: rest, arity };
+  return null;
+}
+
 export const VACUITY_AUTOMATED_CHECKERS: Record<
   string,
   (paths: { md?: string; ts?: string; lean?: string }) => CheckerResult
 > = {
   "lean-no-vacuous-instance-data": (p) => checkNoVacuousInstanceData(p.lean),
+  "lean-no-definitional-laundering": (p) => checkNoDefinitionalLaundering(p.lean),
   "lean-docstring-honesty": (p) => checkDocstringHonesty(p.lean),
 };

--- a/content/pipeline/qa-checkers-vacuity.ts
+++ b/content/pipeline/qa-checkers-vacuity.ts
@@ -241,7 +241,19 @@ const HONESTY_CLAIM =
  * quoting the false claim being corrected.
  */
 const NEGATED_HONESTY_CLAIM =
-  /\b(?:no\s+`?sorry`?|not\s+a\s+`?sorry`?|without\s+(?:a\s+)?`?sorry`?|there\s+is\s+no\s+`?sorry`?|contains?\s+(?:no|neither)\b)/i;
+  /\b(?:no\s+`?sorry`?|not\s+a\s+`?sorry`?|without\s+(?:a\s+)?`?sorry`?|there\s+is\s+no\s+`?sorry`?|contains?\s+(?:no|neither)\b|sorry-free|rather\s+than\s+(?:as\s+)?a\s+`?sorry`?|not\s+by\s+a\s+`?sorry`?)/i;
+
+/**
+ * A *past-tense* mention: the term used to carry a `sorry` and no longer does.
+ *
+ * Recording that history is good practice in this corpus — "carried here as a
+ * `sorry` until 2026-08-17 (bean `qou-gjg6`); it is not provable by this route,
+ * and it was deleted" is a docstring doing its job. Reading it as a present
+ * claim inverts the criterion, flagging the note precisely because it is
+ * thorough.
+ */
+const PAST_TENSE_SORRY =
+  /\b(?:was|were|had\s+been|used\s+to\s+be|until\s+\d{4}-\d{2}-\d{2}|formerly|previously|no\s+longer|since\s+deleted|has\s+been\s+(?:removed|deleted|discharged|replaced))\b/i;
 
 /**
  * `lean-docstring-honesty` — a docstring that claims the term carries a
@@ -269,6 +281,7 @@ export function checkDocstringHonesty(leanPath?: string): CheckerResult {
     // repaired `ConfinementGradingCorrespondence.canonical`, whose new
     // docstring quotes the old false claim in order to explain it.
     if (NEGATED_HONESTY_CLAIM.test(d.docstring)) continue;
+    if (PAST_TENSE_SORRY.test(d.docstring)) continue;
     const whole = d.header + "\n" + d.body;
     // Strip comments before looking for `sorry`, so a docstring or an inline
     // note *about* sorries does not count as one.

--- a/content/pipeline/qa-checkers-vacuity.ts
+++ b/content/pipeline/qa-checkers-vacuity.ts
@@ -193,6 +193,11 @@ export function parseDecls(src: string): Decl[] {
  * Both halves are required. Degenerate data alone is often fine (a genuinely
  * zero object); a `rfl` discharge alone is often fine (a real reflexivity).
  * Together they mean the claim was arranged away rather than proved.
+ *
+ * And a third condition, added 2026-08-24: the declaration must do no
+ * substantive proof work anywhere. Without it the conjunction fires on a
+ * declaration that supplies ONE degenerate-looking datum beside genuinely
+ * non-constant data — see `doesSubstantiveWork`.
  */
 /**
  * The sibling criterion's conjunction, as a predicate on one declaration.
@@ -217,11 +222,63 @@ function vacuousDataConjunction(
   const degenerateData = fields.filter(
     (f) => !isClaimField(f.name) && DEGENERATE_VALUE.test(f.value),
   );
-  const trivialClaims = fields.filter(
-    (f) => isClaimField(f.name) && TRIVIAL_DISCHARGE.test(f.value),
-  );
+  const claimFields = fields.filter((f) => isClaimField(f.name));
+  const trivialClaims = claimFields.filter((f) => TRIVIAL_DISCHARGE.test(f.value));
   if (degenerateData.length === 0 || trivialClaims.length === 0) return null;
+  if (fields.some((f) => !isClaimField(f.name) && isArgumentDependent(f))) return null;
   return { degenerateData, trivialClaims };
+}
+
+/**
+ * A data field whose value genuinely depends on an argument it binds.
+ *
+ * The veto this serves: **a declaration that computes from its arguments is not
+ * dodging an obligation.** Constant data is the entire mechanism of the defect
+ * this criterion looks for — `carrier := PUnit`, `frobWeight _ := 1`,
+ * `hecke_relation := True`. A field that reads its own binder cannot be part of
+ * that mechanism, and its presence means the degenerate-looking siblings are a
+ * corner of a working model.
+ *
+ * `sl3DemazureLevelOne` (`QOU/Machinery/KashiwaraCrystalBasic.lean`) is the
+ * corpus case that forced this. It is the three-vertex crystal written
+ * *specifically* to give `DemazureSubcrystal.demazure_closure` teeth — a proper
+ * sub-crystal `{0,1}` whose closure is checked by exhaustion — and the
+ * conjunction fired on it because `highest := 0` matched `DEGENERATE_VALUE`
+ * (there it is a vertex index, not a degenerate value) and `highest_mem := by
+ * decide` matched `TRIVIAL_DISCHARGE` (there it evaluates `0 ≠ 2`). Its sibling
+ * `member := fun v => v ≠ 2` reads `v`, and nothing about the declaration is
+ * arranged away. Firing on the declaration written to *fix* the defect is the
+ * worst failure mode this criterion has: it reads as evidence the fix did not
+ * take.
+ *
+ * **Why not the sibling criterion's `doesRealWork` veto** ("some field carries a
+ * tactic proof, or some claim is non-trivially discharged"). Measured on the qou
+ * corpus it takes this criterion from 26 hits to 6, and the 20 it removes are
+ * overwhelmingly true positives: `triv_hecke` survives it on
+ * `carrier_addCommGroup := by infer_instance`, and
+ * `witnessR5Full_deuterium_placeholder` on a `by simp` carrying an inline
+ * comment — neither of which is work. `isSubstantiveDischarge` is calibrated for
+ * a population whose fields are already known non-constant; here it is a
+ * `by`-detector. Argument-dependence removes exactly one hit, the false
+ * positive.
+ *
+ * Wildcard binders do not count: `mul _ _ := PUnit.unit` and `centralIdem _ :=
+ * 𝟙 _` discard their arguments, which is what constant data looks like when the
+ * field has a function type.
+ */
+function isArgumentDependent(f: FieldAssign): boolean {
+  const lam = splitLambda(f.value);
+  const binders = lam
+    ? lam.binders
+    : f.binders.startsWith(":")
+      ? []
+      : f.binders.split(/\s+/).filter(Boolean);
+  const body = lam ? lam.body : f.value;
+  return binders
+    .filter((b) => !b.startsWith("_"))
+    .some((b) =>
+      new RegExp(`(?<![A-Za-z0-9_'!?₀-₉])${escapeRe(b)}(?![A-Za-z0-9_'!?₀-₉])`).test(body),
+    );
 }
 
 export function checkNoVacuousInstanceData(leanPath?: string): CheckerResult {
@@ -839,11 +896,15 @@ export function checkNoDefinitionalLaundering(leanPath?: string): CheckerResult 
           file: leanPath,
           line: c.line,
           text:
-            `${d.kind} \`${d.name}\`: claim field \`${c.name} := ${c.value}\` is discharged by ` +
-            `reflexivity, and the data it constrains is a constant behind a lambda ` +
-            `(${lambdaConst.map((f) => `${f.name} := ${f.value}`).join(", ")}). Same defect as ` +
+            `REVIEW (not a verdict) — ${d.kind} \`${d.name}\`: claim field \`${c.name} := ${c.value}\` ` +
+            `is discharged by reflexivity, and the data it constrains is a constant behind a lambda ` +
+            `(${lambdaConst.map((f) => `${f.name} := ${f.value}`).join(", ")}). Same shape as ` +
             `\`lean-no-vacuous-instance-data\`, one \`fun _ =>\` deeper than its anchored ` +
-            `degenerate-value match can reach.`,
+            `degenerate-value match can reach. What this establishes is that the claim fields ` +
+            `carry no force — not that the constant is wrong. It may be the value the mathematics ` +
+            `forces: \`instSl2DemazureSubcrystal\` has \`member := fun _ => True\` because the ` +
+            `level-1 Demazure sub-crystal of \`B(Λ₁)\` really is the whole two-vertex crystal. ` +
+            `Decide which, and record the decision in the docstring.`,
         });
       }
     }
@@ -880,7 +941,21 @@ export function checkNoDefinitionalLaundering(leanPath?: string): CheckerResult 
     }
   }
 
-  const hard = metrics.constant_prop_defs + metrics.lambda_constant_fields;
+  // Only detection 1 is a verdict. `def F (args…) : Prop := True` is a
+  // tautology whatever the author meant by it — the proposition is wrong, not
+  // just unexercised, and no reading of the surrounding mathematics rescues it.
+  //
+  // Detections 2 and 3 both turn on the same non-syntactic question: was the
+  // constant the value the mathematics forces, or a way of arranging the claim
+  // away? Detection 3 has always said so in its evidence and graded `warn`;
+  // detection 2 shipped as `fail` and was immediately wrong about
+  // `instSl2DemazureSubcrystal` (2026-08-24), whose `member := fun _ => True`
+  // is correct — `sl₂` has one simple root, so the level-1 Demazure
+  // sub-crystal of `B(Λ₁)` is the whole crystal. Its docstring concedes the
+  // exact vacuity this reports and there is nothing left to fix, so a `fail`
+  // there is a red that no correct edit can clear. A critical criterion that
+  // cannot be satisfied by correct content gets switched off, not obeyed.
+  const hard = metrics.constant_prop_defs;
   return {
     result: hits.length === 0 ? "pass" : hard > 0 ? "fail" : "warn",
     hits,

--- a/content/pipeline/qa-checkers-vacuity.ts
+++ b/content/pipeline/qa-checkers-vacuity.ts
@@ -1,0 +1,296 @@
+#!/usr/bin/env bun
+/**
+ * Vacuity-by-construction axis — two AST checks over a block's `.lean`.
+ *
+ * ## The defect
+ *
+ * A class carries data fields and a propositional field relating them. An
+ * instance then chooses the data so that the proposition becomes `rfl`:
+ *
+ *     class ConfinementGradingCorrespondence ... where
+ *       confLevel        : NormalForm → ℕ
+ *       klrTopDegree     : NormalForm → ℕ
+ *       filtrations_agree : ∀ T, confLevel T = klrTopDegree T   -- the conjecture
+ *
+ *     instance canonical ... where
+ *       confLevel    _ := 0
+ *       klrTopDegree _ := 0
+ *       filtrations_agree _ := rfl                              -- 0 = 0
+ *
+ * The conjecture is not proved. It is *avoided*, by making both filtrations
+ * identically zero. And because this was an unconditional `instance`, typeclass
+ * resolution supplied it for every `R` and `q`, so every downstream theorem
+ * taking the class as a hypothesis became unconditional and vacuous.
+ *
+ * ## Why this is a different check from the ones already here
+ *
+ * `check-self-discharging-instances.ts` looks at the **proof**: it flags a
+ * propositional field discharged by `rfl`. That is the wrong half. Plenty of
+ * legitimate instances discharge a field by `rfl` because the fact genuinely is
+ * reflexivity — which is why that checker reports 125 instances and cannot rank
+ * the 17 it calls trivial.
+ *
+ * The tell is the **data**. The proposition became `rfl` *because* the data
+ * fields were chosen constant. Requiring both halves — degenerate data AND a
+ * reflexivity discharge — is far more specific, and it does not fire on an
+ * instance that computes something.
+ *
+ * `proof-no-trivial-true` in the registry covers the neighbouring case where
+ * the *stated goal* is a tautology. It is `automated: false`, agent-checked.
+ * This axis is `automated: true`, which is the point: the conjunction above is
+ * syntactic, so it costs no agent turns.
+ *
+ * ## Scope, honestly
+ *
+ * Syntactic. It catches data that is *written* as a constant. It does not catch
+ * data that is constant for a non-obvious reason — `confLevel T := T.length * 0`,
+ * or a value that happens not to vary. That residue needs a reading pass or
+ * Lean-level `whnf` introspection, and this file does not pretend to cover it.
+ *
+ * The durable fix is neither check: give the class a non-degeneracy field
+ * (`nondegenerate : ∃ T, confLevel T ≠ 0`) so a zero model cannot be written at
+ * all. Detection is the fallback for classes that already exist.
+ */
+
+import { readFileSync, existsSync } from "fs";
+import type { CheckerResult, CheckerHit } from "./qa-checkers-voice";
+
+/** A field assignment inside a structure-instance body. */
+interface FieldAssign {
+  name: string;
+  value: string;
+  line: number;
+}
+
+/**
+ * Values that make a data field carry no information.
+ *
+ * `default` and `Classical.arbitrary` are included because they are the
+ * idiomatic way to say "some element, I do not care which" — which is exactly
+ * the intent this axis exists to surface.
+ */
+const DEGENERATE_VALUE =
+  /^(?:0|1|⊥|⊤|∅|PUnit\.unit|Unit\.unit|\(\)|default|True|trivial|Nat\.zero|List\.nil|\[\]|Finset\.empty|Classical\.arbitrary\b.*)$/;
+
+/** Discharges that prove nothing on their own. */
+const TRIVIAL_DISCHARGE =
+  /^(?:rfl|trivial|True\.intro|\.intro|by\s+(?:rfl|trivial|simp|norm_num|decide|omega|constructor)\s*$|fun\s+_+\s*=>\s*rfl|fun\s+_+\s*=>\s*trivial|Or\.inl\s+rfl|⟨⟩)$/;
+
+/**
+ * A field whose name reads as a claim rather than as data.
+ *
+ * Lean has no marker distinguishing a `Prop` field from a data field in the
+ * instance body — the body is just `name := value` — so the field's *name* is
+ * the available signal, and Mathlib-style naming makes it a good one. Kept
+ * deliberately broad: a false positive here costs one line of review, while a
+ * miss is the defect shipping.
+ */
+const CLAIM_FIELD_NAME =
+  /(?:_eq$|_eq_|_agree|agree$|_le$|_lt$|_ne$|_iff|_zero|_one|_comm|_assoc|_spec$|holds$|valid|sound|complete|nondegenerate|nonzero|nontrivial|_mem$|_subset|_pos$|_bound|collapses|converges|exact$|vanish)/;
+
+/** Names that read as data rather than as a claim. */
+function isClaimField(name: string): boolean {
+  return CLAIM_FIELD_NAME.test(name);
+}
+
+/**
+ * Split a declaration body into `field := value` assignments.
+ *
+ * Handles the `where` form (`instance foo : C where` then indented fields) and
+ * the anonymous-constructor form (`⟨a, b⟩` is NOT handled — positional
+ * constructors carry no field names, so there is nothing to key on and the
+ * declaration is skipped rather than guessed at).
+ */
+export function parseFieldAssigns(body: string, startLine: number): FieldAssign[] {
+  const out: FieldAssign[] = [];
+  const lines = body.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i];
+    const line = raw.replace(/--.*$/, "").trimEnd();
+    if (!line.trim()) continue;
+    // `name := value` or `name arg _ := value`; the head is the field name.
+    const m = line.match(/^\s+([A-Za-z_][A-Za-z0-9_'!?]*)\s*((?:[^:=]|:(?!=))*?):=\s*(.*)$/);
+    if (!m) continue;
+    const name = m[1];
+    let value = m[3].trim();
+    // A value continued on following lines: absorb deeper-indented lines.
+    const indent = raw.length - raw.trimStart().length;
+    let j = i + 1;
+    while (j < lines.length) {
+      const nxt = lines[j];
+      if (!nxt.trim()) { j++; continue; }
+      const nIndent = nxt.length - nxt.trimStart().length;
+      if (nIndent <= indent) break;
+      value += " " + nxt.trim();
+      j++;
+    }
+    out.push({ name, value: value.trim(), line: startLine + i });
+  }
+  return out;
+}
+
+/** Declarations that inhabit a structure: `instance`/`def` … `where`. */
+interface Decl {
+  kind: "instance" | "def" | "theorem" | "abbrev";
+  name: string;
+  header: string;
+  body: string;
+  line: number;
+  docstring: string;
+}
+
+/** Split a Lean file into top-level declarations, with preceding docstrings. */
+export function parseDecls(src: string): Decl[] {
+  const lines = src.split("\n");
+  const out: Decl[] = [];
+  let doc = "";
+  let inDoc = false;
+  for (let i = 0; i < lines.length; i++) {
+    const l = lines[i];
+    if (/^\s*\/--/.test(l)) { inDoc = true; doc = l; if (/-\/\s*$/.test(l)) inDoc = false; continue; }
+    if (inDoc) { doc += "\n" + l; if (/-\/\s*$/.test(l)) inDoc = false; continue; }
+    const m = l.match(
+      /^(?:@\[[^\]]*\]\s*)?(?:noncomputable\s+|private\s+|protected\s+|scoped\s+)*(instance|def|theorem|abbrev)\s+([A-Za-z_][A-Za-z0-9_'.!?]*)/,
+    );
+    if (!m) { if (l.trim()) doc = ""; continue; }
+    // Body: everything until the next top-level declaration or `end`.
+    let j = i + 1;
+    const bodyLines: string[] = [];
+    while (j < lines.length) {
+      const nxt = lines[j];
+      if (/^(?:@\[|\/--|noncomputable\s|private\s|protected\s|instance\s|def\s|theorem\s|abbrev\s|structure\s|class\s|end\s|namespace\s|section\s)/.test(nxt)) break;
+      bodyLines.push(nxt);
+      j++;
+    }
+    out.push({
+      kind: m[1] as Decl["kind"],
+      name: m[2],
+      header: l,
+      body: bodyLines.join("\n"),
+      line: i + 1,
+      docstring: doc,
+    });
+    doc = "";
+    i = j - 1;
+  }
+  return out;
+}
+
+/**
+ * `lean-no-vacuous-instance-data` — degenerate data **and** a reflexivity
+ * discharge, in the same declaration.
+ *
+ * Both halves are required. Degenerate data alone is often fine (a genuinely
+ * zero object); a `rfl` discharge alone is often fine (a real reflexivity).
+ * Together they mean the claim was arranged away rather than proved.
+ */
+export function checkNoVacuousInstanceData(leanPath?: string): CheckerResult {
+  if (!leanPath || !existsSync(leanPath)) return { result: "n/a", hits: [] };
+  let src: string;
+  try { src = readFileSync(leanPath, "utf8"); } catch { return { result: "n/a", hits: [] }; }
+
+  const hits: CheckerHit[] = [];
+  for (const d of parseDecls(src)) {
+    if (d.kind !== "instance" && d.kind !== "def") continue;
+    // `where` is tested against the whole declaration, not just its first
+    // line: a real instance signature wraps, and the motivating case put
+    // `where` three lines down after the instance binders. Requiring it in the
+    // header alone missed every multi-line declaration — which is most of them.
+    if (!/\bwhere\b/.test(d.header + "\n" + d.body)) continue;
+    const fields = parseFieldAssigns(d.body, d.line);
+    if (fields.length < 2) continue;
+
+    const degenerateData = fields.filter(
+      (f) => !isClaimField(f.name) && DEGENERATE_VALUE.test(f.value),
+    );
+    const trivialClaims = fields.filter(
+      (f) => isClaimField(f.name) && TRIVIAL_DISCHARGE.test(f.value),
+    );
+    if (degenerateData.length === 0 || trivialClaims.length === 0) continue;
+
+    // An unconditional `instance` is the severe form: typeclass resolution
+    // supplies it everywhere, so downstream hypotheses stop being hypotheses.
+    const severity = d.kind === "instance" ? "instance" : "def";
+    for (const c of trivialClaims) {
+      hits.push({
+        file: leanPath,
+        line: c.line,
+        text:
+          `${severity} \`${d.name}\`: claim field \`${c.name} := ${c.value}\` is ` +
+          `discharged by reflexivity, and the data it constrains is degenerate ` +
+          `(${degenerateData.map((f) => `${f.name} := ${f.value}`).join(", ")}). ` +
+          `The claim is arranged away, not proved.` +
+          (d.kind === "instance"
+            ? " As an `instance` it is resolved everywhere, so downstream theorems taking this class are unconditional."
+            : ""),
+      });
+    }
+  }
+  return { result: hits.length ? "fail" : "pass", hits };
+}
+
+/** Docstring words that assert the term is honestly incomplete. */
+const HONESTY_CLAIM =
+  /\b(?:carries?\s+(?:the\s+)?\w*\s*(?:conjecture|obstruction|claim)?\s*as\s+a\s+sorry|as\s+a\s+`?sorry`?|with\s+a\s+`?sorry`?|sorry\s*=\s*the|axiomatis|axiomatiz|research-grade\s+conjecture)\b/i;
+
+/**
+ * A docstring that explicitly denies carrying a `sorry`.
+ *
+ * Needed because the remedy for this criterion is usually to rewrite the
+ * docstring and say what really discharges the term — which normally means
+ * quoting the false claim being corrected.
+ */
+const NEGATED_HONESTY_CLAIM =
+  /\b(?:no\s+`?sorry`?|not\s+a\s+`?sorry`?|without\s+(?:a\s+)?`?sorry`?|there\s+is\s+no\s+`?sorry`?|contains?\s+(?:no|neither)\b)/i;
+
+/**
+ * `lean-docstring-honesty` — a docstring that claims the term carries a
+ * `sorry` (or is axiomatised) when the body contains neither.
+ *
+ * Cheap and high-signal. `ConfinementGradingCorrespondence.canonical` said
+ * *"Faithful instance. Carries the explicit research-grade conjecture as a
+ * sorry"* and contained no `sorry` at all — it discharged the conjecture by
+ * setting both filtrations to zero. That is strictly worse than a `sorry`,
+ * because a `sorry` is visible to `#print axioms` and this was not: the
+ * docstring was the only place the incompleteness was recorded, and it was
+ * wrong.
+ */
+export function checkDocstringHonesty(leanPath?: string): CheckerResult {
+  if (!leanPath || !existsSync(leanPath)) return { result: "n/a", hits: [] };
+  let src: string;
+  try { src = readFileSync(leanPath, "utf8"); } catch { return { result: "n/a", hits: [] }; }
+
+  const hits: CheckerHit[] = [];
+  for (const d of parseDecls(src)) {
+    if (!d.docstring || !HONESTY_CLAIM.test(d.docstring)) continue;
+    // A docstring that explicitly records the ABSENCE of a sorry is doing the
+    // right thing, and often has to quote the phrase it is correcting. Firing
+    // on it punishes exactly the fix this criterion asks for — it flagged the
+    // repaired `ConfinementGradingCorrespondence.canonical`, whose new
+    // docstring quotes the old false claim in order to explain it.
+    if (NEGATED_HONESTY_CLAIM.test(d.docstring)) continue;
+    const whole = d.header + "\n" + d.body;
+    // Strip comments before looking for `sorry`, so a docstring or an inline
+    // note *about* sorries does not count as one.
+    const code = whole.replace(/--.*$/gm, "").replace(/\/-[\s\S]*?-\//g, "");
+    if (/\bsorry\b/.test(code)) continue;
+    if (/^\s*axiom\s/m.test(code)) continue;
+    hits.push({
+      file: leanPath,
+      line: d.line,
+      text:
+        `\`${d.name}\`: the docstring says it carries a sorry or is axiomatised, ` +
+        `but the body contains neither. If the claim is genuinely open, use a ` +
+        `\`sorry\` so \`#print axioms\` can see it; if it is discharged, say how.`,
+    });
+  }
+  return { result: hits.length ? "fail" : "pass", hits };
+}
+
+export const VACUITY_AUTOMATED_CHECKERS: Record<
+  string,
+  (paths: { md?: string; ts?: string; lean?: string }) => CheckerResult
+> = {
+  "lean-no-vacuous-instance-data": (p) => checkNoVacuousInstanceData(p.lean),
+  "lean-docstring-honesty": (p) => checkDocstringHonesty(p.lean),
+};

--- a/content/pipeline/qa-checkers-vacuity.ts
+++ b/content/pipeline/qa-checkers-vacuity.ts
@@ -210,7 +210,16 @@ export function checkNoVacuousInstanceData(leanPath?: string): CheckerResult {
 
     // An unconditional `instance` is the severe form: typeclass resolution
     // supplies it everywhere, so downstream hypotheses stop being hypotheses.
-    const severity = d.kind === "instance" ? "instance" : "def";
+    //
+    // But only if the carrier is a VARIABLE. An instance at a concrete object —
+    // `instance foo : R5FullWitness LightNucleus.helium3`, binding nothing — is
+    // resolved for that one object and nothing else, so its degenerate fields
+    // are a claim about helium-3 rather than about every carrier. Both survivors
+    // of the 2026-08-24 demotion sweep were this shape, and both had already
+    // been cleared by hand. Detected by the absence of binder groups before the
+    // `:` in the header, which is what universal quantification looks like here.
+    const bindsCarrier = /^[^:]*[({\[]/.test(d.header.replace(/^(?:@\[[^\]]*\]\s*)?(?:noncomputable\s+|private\s+|protected\s+|scoped\s+)*(?:instance|def)\s+[A-Za-z_][A-Za-z0-9_'.!?]*/, ""));
+    const severity = d.kind === "instance" && bindsCarrier ? "instance" : "def";
     for (const c of trivialClaims) {
       hits.push({
         file: leanPath,
@@ -220,9 +229,11 @@ export function checkNoVacuousInstanceData(leanPath?: string): CheckerResult {
           `discharged by reflexivity, and the data it constrains is degenerate ` +
           `(${degenerateData.map((f) => `${f.name} := ${f.value}`).join(", ")}). ` +
           `The claim is arranged away, not proved.` +
-          (d.kind === "instance"
-            ? " As an `instance` it is resolved everywhere, so downstream theorems taking this class are unconditional."
-            : ""),
+          (d.kind === "instance" && bindsCarrier
+            ? " As an `instance` over a variable carrier it is resolved everywhere, so downstream theorems taking this class are unconditional."
+            : d.kind === "instance"
+              ? " Resolved only at this concrete carrier, so the claim is about that object rather than every carrier — lower severity."
+              : ""),
       });
     }
   }

--- a/content/pipeline/qa-checkers-voice.ts
+++ b/content/pipeline/qa-checkers-voice.ts
@@ -30,6 +30,7 @@ import { EXTENDED_AUTOMATED_CHECKERS } from "./qa-checkers-extended";
 import { USES_AUTOMATED_CHECKERS } from "./qa-checkers-uses";
 import { COST_AUTOMATED_CHECKERS } from "./qa-checkers-cost";
 import { TRIVIALITY_AUTOMATED_CHECKERS } from "./qa-checkers-triviality";
+import { VACUITY_AUTOMATED_CHECKERS } from "./qa-checkers-vacuity";
 import { RENDER_AUTOMATED_CHECKERS } from "./qa-checkers-render";
 
 export interface CheckerHit {
@@ -1186,6 +1187,10 @@ export const AUTOMATED_CHECKERS: Record<
   ...COST_AUTOMATED_CHECKERS,
   // Machine-triviality oracle (scaffold; inert without a cache).
   ...TRIVIALITY_AUTOMATED_CHECKERS,
+  // Vacuity-by-construction: degenerate instance data that makes a
+  // propositional field `rfl`, and docstrings that claim a `sorry` the
+  // body does not carry. Bodies in `qa-checkers-vacuity.ts`.
+  ...VACUITY_AUTOMATED_CHECKERS,
   // Render integrity — source patterns that abort pdflatex. Bodies in
   // `qa-checkers-render.ts`.
   ...RENDER_AUTOMATED_CHECKERS,

--- a/content/pipeline/qa-criteria-registry.ts
+++ b/content/pipeline/qa-criteria-registry.ts
@@ -876,6 +876,44 @@ const PROOF: QaCriterionDefinition[] = [
     applies_to: ["theorem", "lemma", "proposition", "corollary"],
   },
   {
+    id: "lean-no-vacuous-instance-data",
+    domain: "proof",
+    description:
+      "No instance discharges a propositional field by reflexivity BECAUSE " +
+      "its data fields were chosen degenerate. The signature is the " +
+      "conjunction — constant data (`_ := 0`, `PUnit.unit`, `default`) AND a " +
+      "`rfl`/`trivial` discharge of a field relating that data. Either half " +
+      "alone is usually legitimate: a genuine zero object has constant data, " +
+      "and plenty of real laws are reflexivity. Together they mean the claim " +
+      "was arranged away rather than proved. An unconditional `instance` is " +
+      "the severe form, since typeclass resolution supplies it everywhere and " +
+      "every downstream theorem taking the class stops being conditional. " +
+      "AST-checked, no agent turn. Fix: demote `instance` to `def` so the " +
+      "model must be named, or give the class a non-degeneracy field so the " +
+      "trivial model cannot be written at all. " +
+      "Routes to `lean-proof-vacuity-audit`.",
+    default_severity: "critical",
+    depends_on: ["lean"],
+    automated: true,
+    applies_to: ["definition", "theorem", "lemma", "proposition", "corollary"],
+  },
+  {
+    id: "lean-docstring-honesty",
+    domain: "proof",
+    description:
+      "A docstring that says the term carries a `sorry`, is axiomatised, or " +
+      "holds a conjecture as a placeholder must be telling the truth: the " +
+      "body contains an actual `sorry` or `axiom`. A docstring is the only " +
+      "place an incompleteness is recorded when the term is in fact closed by " +
+      "construction, and a wrong one is worse than no note at all — a `sorry` " +
+      "is visible to `#print axioms`, a `rfl` on `0 = 0` is not. " +
+      "AST-checked, no agent turn. Routes to `lean-proof-vacuity-audit`.",
+    default_severity: "major",
+    depends_on: ["lean"],
+    automated: true,
+    applies_to: ["definition", "theorem", "lemma", "proposition", "corollary"],
+  },
+  {
     id: "proof-no-false-premise",
     domain: "proof",
     description:

--- a/content/pipeline/qa-criteria-registry.ts
+++ b/content/pipeline/qa-criteria-registry.ts
@@ -1862,6 +1862,28 @@ const SCRIPT_QUALITY: QaCriterionDefinition[] = [
     automated: true,
     source_file: "content/pipeline/qa-checkers-python.ts",
   },
+  {
+    id: "assertions_are_falsifiable",
+    domain: "script-quality",
+    description:
+      "A witness assertion must be able to FAIL. Fires when an " +
+      "`add_assertion(...)` call passes the same expression as both " +
+      "`computed` and `expected`, so the assertion holds by construction " +
+      "and the resulting `allPassed: true` says nothing about what the " +
+      "script produced — which is what a block's `computation.status: " +
+      "\"verified\"` rests on. Keyword and positional forms both checked. " +
+      "Regex, not AST (no Python runtime in the sweep): measured 90% recall " +
+      "at 100% sampled precision against an AST census, and it " +
+      "under-reports by design, since a missed tautology stays a backlog " +
+      "item while a false one costs an author an argument with the checker. " +
+      "Remedy: supply the real expected value; if none exists yet, assert a " +
+      "different property that can fail rather than re-deriving the " +
+      "computation under test, which is the same defect spelled out.",
+    default_severity: "critical",
+    depends_on: ["ts"],
+    automated: true,
+    source_file: "content/pipeline/qa-checkers-python.ts",
+  },
 ];
 
 // ── Domain: devils-advocate ─────────────────────────────────────

--- a/content/pipeline/qa-criteria-registry.ts
+++ b/content/pipeline/qa-criteria-registry.ts
@@ -909,6 +909,52 @@ const PROOF: QaCriterionDefinition[] = [
     applies_to: ["definition", "theorem", "lemma", "proposition", "corollary"],
   },
   {
+    id: "lean-no-definitional-laundering",
+    domain: "proof",
+    description:
+      "The sibling `lean-no-vacuous-instance-data` models vacuity as CONSTANT " +
+      "data. This criterion covers the shape that model cannot see: data that " +
+      "is NOT constant and is still chosen so the claim becomes `rfl`. A hand " +
+      "pass over the qou corpus found eight such sites and the constant " +
+      "detector found twenty-five, with a zero overlap. Three detections, all " +
+      "conjunctive: (1) ARGUMENT-IGNORING BODY — `def F (args…) : Prop := " +
+      "True` (or `False`), possibly after `let` bindings whose results are " +
+      "discarded, so every claim stated in terms of `F` is free without any " +
+      "instance being written; (2) LAMBDA-WRAPPED CONSTANT — `member := fun _ " +
+      "=> True` beside a reflexivity discharge, the sibling's exact " +
+      "conjunction with the constant one lambda deeper than its anchored " +
+      "regex reaches; (3) DEFINITIONAL IDENTITY — the class declares `claim : " +
+      "∀ …, data args = RHS` and the instance assigns `data := fun … => RHS` " +
+      "with that same RHS, then discharges `claim` by reflexivity. " +
+      "AST-checked, no agent turn. " +
+      "DETECTION 3 IS A READING, NOT A VERDICT: pinning a field to a formula " +
+      "and observing the law then holds by `rfl` is a legitimate way to " +
+      "exhibit a model, and whether the class field was a CONSTRAINT the " +
+      "instance had to meet or a DEFINITION it was entitled to make is not a " +
+      "syntactic question. Those hits grade `warn` and say so; when the " +
+      "author's docstring disputes the reading the hit records that too. " +
+      "Detections 1 and 2 grade `fail`. " +
+      "SCOPE, HONESTLY: detection 3 reads only classes declared in the SAME " +
+      "file — resolving an imported class means resolving imports, and a " +
+      "wrong resolution is a confident false report about a decl never read. " +
+      "Semantic constancy (`w A := 3 * A * 0`) needs `whnf`, i.e. the " +
+      "elaborator, and is out of reach here. An argument-free `def X : Prop " +
+      ":= True` is deliberately NOT reported: that is " +
+      "`proof-no-trivial-true`'s `def-disguised-true` pattern. " +
+      "THE REMEDY is the sibling criterion's, and it is the same remedy " +
+      "because it is the same defect one level up: parameterise the class " +
+      "over the data so the instance cannot choose its own shadow, then state " +
+      "the residual vacuity as a proved theorem pair — one instance at the " +
+      "trivial datum, one theorem that the class fails at a non-trivial one. " +
+      "`QOU/MassTheory/CableWidthBraneTowerLift.lean` (`colorRule` beside " +
+      "`not_widthRule_of_ne`) is the worked pattern. " +
+      "Routes to `lean-proof-vacuity-audit`.",
+    default_severity: "critical",
+    depends_on: ["lean"],
+    automated: true,
+    applies_to: ["definition", "theorem", "lemma", "proposition", "corollary"],
+  },
+  {
     id: "lean-docstring-honesty",
     domain: "proof",
     description:

--- a/content/pipeline/qa-criteria-registry.ts
+++ b/content/pipeline/qa-criteria-registry.ts
@@ -888,9 +888,20 @@ const PROOF: QaCriterionDefinition[] = [
       "was arranged away rather than proved. An unconditional `instance` is " +
       "the severe form, since typeclass resolution supplies it everywhere and " +
       "every downstream theorem taking the class stops being conditional. " +
-      "AST-checked, no agent turn. Fix: demote `instance` to `def` so the " +
-      "model must be named, or give the class a non-degeneracy field so the " +
-      "trivial model cannot be written at all. " +
+      "AST-checked, no agent turn. THE REMEDY, best-first: (1) parameterise " +
+      "the class over the data so it cannot choose its own degenerate " +
+      "shadow, then state the residual vacuity as a PROVED THEOREM PAIR — " +
+      "one instance at the trivial datum showing the hypothesis is " +
+      "satisfiable, one theorem showing it fails at any non-trivial datum. " +
+      "That turns the trap into a machine-checked fact about what the " +
+      "hypothesis is worth, instead of forbidding it. See " +
+      "`QOU/Archimedean/JetOrderIndependence.lean` (`trivialError_bound` " +
+      "beside `not_bound_of_physical_ne_zero`) for the worked pattern. " +
+      "(2) Failing that, demote `instance` to `def` so the model must be " +
+      "named and a reader of a downstream theorem can see what discharged " +
+      "the hypothesis. (3) A non-degeneracy field on the class is the " +
+      "blunt option: it prevents the trivial model but also prevents saying " +
+      "anything about it. " +
       "Routes to `lean-proof-vacuity-audit`.",
     default_severity: "critical",
     depends_on: ["lean"],

--- a/content/pipeline/qa-criterion-hash.ts
+++ b/content/pipeline/qa-criterion-hash.ts
@@ -25,8 +25,16 @@
  *
  * ## What is hashed
  *
- * The criterion's dispatch entry (its property in the exported
- * `*_AUTOMATED_CHECKERS` record) plus the transitive closure of module-local
+ * The criterion's dispatch entry — the FIRST property in this module whose key
+ * is the criterion id, in any object literal, at any depth. The record's name
+ * is irrelevant and so is whether it is exported: `findCriterionEntry` matches
+ * on the key alone, so a dispatch table called anything at all is found, and a
+ * property with that key somewhere else would be found first. (An earlier
+ * version of this paragraph claimed the analysis locates an exported
+ * `*_AUTOMATED_CHECKERS` record; it never has, and reading it that way sends
+ * you looking for a naming convention that is not load-bearing.)
+ *
+ * That entry, plus the transitive closure of module-local
  * declarations it references. Cross-module imports are NOT followed — that
  * matches the previous whole-file behaviour, which never hashed other files
  * either, so this is not a new gap. Declared `extra_inputs` remain covered

--- a/content/pipeline/script-sweep.ts
+++ b/content/pipeline/script-sweep.ts
@@ -75,6 +75,7 @@ import {
   checkConnectedToCiPipeline,
   checkDeprecated,
   checkUsesLibraryFrameworkAppropriately,
+  checkAssertionsAreFalsifiable,
 } from "./qa-checkers-python";
 import type { CheckerResult } from "./qa-checkers-voice";
 import type {
@@ -146,6 +147,10 @@ const SCRIPT_CHECKERS: Record<string, ScriptCheckerFn> = {
   uses_library_framework_appropriately: (t) => {
     if (t.language !== "python") return { result: "n/a", hits: [] };
     return checkUsesLibraryFrameworkAppropriately(t.abs);
+  },
+  assertions_are_falsifiable: (t) => {
+    if (t.language !== "python") return { result: "n/a", hits: [] };
+    return checkAssertionsAreFalsifiable(t.abs);
   },
 };
 

--- a/content/pipeline/validate.ts
+++ b/content/pipeline/validate.ts
@@ -34,6 +34,28 @@ import { referenceRegistryConfigured, getReferenceRegistry } from "./references-
 
 // ── File discovery ───────────────────────────────────────────────
 
+/**
+ * Is this `*.qa.json` a **block** sidecar, as opposed to a paper-level audit
+ * artefact that merely shares the extension?
+ *
+ * Block sidecars declare `"$schema": "block-qa/v1"`. Paper-level outputs such
+ * as `section-title-audit.qa.json` are keyed by paper and chapter and carry no
+ * `$schema` at all — they have no `.ts` by design and must not be read as
+ * orphaned blocks.
+ *
+ * Unreadable or unparseable returns `true` on purpose: a corrupt sidecar
+ * should be reported, not silently reclassified as "not a block's".
+ */
+function isBlockSidecar(path: string): boolean {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
+    if (typeof parsed !== "object" || parsed === null) return true;
+    return (parsed as { $schema?: unknown }).$schema === "block-qa/v1";
+  } catch {
+    return true;
+  }
+}
+
 /** Find all .ts manifest files in a directory (excluding index, pipeline). */
 function discoverManifests(dir: string): string[] {
   if (!existsSync(dir)) return [];
@@ -114,6 +136,25 @@ async function loadBlocksFromDir(
       if (!f.endsWith(".qa.json")) continue;
       const base = f.slice(0, -".qa.json".length);
       if (existsSync(join(dir, `${base}.ts`))) continue;
+      // Not every `*.qa.json` is a BLOCK sidecar, and the ones that are not
+      // have no `.ts` by design. `qa-section-title-audit.ts` writes
+      // `content/<paper>/section-title-audit.qa.json` — keyed by paper and
+      // chapter, never by block — and four of those sit in the qou corpus
+      // (bean `qou-efzm`, which had them recorded as orphans left behind by a
+      // deleted block; the file shape says they were never blocks at all).
+      // Deleting them would destroy live audit state that the producing tool
+      // would simply rewrite.
+      //
+      // They escape today only because this scan is non-recursive and they
+      // live at the paper root rather than in a chapter dir — but they still
+      // inflate every census taken over `**/*.qa.json`, which is the very
+      // thing the comment above says this check exists to prevent.
+      //
+      // Discriminate on the block sidecar's own `$schema`. A file that fails
+      // to parse is deliberately NOT skipped: a corrupt sidecar is worth
+      // reporting, and treating unreadable as "not a block sidecar" would let
+      // a real orphan hide behind a truncated write.
+      if (!isBlockSidecar(join(dir, f))) continue;
       issues.push({
         level: "error",
         block: base,

--- a/docs/reference/skill-instructions/lean-proof-vacuity-audit.md
+++ b/docs/reference/skill-instructions/lean-proof-vacuity-audit.md
@@ -196,6 +196,73 @@ proof:
 **Never** the batch anti-fix: wrapping the conclusion in a structure field and
 projecting it. That converts a *visible* gap (`sorry`) into an *invisible* one.
 
+### Demonstrating non-degeneracy — the theorem-pair pattern
+
+Step 2 requires the conditional class to be "non-degenerate", and that is where
+most of these go wrong: a class is written, a `canonical` instance sets its data
+to zero so the propositional field becomes `rfl`, and the class asserts nothing
+for anyone. Demoting `instance` → `def` stops typeclass resolution supplying it
+silently, but it does not *say* what the hypothesis is worth.
+
+**Parameterise the class over the data, then state the residual vacuity as a
+proved pair.** Worked example in
+[`QOU/Archimedean/JetOrderIndependence.lean`](../../..) — read it before
+inventing your own:
+
+```lean
+/-- The identically-zero transport error. -/
+def trivialError : TransportErrorData where
+  shadow := fun _ => 0
+  physical := fun _ => 0
+  ...
+
+/-- **The bound is vacuous at the zero error (PROVED).** So an instance for an
+    *unspecified* `E` asserts nothing: it is satisfiable. -/
+instance trivialError_bound : SurrealParallelTransportBound trivialError where ...
+
+/-- **…and non-vacuous at any error with a non-zero physical shadow (PROVED).**
+    For a specific `E` the bound is a real constraint that can fail. -/
+theorem not_bound_of_physical_ne_zero (h : E.physical N ≠ 0) :
+    ¬ Nonempty (SurrealParallelTransportBound E) := ...
+```
+
+Read together the two say exactly what an instance buys: **the hypothesis
+carries no information until the datum is pinned down, and real information as
+soon as it is.** The trap becomes a machine-checked fact instead of a latent
+one — which is strictly better than forbidding the trivial model, because a
+non-degeneracy field on the class would prevent the trivial model *and*
+prevent saying anything about it.
+
+Parameterising alone is not enough: it stops the class choosing its own shadow,
+but a consumer can still instantiate at the zero datum. The pair is what closes
+that.
+
+Detected mechanically by **two** criteria in `content/pipeline/qa-checkers-vacuity.ts`,
+which partition the defect rather than overlap — a decl the first flags is
+skipped by the second:
+
+- `lean-no-vacuous-instance-data` — degenerate data *written as a constant*
+  (`_ := 0`, `PUnit.unit`, `default`) plus a reflexivity discharge.
+- `lean-no-definitional-laundering` — data that is **not** constant and is still
+  chosen so the claim becomes `rfl`. Three shapes: an argument-ignoring body
+  (`def F (args…) : Prop := True`), a constant one lambda deep
+  (`member := fun _ => True`), and a field defined to BE the right-hand side its
+  class field compares against (`w := fun _ => cableWidthColor` under
+  `is_color : ∀ A, w A = cableWidthColor`).
+
+The two lists were measured **disjoint** on the qou corpus on 2026-08-24: a hand
+read found eight laundering sites, the constant detector found twenty-five, and
+no site appeared in both. If you are auditing for vacuity, running only one of
+them is running half the check.
+
+The third shape grades `warn`, not `fail`, and says "REVIEW (not a verdict)" in
+its own evidence. Pinning a field to a formula and observing the law then holds
+by `rfl` is a legitimate way to exhibit a model; whether the class field was a
+*constraint* the instance had to meet or a *definition* it was entitled to make
+is a question about what the class was for, and no regex answers it. Answer it
+and record the answer — do not treat the hit as a defect, and do not dismiss it
+because the docstring already argues it is fine.
+
 ## Detection heuristic (candidate grep → agent confirmation)
 
 0. **Runnable scanner (preferred).** `bun run

--- a/scripts/check-self-discharging-instances.ts
+++ b/scripts/check-self-discharging-instances.ts
@@ -1,0 +1,444 @@
+#!/usr/bin/env bun
+/**
+ * check-self-discharging-instances — find class hypotheses that are free.
+ *
+ * ## The defect
+ *
+ * A `class` that carries a **propositional field** is a claim: downstream code
+ * takes `[C X]` as a hypothesis and the reader understands the theorem to be
+ * conditional on it. An **unconditional `instance`** of such a class destroys
+ * that: typeclass resolution supplies it everywhere, every downstream theorem
+ * becomes unconditional, and the hypothesis asserts nothing.
+ *
+ * The shape is easy to introduce and nearly invisible in review, because the
+ * instance is usually honest about being trivial — in its docstring, where no
+ * gate reads it. Four occurrences in `qou` inside one week:
+ *
+ *   hasDqSquaredNonvanishing_of_fact            produced the class from a
+ *                                               `Fact` of its own conclusion
+ *   hasCategoricalIrreducibility_of_subsingleton  same shape
+ *   SpectralSequence.canonical (+6 more)        `PUnit` model, and the file
+ *                                               said "vacuously discharges"
+ *
+ * The first two were removed by hand; the third was found by reading. This
+ * checker exists so the fourth is found by running something.
+ *
+ * ## What counts as a finding
+ *
+ * An `instance` is reported when **both** hold:
+ *
+ *   1. its result class is declared (anywhere in the package) with at least one
+ *      field whose type looks propositional — an equation, an inequality, a
+ *      quantifier, `Prop`, or the class is `... : Prop`; and
+ *   2. it is **unconditional**: every argument is a type, a universe, or an
+ *      instance binder `[…]`. No explicit hypothesis for the caller to supply.
+ *
+ * Condition 2 is the load-bearing one. `instance foo (h : P) : C X` is fine —
+ * the caller still has to produce `h`. `instance foo (R : Type) : C R` is not.
+ *
+ * ## What it deliberately does not flag
+ *
+ * Classes with no propositional field: `Inhabited`, `Repr`, coercions, plain
+ * data bundles. Making those unconditional is the normal and correct use of
+ * the instance mechanism, and flagging them would bury the signal.
+ *
+ * ## Fixing a finding
+ *
+ * Demote `instance` to `def`. The model stays available and must be supplied by
+ * name, so a reader of a downstream theorem can see whether the hypothesis was
+ * discharged by real content or by a placeholder. That is what
+ * `QOU/Mathlib/SpectralSequence.lean` now does, and what
+ * `TauFunctorTargetSpec.interface_alone_is_trivially_inhabitable` documents as
+ * the house pattern.
+ *
+ * Usage:
+ *   bun run scripts/check-self-discharging-instances.ts --package qou
+ *   … --baseline N   growth-only ratchet (exit 3 when the count exceeds N)
+ *   … --warn-only    always exit 0
+ *   … --json         machine-readable
+ */
+
+import { readdirSync, readFileSync, statSync } from "fs";
+import { join, relative, resolve } from "path";
+
+import { LEAN_PACKAGES, type LeanPackage } from "../schemas/lean-packages.ts";
+import { findContentRepoRoot } from "../content/pipeline/repo-root";
+
+/** A `class` declaration and whether it carries a claim. */
+interface ClassInfo {
+  name: string;
+  file: string;
+  line: number;
+  /** Field types that read as propositional. */
+  propFields: string[];
+}
+
+/** An `instance` declaration. */
+interface InstanceInfo {
+  name: string;
+  className: string;
+  file: string;
+  line: number;
+  /** Binder text between the name and the `:` that gives the result type. */
+  binders: string;
+  /** `field := proof` pairs from the instance body. */
+  discharges: string[];
+}
+
+export interface Finding {
+  instance: string;
+  className: string;
+  file: string;
+  line: number;
+  propFields: string[];
+  /** How the claim fields are discharged, and therefore how bad this is. */
+  severity: "trivial" | "substantive";
+  /** The `field := proof` terms found in the instance body, for the report. */
+  discharges: string[];
+}
+
+/**
+ * Proof terms that discharge a proposition without establishing anything about
+ * the model — the instance is true *by construction*, so the class field
+ * asserts nothing of it.
+ *
+ * `hf.out` and friends are the `Fact`-of-the-conclusion shape that
+ * `hasDqSquaredNonvanishing_of_fact` had.
+ */
+export function isTrivialDischarge(proof: string): boolean {
+  const t = proof.trim().replace(/^by\s+/, "");
+  return /^(rfl|trivial|default|True\.intro|\.intro|Subsingleton\.elim.*|PUnit\.unit|⟨⟩|fun\s+_+\s*=>\s*rfl|fun\s+_+\s*=>\s*trivial|[A-Za-z_][A-Za-z0-9_']*\.out|inferInstance)$/.test(t)
+    || /^fun\b.*=>\s*(rfl|trivial|default)$/.test(t);
+}
+
+/**
+ * Does this field type read as a proposition?
+ *
+ * Deliberately generous — a false positive costs a reader ten seconds, while a
+ * false negative is the whole defect. `Type`/`Sort`-valued fields are excluded
+ * explicitly so data bundles do not trip it.
+ */
+export function looksPropositional(ty: string, propNames?: Set<string>): boolean {
+  const t = ty.trim();
+  if (/^Type\b|^Sort\b|^Prop$/.test(t)) return false;
+  if (
+    /(^|[^:!<>=])=([^=]|$)/.test(t) ||
+    /≠|≤|≥|<|>|∀|∃|¬|↔|→\s*False|\bProp\b|\bSubsingleton\b|\bIsIso\b|\bEpi\b|\bMono\b|\bNonempty\b|\bFact\b/.test(t)
+  ) return true;
+  // A field whose type is a NAMED predicate — `CollapsesAtE2 ss`,
+  // `MarkovAxiomHolds …`. Missing this was a real bug: the checker returned
+  // zero on `GBFiltrationCollapsesAtE2`, the very defect it was written for,
+  // because `collapses : CollapsesAtE2 ss` contains no inline proposition.
+  // Caught by testing the checker against the pre-fix file rather than
+  // trusting its clean run.
+  if (propNames) {
+    const head = /^([A-Za-z_][A-Za-z0-9_'.!?]*)/.exec(t)?.[1];
+    if (head && propNames.has(head)) return true;
+    if (head && propNames.has(head.split(".").pop()!)) return true;
+  }
+  return false;
+}
+
+/** `def`/`abbrev`/`class`/`structure` declarations whose result is `Prop`. */
+const PROP_DECL =
+  /^\s*(?:noncomputable\s+)?(?:def|abbrev|class|structure)\s+([A-Za-z_][A-Za-z0-9_'.!?]*).*:\s*Prop\b/;
+
+/** Collect the names of `Prop`-valued declarations in one file. */
+export function propDeclNames(text: string): string[] {
+  const out: string[] = [];
+  for (const line of text.split("\n")) {
+    const m = PROP_DECL.exec(line);
+    if (m) out.push(m[1], m[1].split(".").pop()!);
+  }
+  return out;
+}
+
+/**
+ * Is every binder a type, universe, or instance argument?
+ *
+ * `(R : Type u)`, `{α : Type*}`, `[CommRing R]` → unconditional.
+ * `(h : P)`, `(hq : q ≠ 1)` → conditional, and therefore fine.
+ */
+export function isUnconditional(binders: string, propNames?: Set<string>): boolean {
+  // Walk top-level bracket groups. A regex cannot do this either:
+  // `(h : CollapsesAtE2 (bar R))` nests, and `[^()]*` cannot span the inner
+  // parens — so the binder was skipped and a conditional instance was reported
+  // as unconditional. Fourth bug of this family; all four were the same
+  // mistake, using a regex where the grammar is bracketed.
+  let i = 0;
+  while (i < binders.length) {
+    const open = binders[i];
+    if (open !== "(" && open !== "[" && open !== "{") { i++; continue; }
+    let depth = 0;
+    let j = i;
+    for (; j < binders.length; j++) {
+      const c = binders[j];
+      if (c === "(" || c === "[" || c === "{") depth++;
+      else if (c === ")" || c === "]" || c === "}") {
+        depth--;
+        if (depth === 0) break;
+      }
+    }
+    const inner = binders.slice(i + 1, j);
+    i = j + 1;
+    if (open === "[") continue; // instance binder — resolved, not supplied
+    // find the depth-0 colon inside this binder
+    let d = 0, colon = -1;
+    for (let k = 0; k < inner.length; k++) {
+      const c = inner[k];
+      if (c === "(" || c === "[" || c === "{") d++;
+      else if (c === ")" || c === "]" || c === "}") d--;
+      else if (c === ":" && d === 0) { colon = k; break; }
+    }
+    if (colon < 0) continue;
+    const ty = inner.slice(colon + 1).trim();
+    // Only a PROOF OBLIGATION makes an instance conditional. A data parameter
+    // such as `(n : ℕ)` does not: resolution fills it from the goal, so the
+    // instance is still supplied for free at every `n`. Requiring `Type`
+    // here was too strict and hid three of the seven known cases.
+    if (looksPropositional(ty, propNames)) return false;
+  }
+  return true;
+}
+
+function* walkLean(dir: string): Generator<string> {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const e of entries) {
+    if (e === ".lake" || e === "build") continue;
+    const p = join(dir, e);
+    let st;
+    try {
+      st = statSync(p);
+    } catch {
+      continue;
+    }
+    if (st.isDirectory()) yield* walkLean(p);
+    else if (e.endsWith(".lean")) yield p;
+  }
+}
+
+const CLASS_HEAD = /^\s*class\s+([A-Za-z_][A-Za-z0-9_'.!?]*)/;
+const INSTANCE_START = /^\s*(?:noncomputable\s+)?instance\b\s*(.*)$/;
+
+/**
+ * Split `<name?> <binders> : <resultType>` at the colon that is **not** inside
+ * a binder.
+ *
+ * A plain `[^:]*` regex cannot do this: `instance canonical (R : Type u) : C R`
+ * has a colon inside `(R : Type u)`, so the regex stopped early and the result
+ * class came out wrong. That is why the first version of this checker reported
+ * **zero** findings on the exact file it was written for — caught by testing it
+ * against the pre-fix source rather than trusting a clean run.
+ */
+export function splitInstanceHead(
+  rest: string,
+): { name: string; binders: string; className: string } | null {
+  let depth = 0;
+  for (let i = 0; i < rest.length; i++) {
+    const ch = rest[i];
+    if (ch === "(" || ch === "[" || ch === "{") depth++;
+    else if (ch === ")" || ch === "]" || ch === "}") depth--;
+    else if (ch === ":" && depth === 0) {
+      const left = rest.slice(0, i).trim();
+      const right = rest.slice(i + 1).trim();
+      const cm = /^([A-Za-z_][A-Za-z0-9_'.!?]*)/.exec(right);
+      if (!cm) return null;
+      const nm = /^([A-Za-z_][A-Za-z0-9_'.!?]*)/.exec(left);
+      const name = nm && !left.startsWith("(") && !left.startsWith("{") &&
+        !left.startsWith("[") ? nm[1] : "«anonymous»";
+      const binders = name === "«anonymous»" ? left : left.slice(nm![1].length);
+      return { name, binders, className: cm[1] };
+    }
+  }
+  return null;
+}
+const FIELD = /^\s{2,}([A-Za-z_][A-Za-z0-9_'!?]*)\s*:\s*(.+)$/;
+
+/** Parse one file for class declarations (with their fields) and instances. */
+export function parseLean(
+  text: string,
+  file: string,
+  propNames?: Set<string>,
+): { classes: ClassInfo[]; instances: InstanceInfo[] } {
+  const classes: ClassInfo[] = [];
+  const instances: InstanceInfo[] = [];
+  const lines = text.split("\n");
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    const cm = CLASS_HEAD.exec(line);
+    if (cm) {
+      const propFields: string[] = [];
+      // Fields are the indented `name : type` lines until dedent.
+      for (let j = i + 1; j < lines.length; j++) {
+        const l = lines[j];
+        if (l.trim() === "" || l.trimStart().startsWith("/-") ||
+            l.trimStart().startsWith("--")) continue;
+        if (!/^\s{2,}/.test(l)) break;
+        const fm = FIELD.exec(l);
+        if (fm && looksPropositional(fm[2], propNames)) propFields.push(fm[1]);
+      }
+      classes.push({ name: cm[1], file, line: i + 1, propFields });
+      continue;
+    }
+
+    const istart = INSTANCE_START.exec(line);
+    // Instance heads wrap. `instance conditional (R : Type u) (h : P) :\n
+    //     TheClass R where` puts the class name on the NEXT line, and a
+    // single-line parse silently misses it — a third bug of the same family,
+    // caught by a test rather than by reading. Join continuation lines until
+    // the head can be split or the body starts.
+    let headText = istart ? istart[1] : "";
+    let consumed = 0;
+    let im = istart ? splitInstanceHead(headText) : null;
+    while (istart && im === null && consumed < 6 && i + consumed + 1 < lines.length) {
+      const nxt = lines[i + consumed + 1];
+      if (nxt.trim() === "" || /^\S/.test(nxt)) break;
+      headText += " " + nxt.trim();
+      consumed++;
+      im = splitInstanceHead(headText);
+    }
+    if (im) {
+      // Collect `field := proof` from the instance body (indented `where` block).
+      const discharges: string[] = [];
+      for (let j = i + consumed + 1; j < lines.length; j++) {
+        const l = lines[j];
+        if (l.trim() === "") continue;
+        if (!/^\s{2,}/.test(l)) break;
+        const dm = /^\s{2,}([A-Za-z_][A-Za-z0-9_'!?]*)\s*:=\s*(.+)$/.exec(l);
+        if (dm) discharges.push(`${dm[1]} := ${dm[2].trim()}`);
+      }
+      instances.push({
+        name: im.name,
+        binders: im.binders,
+        className: im.className,
+        file,
+        line: i + 1,
+        discharges,
+      });
+    }
+  }
+  return { classes, instances };
+}
+
+function scanPackage(repoRoot: string, pkg: LeanPackage): Finding[] {
+  const classes = new Map<string, ClassInfo>();
+  const instances: InstanceInfo[] = [];
+
+  // Pass 1 — every `Prop`-valued name in the package, so a field typed by a
+  // NAMED predicate is recognised as a claim.
+  const files = [...walkLean(resolve(repoRoot, pkg.lakeRoot))];
+  const propNames = new Set<string>();
+  const texts = new Map<string, string>();
+  for (const f of files) {
+    const t = readFileSync(f, "utf8");
+    texts.set(f, t);
+    for (const n of propDeclNames(t)) propNames.add(n);
+  }
+
+  // Pass 2 — classes and instances, now able to see named predicates.
+  for (const f of files) {
+    const parsed = parseLean(texts.get(f)!, relative(repoRoot, f), propNames);
+    for (const c of parsed.classes) classes.set(c.name, c);
+    instances.push(...parsed.instances);
+  }
+
+  const findings: Finding[] = [];
+  for (const inst of instances) {
+    const cls = classes.get(inst.className);
+    if (!cls || cls.propFields.length === 0) continue;
+    if (!isUnconditional(inst.binders, propNames)) continue;
+    // Only the discharges of CLAIM fields matter; data fields may be anything.
+    const claimDischarges = inst.discharges.filter((d) =>
+      cls.propFields.some((f) => d.startsWith(`${f} :=`)));
+    const trivial = claimDischarges.length > 0 &&
+      claimDischarges.every((d) => isTrivialDischarge(d.split(":=").slice(1).join(":=")));
+    findings.push({
+      instance: inst.name,
+      className: inst.className,
+      file: inst.file,
+      line: inst.line,
+      propFields: cls.propFields,
+      severity: trivial ? "trivial" : "substantive",
+      discharges: claimDischarges,
+    });
+  }
+  findings.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line);
+  return findings;
+}
+
+function main(): void {
+  const argv = process.argv.slice(2);
+  let packageName: string | null = null;
+  let baseline: number | null = null;
+  let warnOnly = false;
+  let json = false;
+
+  for (let i = 0; i < argv.length; i++) {
+    switch (argv[i]) {
+      case "--package": packageName = argv[++i]; break;
+      case "--baseline": baseline = Number(argv[++i]); break;
+      case "--warn-only": warnOnly = true; break;
+      case "--json": json = true; break;
+    }
+  }
+
+  const repoRoot = findContentRepoRoot();
+  const pkgs = packageName
+    ? LEAN_PACKAGES.filter((p) => p.name === packageName)
+    : LEAN_PACKAGES;
+
+  const findings: Finding[] = [];
+  for (const pkg of pkgs) findings.push(...scanPackage(repoRoot, pkg));
+
+  if (json) {
+    console.log(JSON.stringify({
+      totals: {
+        findings: findings.length,
+        trivial: findings.filter((f) => f.severity === "trivial").length,
+      },
+      findings,
+    }, null, 2));
+  } else {
+    console.log(
+      `self-discharging-instances — packages: ${pkgs.map((p) => p.name).join(", ")}`,
+    );
+    for (const f of findings) {
+      const tag = f.severity === "trivial" ? "TRIVIAL-DISCHARGE" : "unconditional";
+      console.log(`${tag}  ${f.instance} : ${f.className}`);
+      console.log(`    ${f.file}:${f.line}`);
+      console.log(`    claim fields: ${f.propFields.join(", ")}`);
+      for (const d of f.discharges) console.log(`      ${d}`);
+    }
+    const triv = findings.filter((f) => f.severity === "trivial").length;
+    console.log(`  unconditional instances of claim-carrying classes: ${findings.length}`);
+    console.log(`    of which discharge every claim field TRIVIALLY: ${triv}`);
+    console.log(`    the remainder prove their claims and are usually legitimate;`);
+    console.log(`    the trivial ones are the qou-fngs shape.`);
+    if (findings.length > 0) {
+      console.log(
+        "  fix: demote `instance` to `def` — the model stays available and must",
+      );
+      console.log(
+        "       be named, so a reader can see what discharged the hypothesis.",
+      );
+    }
+  }
+
+  if (warnOnly) process.exit(0);
+  if (baseline !== null && findings.length > baseline) {
+    console.error(
+      `\nGROWTH: ${findings.length} exceeds baseline ${baseline}.`,
+    );
+    process.exit(3);
+  }
+  process.exit(0);
+}
+
+if (import.meta.main) main();

--- a/scripts/pdf-structure.py
+++ b/scripts/pdf-structure.py
@@ -117,7 +117,36 @@ RE_NOT_HEADING = re.compile(
 # Periods must be allowed — initials are near-universal — so a sentence is
 # excluded by looking for ". " followed by a lower-case word instead.
 RE_AUTHORS = re.compile(r"^[A-ZÀ-ʯ](?![^\n]*[.!?]\s+[a-z])[^!?]{2,120}$")
+
+# Punctuation that betrays a list of names: a comma between them, or a
+# conjunction. Necessary but far from sufficient — see `looks_like_byline`,
+# which uses it as one of two routes and vetoes both with the abstract test.
 RE_AUTHOR_HINT = re.compile(r"(,\s|\band\b|\&)", re.I)
+# Words that join names in a byline, and carry no evidence either way.
+BYLINE_CONNECTORS = {"and", "&", "und", "et", "e", "y"}
+# Nobiliary particles and name prefixes, which are lower-case yet name-like.
+NAME_PARTICLES = {
+    "van", "von", "de", "der", "den", "del", "della", "di", "da", "das", "dos",
+    "du", "la", "le", "ten", "ter", "bin", "ibn", "al", "mac", "mc", "st",
+}
+# Function words a *title* uses and a byline does not. Their presence is the
+# cheapest proof that a line is title text rather than a list of names.
+TITLE_FUNCTION_WORDS = {
+    "a", "an", "the", "of", "for", "in", "on", "with", "to", "from", "via",
+    "at", "as", "into", "over", "under", "between", "through", "without",
+    "upon", "its", "their", "some", "new", "toward", "towards", "about",
+    "against", "among", "beyond", "near", "per", "than", "that", "which",
+    "when", "where", "why", "how", "is", "are", "be", "do", "does",
+}
+# Lines that end the title even though they are neither a byline nor the
+# abstract marker: a numbered section heading, or the start of a table of
+# contents. Without this the title runs on into the body — a bound book
+# chapter with no byline took its whole first paragraph as its title.
+RE_TITLE_STOP = re.compile(
+    r"^\s*(?:\d+(?:\.\d+)*\.?\s+[A-ZÀ-ʯ]"
+    r"|contents\b|table of contents\b|introduction\b|keywords?\b|key words\b)",
+    re.I,
+)
 # Report numbers / preprint stamps that precede the title.
 RE_REPORT_NO = re.compile(
     r"^\s*(?:[A-Z]{2,}[-–—/]{1,2}[\w\-–/.]*\d|[a-z\-]+(?:\.[A-Z]{2})?/\d{7}"
@@ -225,9 +254,22 @@ def rejoin_caps(s: str, vocab) -> str:
     # attestation, because the same shape is also a symbol followed by an
     # ordinary word — ungated, this turned the French "Soit K un corps"
     # into "Soit Kun corps".
+    #
+    # Attestation of the JOIN is not enough on its own, because the join can
+    # be a real word while the split was never damage. Seidel's title, "A long
+    # exact sequence for symplectic Floer cohomology", became "Along exact
+    # sequence": `along` is attested on nearly every page of a symplectic
+    # paper, so the join passed — and the paper this repo most wanted became
+    # unfindable by its own name.
+    #
+    # A genuine kerning split leaves a fragment, not a word: "olume", "ector",
+    # "opology". So the tail must be unattested as well. Erring this way is
+    # the safe direction — a missed join leaves text readable, a wrong join
+    # destroys a title.
     s = RE_SPLIT_CAP.sub(
         lambda m: m.group(1) + m.group(2)
-        if freq(m.group(1) + m.group(2)) else m.group(0), s)
+        if freq(m.group(1) + m.group(2)) and not freq(m.group(2))
+        else m.group(0), s)
 
     # Whole runs, longest first. A name can be broken more than once —
     # "J ÉR ÔME" — and joining pairwise never fires there, because the
@@ -432,6 +474,122 @@ def infer_headings(pages: list[str]) -> list[TocEntry]:
     return entries
 
 
+def looks_like_byline(line: str, abstract_words: set[str]) -> bool:
+    """Is `line` a list of author names rather than more of the title?
+
+    This replaces a punctuation test — a line counted as the byline only if it
+    held a comma, "and", or "&" — which failed in both directions. Every
+    **single-author** byline slipped through and was appended to the title
+    (`"FLOER COHOMOLOGY AND PENCILS OF QUADRICS IVAN SMITH"`), and a title
+    continuation that happened to contain "and" was taken *as* the byline,
+    truncating the title and losing the real authors
+    (`"...IN THE MIRROR OF THE PROJECTIVE"` / `"PLANE AND A BINODAL CUBIC
+    CURVE"`). Measured on nine documents ingested 2026-08-24, one title in
+    nine came out correct.
+
+    Two signals, because neither is sufficient alone.
+
+    **Shape.** A byline is names: capitalised words, initials, and nobiliary
+    particles, joined by connectors. One `TITLE_FUNCTION_WORDS` member settles
+    it — no byline says "of" or "the". This alone kills the *"PLANE AND A
+    BINODAL CUBIC CURVE"* case on its bare article "A".
+
+    **The abstract.** Shape cannot separate `"TOM BRIDGELAND"` from
+    `"TORUS KNOT"`; both are two capitalised words. But an author is rarely
+    named in their own abstract, while the nouns of a title are almost always
+    restated in it. So a line whose name-like words are mostly *already in the
+    abstract* is title text. Majority rather than any single hit, so a paper
+    whose author shares a surname with its subject — Roth, on Roth's theorem —
+    is not derailed by one coincidence.
+
+    Document frequency was tried first and rejected: running heads repeat the
+    author surname on every even page, so a name is not rarer than a title
+    word in the text as a whole. The abstract is the part of the document that
+    discriminates.
+
+    `line` must already be repaired (`repair_text` + `rejoin_caps`).
+    Letter-spacing damage splits "IVAN" into "IV AN", and "AN" is a function
+    word — so testing the raw line rejects exactly the bylines this exists to
+    catch.
+    """
+    toks = [t.strip(".,;:()[]") for t in re.split(r"[\s,;]+", line) if t.strip(".,;:()[]")]
+    content = [t for t in toks if t.lower() not in BYLINE_CONNECTORS]
+    if not content:
+        return False
+
+    # The abstract test: a line whose capitalised words are mostly already in
+    # the abstract is title text, because an author is rarely named in their
+    # own abstract while the nouns of a title are almost always restated.
+    words = [t.lower() for t in content if len(t) >= 3 and t[:1].isupper()]
+    in_abstract = bool(abstract_words and words and
+                       sum(1 for w in words if w in abstract_words) * 2 >= len(words))
+
+    # Route 1, inherited: punctuation. A comma, "and" or "&" between names.
+    # Kept because it is what catches the messy real-world byline — emails,
+    # affiliations and daggers inline — which no name-shape test survives:
+    # "Nori Jacoby (nori jacoby@hotmail.com) and Ruth Lawrence (...)". Dropping
+    # it for the shape rule alone ran 104 titles on into their affiliations.
+    #
+    # The abstract veto is applied to this route ONLY when the sole signal is a
+    # bare "and"/"&" with no comma. That is precisely the title-continuation
+    # case — "...IN THE MIRROR OF THE PROJECTIVE" / "PLANE AND A BINODAL CUBIC
+    # CURVE" — while a genuine multi-author byline separates with commas.
+    # Vetoing the comma case as well cost 40 titles their stopping point, the
+    # byline no longer being detected at all: "Modern Theory of Nuclear Forces
+    # E. Epelbaum∗" ran on into "Forschungszentrum Jülich, Institut für ...".
+    if RE_AUTHOR_HINT.search(line):
+        if in_abstract and "," not in line:
+            return False
+        return True
+
+    if in_abstract:
+        return False
+
+    # Route 2, new: name shape, for the single-author byline that carries no
+    # punctuation at all and so was invisible to route 1.
+    #
+    # The token cap belongs to THIS route only. A real byline is often long and
+    # messy — "Ma¨ ıté Dupuis1,∗ and Florian Girelli 2, 1,†" is nine tokens of
+    # kerning damage, superscripts and affiliation markers — and route 1
+    # already recognises it by its punctuation. Applying the cap to both routes
+    # rejected those and let the title run on into the affiliation.
+    if len(content) > 8:
+        return False
+    all_caps = line == line.upper()
+    names: list[str] = []
+    initials = 0
+    for tok in content:
+        low = tok.lower()
+        # Particles are tested before the short-token rule, or "DE LA FACULTÉ"
+        # banks two "initials" and passes as a byline.
+        if low in NAME_PARTICLES:
+            continue
+        if len(tok) == 1 and tok.isalpha() and low not in ("a", "i"):
+            initials += 1
+            continue
+        # In an ALL-CAPS line case carries no information and kerning damage is
+        # the norm, so a one- or two-letter token is a fragment, not a word.
+        # "IVAN SMITH" extracts as "IV AN SMITH" and the damage repeats in the
+        # running heads, so "ivan" is never attested and `rejoin_caps` cannot
+        # repair it; reading "AN" as the article rejects the byline outright.
+        if all_caps and len(tok) <= 2 and tok.isalpha():
+            initials += 1
+            continue
+        if low in TITLE_FUNCTION_WORDS:
+            return False
+        if not tok[:1].isupper():
+            return False
+        if len(tok) >= 3:
+            names.append(low)
+
+    if not names:
+        return False
+    # A lone capitalised word is a title continuation far more often than a
+    # byline — "...FOR NUMBER" / "FIELDS" cost 23 titles their tail. Demand a
+    # second name, or an initial beside it ("E. Epelbaum").
+    return len(names) >= 2 or initials >= 1
+
+
 def parse_front_matter(pages: list[str]) -> dict[str, Any]:
     """Title, authors, abstract, arXiv id, DOI — from page-1 text."""
     p1 = pages[0] if pages else ""
@@ -475,6 +633,11 @@ def parse_front_matter(pages: list[str]) -> dict[str, Any]:
     #
     # The old rule started at line 10.
     def furniture(l: str) -> bool:
+        # "Chapter 5" / "Part II" / "Appendix A" head a book division and are
+        # not the title. Left in, a bound chapter took "Chapter 5" as its
+        # title and pushed its real one ("ROTH'S LEMMA") into the byline.
+        if re.match(r"^(?:chapter|section|part|appendix)\s+[\dIVXLC]+\.?$", l, re.I):
+            return True
         return bool(re.search(r"ar\s*X\s*iv", l, re.I) or RE_REPORT_NO.match(l))
 
     start = 0
@@ -521,26 +684,6 @@ def parse_front_matter(pages: list[str]) -> dict[str, Any]:
             continue
         break
 
-    title_lines: list[str] = []
-    author_lines: list[str] = []
-    for l in lines[start:start + 20]:
-        if re.match(r"^abstract\b", l, re.I):
-            break
-        if not l or len(l) < 3 or re.match(r"^\d+$", l) or RE_REPORT_NO.match(l):
-            if title_lines and not l:
-                # blank line after a title usually precedes the authors
-                continue
-            continue
-        # An author line: capitalised, comma/and-separated, no trailing colon,
-        # and we already have some title text.
-        if title_lines and RE_AUTHORS.match(l) and RE_AUTHOR_HINT.search(l) \
-                and not l.endswith(":") and len(l) < 120:
-            author_lines.append(l)
-            break
-        title_lines.append(l)
-        if len(" ".join(title_lines)) > 180:
-            break
-
     # The document's own token set, used to decide whether an all-caps
     # split is real, and built from *repaired* text so an accented name
     # can attest its own join.
@@ -554,6 +697,46 @@ def parse_front_matter(pages: list[str]) -> dict[str, Any]:
                     re.findall(r"[^\W\d_]{3,}", repair_text("\n".join(pages))))
 
     fix = lambda s: rejoin_caps(repair_text(s), vocab).strip(" .,")
+
+    # The abstract's vocabulary, needed *before* the title/byline walk because
+    # `looks_like_byline` uses it to tell a name from a title noun. Read
+    # straight from page-1 text rather than from `meta["abstract"]`, which is
+    # assembled further down and would make the two mutually dependent.
+    abstract_words: set[str] = set()
+    _am = re.search(r"\babstract\b\s*[.:—–-]?\s*", p1, re.I)
+    if _am:
+        abstract_words = {
+            w.lower() for w in re.findall(r"[^\W\d_]{3,}", p1[_am.end(): _am.end() + 2000])
+        }
+
+    title_lines: list[str] = []
+    author_lines: list[str] = []
+    for l in lines[start:start + 20]:
+        if re.match(r"^abstract\b", l, re.I):
+            break
+        if not l or len(l) < 3 or re.match(r"^\d+$", l) or RE_REPORT_NO.match(l):
+            if title_lines and not l:
+                # blank line after a title usually precedes the authors
+                continue
+            continue
+        # A numbered section heading or a table of contents ends the title,
+        # even where the document carries no byline at all to stop it.
+        if title_lines and RE_TITLE_STOP.match(l):
+            break
+        # An author line: capitalised, name-shaped, no trailing colon, and we
+        # already have some title text. `looks_like_byline` is given the
+        # *repaired* line — letter-spacing damage splits "IVAN" into "IV AN",
+        # and "AN" reads as a function word, so the raw line rejects the very
+        # bylines this is here to catch.
+        if title_lines and RE_AUTHORS.match(l) and not l.endswith(":") \
+                and len(l) < 120 \
+                and looks_like_byline(fix(l), abstract_words):
+            author_lines.append(l)
+            break
+        title_lines.append(l)
+        if len(" ".join(title_lines)) > 180:
+            break
+
     title = fix(" ".join(title_lines))
     meta["title"] = title or None
     authors = fix(" ".join(author_lines))
@@ -561,13 +744,13 @@ def parse_front_matter(pages: list[str]) -> dict[str, Any]:
     # The lines the title was assembled from, kept separately.
     #
     # Joining them destroys the one boundary that reliably separates a
-    # title from its byline: the line break. When the author-line test
-    # above misses — it needs a comma or an "and", so a single-author
-    # byline slips through — the byline is appended to the title and no
-    # downstream heuristic can recover it, because in an all-caps title
-    # "THEORY TOM BRIDGELAND" is indistinguishable from "TORUS KNOT" by
-    # shape alone. With the lines kept, a consumer can test the last one
-    # on its own.
+    # title from its byline: the line break. `looks_like_byline` now makes
+    # that test in-place, so the byline no longer silently lands in the
+    # title — but the lines stay exported anyway. The case that motivated
+    # them is real and unsolved by shape alone ("THEORY TOM BRIDGELAND" is
+    # indistinguishable from "TORUS KNOT"); the byline test settles it with
+    # the abstract's vocabulary, which is evidence, not proof. A consumer
+    # that disagrees can still re-split on the original boundary.
     meta["title_lines"] = [fix(l) for l in title_lines] or None
 
     # Abstract: everything after the marker, cut at the first section heading.

--- a/scripts/pdf-structure.py
+++ b/scripts/pdf-structure.py
@@ -118,6 +118,16 @@ RE_NOT_HEADING = re.compile(
 # excluded by looking for ". " followed by a lower-case word instead.
 RE_AUTHORS = re.compile(r"^[A-ZÀ-ʯ](?![^\n]*[.!?]\s+[a-z])[^!?]{2,120}$")
 
+# Marks that only a byline carries: an initial ("D. J."), an affiliation
+# superscript ("Kreimer 2)", "Lv*1"), or a dagger/asterisk footnote. A title
+# continuation has none of these, so their presence outranks the abstract test.
+RE_BYLINE_MARKER = re.compile(
+    r"(?:\b[A-ZÀ-ʯ]\.(?:\s|$)"          # an initial with its period
+    r"|\d\s*\)"                          # "1)" affiliation marker
+    r"|[∗*†‡§]"                           # footnote marks
+    r"|\b[A-ZÀ-ʯ][a-zà-ʯ]+\s*\*?\d)"     # "Lv*1", "Zhou 2"
+)
+
 # Punctuation that betrays a list of names: a comma between them, or a
 # conjunction. Necessary but far from sufficient — see `looks_like_byline`,
 # which uses it as one of two routes and vetoes both with the abstract test.
@@ -521,8 +531,24 @@ def looks_like_byline(line: str, abstract_words: set[str]) -> bool:
     # the abstract is title text, because an author is rarely named in their
     # own abstract while the nouns of a title are almost always restated.
     words = [t.lower() for t in content if len(t) >= 3 and t[:1].isupper()]
-    in_abstract = bool(abstract_words and words and
-                       sum(1 for w in words if w in abstract_words) * 2 >= len(words))
+    hits = sum(1 for w in words if w in abstract_words) if abstract_words else 0
+    # A STRICT majority, and never on the strength of one word.
+    #
+    # `>= half` collapses to "any single hit" on a two-name byline: filtering
+    # initials and digits leaves `['broadhurst', 'kreimer']`, and one match
+    # satisfies `1 * 2 >= 2`. The old docstring defended "majority rather than
+    # any single hit" — true of a long byline, false of exactly the short one
+    # this test is usually asked about.
+    in_abstract = bool(words and hits >= 2 and hits * 2 > len(words))
+
+    # …and the veto does not apply at all to a line carrying INITIALS or
+    # affiliation markers. Those are positive byline evidence that a title
+    # continuation does not have, and they outrank the abstract heuristic,
+    # whose premise — "an author is rarely named in their own abstract" — is
+    # simply false in physics: `hep-th/0001202`'s abstract names both
+    # Broadhurst and Kreimer, and that is ordinary self-reference.
+    if RE_BYLINE_MARKER.search(line):
+        in_abstract = False
 
     # Route 1, inherited: punctuation. A comma, "and" or "&" between names.
     # Kept because it is what catches the messy real-world byline — emails,
@@ -705,9 +731,24 @@ def parse_front_matter(pages: list[str]) -> dict[str, Any]:
     abstract_words: set[str] = set()
     _am = re.search(r"\babstract\b\s*[.:—–-]?\s*", p1, re.I)
     if _am:
-        abstract_words = {
-            w.lower() for w in re.findall(r"[^\W\d_]{3,}", p1[_am.end(): _am.end() + 2000])
-        }
+        _tail = p1[_am.end(): _am.end() + 2600]
+        # Cut at the first section heading — the SAME cut `meta["abstract"]`
+        # uses below, so the two cannot disagree about what the abstract is.
+        #
+        # A raw window overruns the abstract into the body, the author
+        # addresses and the bibliography, and then "named in the abstract"
+        # becomes "named anywhere on page 1" — which every author is.
+        # `arxiv-math-0304010v1` lost its byline to exactly this: all four of
+        # Vladimir/Ivanov/Grigori/Olshanski were found, so the veto fired at
+        # full strength on a line that is nothing but names.
+        _cut = re.search(
+            r"\n\s*(?:1\s*\.?\s+Introduction\b|Introduction\b|Contents\b"
+            r"|Keywords?\b|Key words\b|MSC\b|AMS\b|\d{4}\s+Mathematics)",
+            _tail, re.I,
+        )
+        if _cut:
+            _tail = _tail[: _cut.start()]
+        abstract_words = {w.lower() for w in re.findall(r"[^\W\d_]{3,}", _tail)}
 
     title_lines: list[str] = []
     author_lines: list[str] = []

--- a/scripts/pypdf_safe.py
+++ b/scripts/pypdf_safe.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""
+pypdf_safe — import `pypdf` without being killed by a broken `cryptography`.
+
+## The failure this prevents
+
+`pypdf` imports `cryptography` optionally, for AES-encrypted PDFs, and guards
+it with `except ImportError`. On a system where `cryptography`'s Rust bindings
+are broken — debian's 41.0.7 against a mismatched pyo3 is the case observed in
+this project's containers — importing it does not raise `ImportError`. It
+raises pyo3's `PanicException`, which derives from **`BaseException`**, not
+`Exception`:
+
+    File ".../cryptography/exceptions.py", line 9, in <module>
+        from cryptography.hazmat.bindings._rust import exceptions
+    pyo3_runtime.PanicException: Python API call failed
+
+So `pypdf`'s guard does not catch it, and `import pypdf` takes the whole
+process down. Every consumer inherits the failure, and the traceback points at
+`cryptography` rather than at the PDF tool the user actually ran, which is why
+this went undiagnosed long enough to be worth a module.
+
+`scripts/pdf-extract.py` solves the same problem by *recovery* — every rung of
+its extraction ladder catches `BaseException` and falls through to the next,
+ending at a zero-dependency content-stream reader. That is the right design
+there, because its job is to return text from a hostile file by any means.
+This module is the *prevention* half, for the scripts whose job is structure
+rather than salvage and which therefore need `pypdf` specifically.
+
+## Why it probes instead of always stubbing
+
+Blanket-stubbing `cryptography` would silently disable AES support on healthy
+systems, turning "this PDF is encrypted" into a mystery. So the module tries
+the real import first, catching `BaseException`, and installs stubs only when
+that fails. On a working system nothing changes; on a broken one, `pypdf`
+takes its no-crypto branch and encrypted PDFs — of which this corpus has none
+— report as unreadable rather than aborting the run.
+
+After a panic the failed package can be left half-initialised in
+`sys.modules`, so the entries are purged before the stubs go in.
+
+## Use
+
+Import this instead of `pypdf`, and do it before anything else imports pypdf::
+
+    from pypdf_safe import PdfReader          # or PdfWriter
+
+`scripts/` is `sys.path[0]` when a script there is run directly, so the plain
+module name resolves without path juggling.
+
+`CRYPTOGRAPHY_STUBBED` records which branch was taken, for diagnostics.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+
+__all__ = ["PdfReader", "PdfWriter", "CRYPTOGRAPHY_STUBBED"]
+
+# Submodules pypdf reaches for. Parents are listed too: a stub must exist for
+# every level, or Python falls through to the real (panicking) package.
+_CRYPTO_MODULES = (
+    "cryptography",
+    "cryptography.exceptions",
+    "cryptography.hazmat",
+    "cryptography.hazmat.backends",
+    "cryptography.hazmat.bindings",
+    "cryptography.hazmat.primitives",
+    "cryptography.hazmat.primitives.ciphers",
+    "cryptography.hazmat.primitives.ciphers.algorithms",
+    "cryptography.hazmat.primitives.ciphers.modes",
+    "cryptography.hazmat.primitives.padding",
+)
+
+
+def _cryptography_is_healthy() -> bool:
+    """True if `cryptography` imports without exploding.
+
+    Catches `BaseException` deliberately: pyo3's `PanicException` is not an
+    `Exception`, which is the entire reason this module exists.
+
+    The probe's stderr is silenced at the **file-descriptor** level, not with
+    `contextlib.redirect_stderr`, because the noise comes from Rust's panic
+    hook writing to fd 2 directly and never passes through `sys.stderr`. It is
+    ordinary output for an expected, handled condition, and leaving it in
+    place would reproduce the original problem in miniature: a run that
+    succeeded would still print `thread '<unnamed>' panicked` and read as a
+    failure. Only the probe is muted; everything the calling script writes is
+    untouched.
+    """
+    saved = None
+    devnull = None
+    try:
+        devnull = os.open(os.devnull, os.O_WRONLY)
+        saved = os.dup(2)
+        sys.stderr.flush()
+        os.dup2(devnull, 2)
+    except OSError:  # pragma: no cover -- no fd 2 to speak of; just probe loudly
+        saved = None
+
+    try:
+        import cryptography.exceptions  # noqa: F401
+        import cryptography.hazmat.primitives.ciphers  # noqa: F401
+    except BaseException:  # noqa: BLE001 -- see docstring
+        return False
+    else:
+        return True
+    finally:
+        if saved is not None:
+            os.dup2(saved, 2)
+            os.close(saved)
+        if devnull is not None:
+            os.close(devnull)
+
+
+def _install_stubs() -> None:
+    """Replace `cryptography` with empty packages.
+
+    An attribute lookup into an empty module raises `ImportError`, which is
+    what `pypdf`'s own guard expects, so it takes the no-crypto branch.
+    """
+    # A panicking import can leave partially built parents behind; drop them
+    # so the stubs are what later imports find.
+    for name in [m for m in sys.modules if m == "cryptography" or m.startswith("cryptography.")]:
+        del sys.modules[name]
+
+    for name in _CRYPTO_MODULES:
+        module = types.ModuleType(name)
+        # `__path__` marks it a package, so `import a.b.c` resolves here
+        # instead of falling through to the real distribution on disk.
+        module.__path__ = []  # type: ignore[attr-defined]
+        sys.modules[name] = module
+
+
+def _prepare() -> bool:
+    if "pypdf" in sys.modules:
+        # Someone imported it already and survived; leave well alone.
+        return False
+    if _cryptography_is_healthy():
+        return False
+    _install_stubs()
+    return True
+
+
+CRYPTOGRAPHY_STUBBED = _prepare()
+
+try:
+    from pypdf import PdfReader, PdfWriter
+except ImportError as exc:  # pragma: no cover -- genuinely absent
+    raise SystemExit(
+        f"pypdf_safe: needs pypdf — pip install pypdf ({exc})"
+    ) from exc
+except BaseException as exc:  # noqa: BLE001 -- pragma: no cover
+    # Stubs installed and it still panicked: something else is broken, and
+    # saying so beats a bare traceback from inside a dependency.
+    raise SystemExit(
+        "pypdf_safe: pypdf failed to import even with `cryptography` stubbed "
+        f"({type(exc).__name__}: {exc}). Try `pip install --force-reinstall "
+        "pypdf`, or use scripts/pdf-extract.py, whose last rung needs no "
+        "third-party library."
+    ) from exc

--- a/scripts/tests/check-self-discharging-instances.test.ts
+++ b/scripts/tests/check-self-discharging-instances.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from "bun:test";
+import {
+  splitInstanceHead,
+  propDeclNames,
+  looksPropositional,
+  isUnconditional,
+  isTrivialDischarge,
+  parseLean,
+} from "../check-self-discharging-instances.ts";
+
+/**
+ * Every test below pins a bug that was live in the first version, found by
+ * running the checker against the file it was written for and getting **zero**.
+ * A checker that returns a clean zero without examining anything is
+ * indistinguishable from one that passed.
+ */
+
+describe("splitInstanceHead — binder colons", () => {
+  test("splits at the colon OUTSIDE the binders", () => {
+    // The original `[^:]*` regex stopped at the colon inside `(R : Type u)`
+    // and produced the wrong result class, so nothing was ever flagged.
+    const r = splitInstanceHead("canonical (R : Type u) : GBFiltrationCollapsesAtE2 R");
+    expect(r).not.toBeNull();
+    expect(r!.name).toBe("canonical");
+    expect(r!.className).toBe("GBFiltrationCollapsesAtE2");
+  });
+
+  test("handles instance-implicit and implicit binders", () => {
+    const r = splitInstanceHead("foo {α : Type*} [CommRing α] (n : ℕ) : MyClass α n");
+    expect(r!.name).toBe("foo");
+    expect(r!.className).toBe("MyClass");
+    expect(r!.binders).toContain("[CommRing α]");
+  });
+
+  test("anonymous instance has no leading name", () => {
+    const r = splitInstanceHead("(R : Type u) : HasThing R");
+    expect(r!.name).toBe("«anonymous»");
+    expect(r!.className).toBe("HasThing");
+  });
+
+  test("no top-level colon yields null rather than a wrong answer", () => {
+    expect(splitInstanceHead("mangled (R : Type u)")).toBeNull();
+  });
+});
+
+describe("propDeclNames — result colon, not binder colon", () => {
+  test("finds a Prop-valued def whose binders contain colons", () => {
+    // The original `[^:]*` could not span `{R : Type u} (S : Foo R)`.
+    const src = "def CollapsesAt {R : Type u} (S : Foo R) (r₀ : ℕ) : Prop :=\n  True\n";
+    expect(propDeclNames(src)).toContain("CollapsesAt");
+  });
+
+  test("finds abbrev and ignores non-Prop defs", () => {
+    const src = [
+      "abbrev CollapsesAtE2 {R : Type u} (S : Foo R) : Prop := CollapsesAt S 2",
+      "def notAClaim (R : Type u) : Type u := R",
+    ].join("\n");
+    const names = propDeclNames(src);
+    expect(names).toContain("CollapsesAtE2");
+    expect(names).not.toContain("notAClaim");
+  });
+});
+
+describe("looksPropositional", () => {
+  test("inline propositions", () => {
+    expect(looksPropositional("q0 > 1")).toBe(true);
+    expect(looksPropositional("∀ A, w A = 3")).toBe(true);
+  });
+
+  test("a NAMED predicate needs the package's Prop set", () => {
+    // This is what made the checker miss its own flagship case.
+    expect(looksPropositional("CollapsesAtE2 ss")).toBe(false);
+    expect(looksPropositional("CollapsesAtE2 ss", new Set(["CollapsesAtE2"]))).toBe(true);
+  });
+
+  test("data fields are not claims", () => {
+    expect(looksPropositional("Type u")).toBe(false);
+    expect(looksPropositional("M → ℝ")).toBe(false);
+  });
+});
+
+describe("isUnconditional", () => {
+  test("type and instance binders only", () => {
+    expect(isUnconditional(" (R : Type u) ")).toBe(true);
+    expect(isUnconditional(" {α : Type*} [CommRing α] ")).toBe(true);
+  });
+
+  test("an explicit PROOF OBLIGATION makes it conditional, and fine", () => {
+    // `instance foo (hq : q ≠ 1) : C X` is legitimate — the caller supplies it.
+    expect(isUnconditional(" (R : Type u) (hq : q ≠ 1) ")).toBe(false);
+    // A named predicate needs the package Prop set, same as field types.
+    expect(isUnconditional(" (h : MyClaim R) ")).toBe(true);
+    expect(isUnconditional(" (h : MyClaim R) ", new Set(["MyClaim"]))).toBe(false);
+  });
+
+  test("a DATA parameter does not make it conditional", () => {
+    // `instance foo (n : ℕ) : C n` is still supplied for free at every `n` —
+    // resolution fills `n` from the goal. Requiring `Type` here was too strict
+    // and hid three of the seven known cases in QOU/Mathlib/SpectralSequence.
+    expect(isUnconditional(" (R : Type u) (n : ℕ) ")).toBe(true);
+  });
+
+  test("nested parens in a binder type are handled", () => {
+    // `[^()]*` could not span `(bar R)`, so the binder was skipped entirely and
+    // a conditional instance was reported as unconditional.
+    expect(isUnconditional(" (h : MyClaim (bar R)) ", new Set(["MyClaim"]))).toBe(false);
+  });
+});
+
+describe("isTrivialDischarge", () => {
+  test("by-construction proofs", () => {
+    expect(isTrivialDischarge("rfl")).toBe(true);
+    expect(isTrivialDischarge("fun _ => rfl")).toBe(true);
+    expect(isTrivialDischarge("fun _ _ _ => rfl")).toBe(true);
+    expect(isTrivialDischarge("hf.out")).toBe(true);
+  });
+
+  test("a real proof term is not trivial", () => {
+    expect(isTrivialDischarge("q_zero_gt_one")).toBe(false);
+    expect(isTrivialDischarge("lt_of_lt_of_le zero_lt_one h")).toBe(false);
+  });
+});
+
+describe("end-to-end", () => {
+  const src = [
+    "def CollapsesAt {R : Type u} (S : Foo R) (r₀ : ℕ) : Prop := True",
+    "abbrev CollapsesAtE2 {R : Type u} (S : Foo R) : Prop := CollapsesAt S 2",
+    "",
+    "class GBFiltrationCollapsesAtE2 (R : Type u) where",
+    "  ss : Foo R",
+    "  collapses : CollapsesAtE2 ss",
+    "",
+    "instance canonical (R : Type u) : GBFiltrationCollapsesAtE2 R where",
+    "  ss := trivial R",
+    "  collapses := trivial_collapses_at_E2 R",
+    "",
+    "instance conditional (R : Type u) (h : CollapsesAtE2 (bar R)) :",
+    "    GBFiltrationCollapsesAtE2 R where",
+    "  ss := bar R",
+    "  collapses := h",
+  ].join("\n");
+
+  test("catches the unconditional instance of a claim-carrying class", () => {
+    const names = new Set(propDeclNames(src));
+    const { classes, instances } = parseLean(src, "t.lean", names);
+    const cls = new Map(classes.map((c) => [c.name, c]));
+    const caught = instances.filter((i) => {
+      const c = cls.get(i.className);
+      return c && c.propFields.length > 0 && isUnconditional(i.binders, names);
+    });
+    expect(caught.map((c) => c.name)).toEqual(["canonical"]);
+  });
+
+  test("does NOT flag the conditional instance beside it", () => {
+    // The discriminator must not become a blanket flag on the class.
+    const names = new Set(propDeclNames(src));
+    const { instances } = parseLean(src, "t.lean", names);
+    const cond = instances.find((i) => i.name === "conditional");
+    expect(cond).toBeDefined();
+    expect(isUnconditional(cond!.binders, names)).toBe(false);
+  });
+});

--- a/scripts/tests/infrastructure.test.ts
+++ b/scripts/tests/infrastructure.test.ts
@@ -6,10 +6,11 @@
  */
 
 import { describe, test, expect } from "bun:test";
-import { readFileSync, existsSync } from "fs";
+import { readFileSync, existsSync, readdirSync } from "fs";
 import { join } from "path";
 import { execSync } from "child_process";
 import { REPO_ROOT, FOLIO_ROOT, hasFolio } from "./helpers";
+import { maskComments } from "../../content/pipeline/uses-field";
 
 /** Skip folio-side assertions when no content repo is attached. */
 const folio = hasFolio();
@@ -246,6 +247,57 @@ describe.skipIf(!folio)(".gitignore", () => {
 
   test("blocks content/quantum-observable-universe/lean/.lake/", () => {
     expect(gitignore).toContain("content/quantum-observable-universe/lean/.lake/");
+  });
+});
+
+// ── Test-suite path anchoring ───────────────────────────────────
+
+/**
+ * `run-tests.sh` does `cd "$SCRIPT_DIR"` before `bun test`, so under the
+ * canonical runner `process.cwd()` is `scripts/tests/`, NOT the repo root. A
+ * test that builds a repo path with `join(process.cwd(), ...)` therefore points
+ * at `scripts/tests/<path>`, which does not exist — and the failure surfaces as
+ * whatever the code under test does with a missing file rather than as "wrong
+ * path". `qa-criterion-hash.test.ts` lost its real-module guard that way: the
+ * hash came back `null` from an ENOENT, indistinguishable from the checker
+ * shape drift the guard exists to catch, and the test only ever passed when the
+ * suite was invoked by hand from the repo root.
+ *
+ * Repo paths in tests anchor at `import.meta.dir` (`REPO_ROOT` in `helpers.ts`)
+ * — which is also what survives a folio embedding this repo by symlink.
+ */
+describe("tests anchor repo paths at import.meta.dir, not process.cwd()", () => {
+  // `join(process.cwd(), ...)` / `resolve(process.cwd(), ...)`, across line
+  // breaks, plus the `process.cwd() + "/..."` spelling. Bare `process.cwd()` is
+  // NOT flagged: saving and restoring it around a `process.chdir` is legitimate
+  // and several tests do exactly that.
+  const CWD_ANCHORED = /(?:\b(?:join|resolve)\(\s*process\.cwd\(\)|process\.cwd\(\)\s*\+)/g;
+  /** Opt-out for a test that genuinely means "relative to wherever we are". */
+  const ALLOW = "allow-cwd-anchored-paths";
+
+  const dir = join(REPO_ROOT, "scripts/tests");
+  const files = readdirSync(dir).filter((f) => f.endsWith(".ts"));
+
+  test("scans a plausible number of test files", () => {
+    // Guards the guard: a bad directory or filter would make it vacuous.
+    expect(files.length).toBeGreaterThan(50);
+  });
+
+  test("no test builds a repo path from the runner's cwd", () => {
+    const offenders: string[] = [];
+    for (const file of files) {
+      const source = readFileSync(join(dir, file), "utf-8");
+      if (source.includes(ALLOW)) continue;
+      // Comments are prose ABOUT the anti-pattern — this block's own docstring
+      // included. `maskComments` blanks them in place, so offsets and line
+      // numbers still point at the real source.
+      const code = maskComments(source);
+      for (const m of code.matchAll(CWD_ANCHORED)) {
+        const line = code.slice(0, m.index).split("\n").length;
+        offenders.push(`${file}:${line}: ${m[0].replace(/\s+/g, " ")}`);
+      }
+    }
+    expect(offenders).toEqual([]);
   });
 });
 

--- a/scripts/tests/pypdf-safe.test.ts
+++ b/scripts/tests/pypdf-safe.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Regression tests for `scripts/pypdf_safe.py`.
+ *
+ * The bug: `pypdf` guards its optional `cryptography` import with
+ * `except ImportError`, but a broken Rust binding raises pyo3's
+ * `PanicException`, which derives from `BaseException`. The guard misses it
+ * and `import pypdf` takes the whole process down — observed in this
+ * project's containers with debian `cryptography` 41.0.7, where it made
+ * `pdf-structure.py` unusable and had to be worked around by hand with a
+ * `sitecustomize.py` shim.
+ *
+ * These tests poison `cryptography` the same way (a module that raises a
+ * BaseException on import, planted ahead of the real one on PYTHONPATH) and
+ * assert the PDF scripts still run. Without the fix they fail; the poison
+ * subclasses BaseException directly, so an `except Exception` or
+ * `except ImportError` guard cannot catch it.
+ *
+ * Run via the standard harness:
+ *
+ *     ./scripts/tests/run-tests.sh
+ *     # or
+ *     cd scripts/tests && bun test pypdf-safe.test.ts
+ */
+
+import { describe, test, expect, beforeAll } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join, resolve } from "path";
+
+const SCRIPTS = resolve(import.meta.dir, "..");
+
+/** A `cryptography` package that explodes on import, exactly as pyo3 does. */
+function plantPoisonedCryptography(root: string): void {
+  const pkg = join(root, "cryptography");
+  mkdirSync(join(pkg, "hazmat", "primitives", "ciphers"), { recursive: true });
+  // PanicException is not an Exception; reproduce that, not a plain error.
+  const boom = [
+    "class PanicException(BaseException):",
+    "    pass",
+    "",
+    "raise PanicException('Python API call failed')",
+    "",
+  ].join("\n");
+  writeFileSync(join(pkg, "__init__.py"), boom);
+  writeFileSync(join(pkg, "exceptions.py"), boom);
+  writeFileSync(join(pkg, "hazmat", "__init__.py"), boom);
+  writeFileSync(join(pkg, "hazmat", "primitives", "__init__.py"), boom);
+  writeFileSync(join(pkg, "hazmat", "primitives", "ciphers", "__init__.py"), boom);
+}
+
+interface Run {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+async function runPython(args: string[], env: Record<string, string>): Promise<Run> {
+  const proc = Bun.spawn(["python3", ...args], {
+    cwd: SCRIPTS,
+    env: { ...process.env, ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const code = await proc.exited;
+  return { code, stdout, stderr };
+}
+
+let havePypdf = false;
+
+beforeAll(async () => {
+  const probe = await runPython(["-c", "import pypdf"], {});
+  havePypdf = probe.code === 0;
+});
+
+describe("pypdf_safe", () => {
+  test("imports pypdf when cryptography is healthy, without stubbing it", async () => {
+    if (!havePypdf) return; // pypdf absent: nothing to assert about its import
+    const r = await runPython(
+      ["-c", "import pypdf_safe; print('STUBBED', pypdf_safe.CRYPTOGRAPHY_STUBBED)"],
+      {},
+    );
+    expect(r.code).toBe(0);
+    // Whether the real cryptography works is environment-dependent, so this
+    // only pins that the module reports its branch rather than guessing.
+    expect(r.stdout).toContain("STUBBED");
+  });
+
+  test("survives a cryptography that raises BaseException on import", async () => {
+    if (!havePypdf) return;
+    const dir = mkdtempSync(join(tmpdir(), "pypdf-safe-poison-"));
+    try {
+      plantPoisonedCryptography(dir);
+      const r = await runPython(
+        ["-c", "import pypdf_safe; print('READER', pypdf_safe.PdfReader.__name__)"],
+        { PYTHONPATH: dir },
+      );
+      expect(r.stderr).not.toContain("PanicException");
+      expect(r.code).toBe(0);
+      expect(r.stdout).toContain("READER PdfReader");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("reports that it stubbed, when it stubbed", async () => {
+    if (!havePypdf) return;
+    const dir = mkdtempSync(join(tmpdir(), "pypdf-safe-flag-"));
+    try {
+      plantPoisonedCryptography(dir);
+      const r = await runPython(
+        ["-c", "import pypdf_safe; print('STUBBED', pypdf_safe.CRYPTOGRAPHY_STUBBED)"],
+        { PYTHONPATH: dir },
+      );
+      expect(r.code).toBe(0);
+      expect(r.stdout).toContain("STUBBED True");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("pdf-structure.py starts under a poisoned cryptography", async () => {
+    if (!havePypdf) return;
+    const dir = mkdtempSync(join(tmpdir(), "pypdf-safe-structure-"));
+    try {
+      plantPoisonedCryptography(dir);
+      const r = await runPython(["pdf-structure.py", "--help"], { PYTHONPATH: dir });
+      expect(r.stderr).not.toContain("PanicException");
+      expect(r.code).toBe(0);
+      expect(r.stdout).toContain("usage");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("split-pdf-by-chapter.py starts under a poisoned cryptography", async () => {
+    if (!havePypdf) return;
+    const dir = mkdtempSync(join(tmpdir(), "pypdf-safe-split-"));
+    try {
+      plantPoisonedCryptography(dir);
+      const r = await runPython(["split-pdf-by-chapter.py", "--help"], { PYTHONPATH: dir });
+      expect(r.stderr).not.toContain("PanicException");
+      expect(r.code).toBe(0);
+      expect(r.stdout).toContain("usage");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("the poison actually reproduces the bug (a bare pypdf import dies)", async () => {
+    if (!havePypdf) return;
+    const dir = mkdtempSync(join(tmpdir(), "pypdf-safe-control-"));
+    try {
+      plantPoisonedCryptography(dir);
+      // Control: this is what the scripts used to do. If this ever starts
+      // passing, the poison stopped reproducing the failure and the tests
+      // above have quietly stopped proving anything.
+      const r = await runPython(
+        ["-c", "from pypdf import PdfReader; print('SURVIVED')"],
+        { PYTHONPATH: dir },
+      );
+      expect(r.stdout).not.toContain("SURVIVED");
+      expect(r.code).not.toBe(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/tests/qa-checkers-python.test.ts
+++ b/scripts/tests/qa-checkers-python.test.ts
@@ -27,7 +27,20 @@ import {
   checkConnectedToCiPipeline,
   checkDeprecated,
   checkUsesLibraryFrameworkAppropriately,
+  checkAssertionsAreFalsifiable,
 } from "../../content/pipeline/qa-checkers-python";
+
+/** Write `source` to a temp `.py` and run `fn` against its path. */
+function withPy<T>(source: string, fn: (p: string) => T): T {
+  const dir = mkdtempSync(join(tmpdir(), "qa-py-"));
+  try {
+    const file = join(dir, "fixture.py");
+    writeFileSync(file, source);
+    return fn(file);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
 
 function runChecker(source: string): {
   bare_literals: number;
@@ -668,5 +681,69 @@ describe("checkUsesLibraryFrameworkAppropriately", () => {
       checkUsesLibraryFrameworkAppropriately,
     );
     expect(r.result).toBe("pass");
+  });
+});
+
+describe("assertions_are_falsifiable", () => {
+  test("fires when computed and expected are the same expression", () => {
+    const src = `
+w.add_assertion("gluon", computed=sel[0], expected=sel[0], source="ILP")
+`;
+    const r = withPy(src, (p) => checkAssertionsAreFalsifiable(p));
+    expect(r.result).toBe("fail");
+    expect(r.hits[0].text).toContain("compares `sel[0]` to itself");
+  });
+
+  test("fires on literal-vs-literal, the clearest form", () => {
+    const src = `
+wb.add_assertion("kernel_ran", computed=1, expected=1, tolerance=0)
+`;
+    expect(withPy(src, (p) => checkAssertionsAreFalsifiable(p)).result).toBe("fail");
+  });
+
+  test("fires across a multi-line call", () => {
+    const src = `
+w.add_assertion(
+    "tr_M",
+    computed=r["tr_M"],
+    expected=r["tr_M"],
+    tolerance=1e-10,
+)
+`;
+    expect(withPy(src, (p) => checkAssertionsAreFalsifiable(p)).result).toBe("fail");
+  });
+
+  test("does NOT fire when the two sides differ", () => {
+    const src = `
+w.add_assertion("vol", computed=vol_computed, expected=2.0298, tolerance=1e-6)
+`;
+    expect(withPy(src, (p) => checkAssertionsAreFalsifiable(p)).result).toBe("pass");
+  });
+
+  test("does NOT fire inside a docstring", () => {
+    // `witness.py` documents its own API with a same-value example. Firing on
+    // the documentation of the function under test was the first corpus run's
+    // only false positive.
+    const src = [
+      '"""Usage:',
+      '',
+      '    w.add_assertion("Vol(4_1)", computed=2.0298, expected=2.0298)',
+      '"""',
+      'x = 1',
+    ].join("\n");
+    expect(withPy(src, (p) => checkAssertionsAreFalsifiable(p)).result).toBe("pass");
+  });
+
+  test("still sees string-valued tautologies", () => {
+    // Only TRIPLE-quoted blocks are blanked; blanking every string literal
+    // would trade the docstring false positive for these real ones.
+    const src = `
+w.add_assertion("resid", computed="0", expected="0")
+`;
+    expect(withPy(src, (p) => checkAssertionsAreFalsifiable(p)).result).toBe("fail");
+  });
+
+  test("n/a when the file has no assertions at all", () => {
+    expect(withPy("x = 1\n", (p) => checkAssertionsAreFalsifiable(p)).result).toBe("n/a");
   });
 });

--- a/scripts/tests/qa-checkers-vacuity.test.ts
+++ b/scripts/tests/qa-checkers-vacuity.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Tests for the vacuity-by-construction axis.
+ *
+ * The motivating case is reproduced verbatim as a fixture: qou's
+ * `ConfinementGradingCorrespondence.canonical` set both filtrations to `0` so
+ * that `filtrations_agree := rfl` discharged the conjecture, and advertised
+ * itself in its docstring as carrying "the explicit research-grade conjecture
+ * as a sorry" while containing no `sorry`.
+ *
+ * Both halves of the conjunction are pinned negatively as well as positively:
+ * degenerate data alone must NOT fire, and a `rfl` discharge alone must NOT
+ * fire. That is the whole reason this axis is more specific than
+ * `check-self-discharging-instances.ts`, and a regression that loosened it
+ * would show up as noise rather than as a failure.
+ *
+ *     ./scripts/tests/run-tests.sh
+ *     cd scripts/tests && bun test qa-checkers-vacuity.test.ts
+ */
+
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  checkNoVacuousInstanceData,
+  checkDocstringHonesty,
+  parseFieldAssigns,
+  parseDecls,
+} from "../../content/pipeline/qa-checkers-vacuity";
+
+function withLean<T>(src: string, fn: (p: string) => T): T {
+  const dir = mkdtempSync(join(tmpdir(), "qa-vacuity-"));
+  try {
+    const p = join(dir, "Fixture.lean");
+    writeFileSync(p, src);
+    return fn(p);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/** The real defect, as it stood in qou. */
+const MOTIVATING_CASE = `
+namespace QOU.BraidKnot
+
+/-- **Faithful instance.** Carries the explicit research-grade conjecture as a sorry. -/
+instance canonical (R : Type u) [CommRing R] (q : R)
+    [C : CrystalGraphRealization R q] :
+    ConfinementGradingCorrespondence R q where
+  confLevel _ := 0
+  klrTopDegree _ := 0
+  filtrations_agree _ := rfl
+
+end QOU.BraidKnot
+`;
+
+describe("lean-no-vacuous-instance-data", () => {
+  test("fires on the motivating case", () => {
+    const r = withLean(MOTIVATING_CASE, (p) => checkNoVacuousInstanceData(p));
+    expect(r.result).toBe("fail");
+    expect(r.hits.length).toBeGreaterThan(0);
+    expect(r.hits[0].text).toContain("filtrations_agree");
+    expect(r.hits[0].text).toContain("confLevel := 0");
+  });
+
+  test("says so when the vacuous decl is an `instance`, not a `def`", () => {
+    const r = withLean(MOTIVATING_CASE, (p) => checkNoVacuousInstanceData(p));
+    expect(r.hits[0].text).toContain("resolved everywhere");
+  });
+
+  test("still fires on a `def`, but without the resolution warning", () => {
+    const r = withLean(MOTIVATING_CASE.replace("instance canonical", "def canonical"), (p) =>
+      checkNoVacuousInstanceData(p),
+    );
+    expect(r.result).toBe("fail");
+    expect(r.hits[0].text).not.toContain("resolved everywhere");
+  });
+
+  test("does NOT fire on degenerate data alone — a genuine zero object", () => {
+    const src = `
+/-- The zero module is a legitimate object. -/
+instance zeroModel : MyStructure where
+  carrier := 0
+  dim := 0
+`;
+    const r = withLean(src, (p) => checkNoVacuousInstanceData(p));
+    expect(r.result).toBe("pass");
+  });
+
+  test("does NOT fire on a `rfl` discharge alone — real reflexivity", () => {
+    const src = `
+/-- A real instance whose one law happens to be reflexivity. -/
+instance realThing : MyStructure where
+  confLevel T := T.degree + 1
+  klrTopDegree T := T.degree + 1
+  filtrations_agree _ := rfl
+`;
+    const r = withLean(src, (p) => checkNoVacuousInstanceData(p));
+    expect(r.result).toBe("pass");
+  });
+
+  test("does NOT fire on an instance with no claim field at all", () => {
+    const src = `
+instance dataOnly : MyStructure where
+  a := 0
+  b := 0
+`;
+    const r = withLean(src, (p) => checkNoVacuousInstanceData(p));
+    expect(r.result).toBe("pass");
+  });
+
+  test("catches PUnit and default as degenerate data", () => {
+    const src = `
+instance punitModel : MyStructure where
+  cell _ := PUnit.unit
+  weight _ := default
+  cells_agree _ := rfl
+`;
+    const r = withLean(src, (p) => checkNoVacuousInstanceData(p));
+    expect(r.result).toBe("fail");
+  });
+
+  test("catches `by simp` and `trivial` as trivial discharges", () => {
+    for (const discharge of ["by simp", "trivial", "by decide"]) {
+      const src = `
+instance m : S where
+  lhs _ := 0
+  rhs _ := 0
+  lhs_eq_rhs _ := ${discharge}
+`;
+      const r = withLean(src, (p) => checkNoVacuousInstanceData(p));
+      expect(r.result).toBe("fail");
+    }
+  });
+
+  test("n/a when there is no lean file", () => {
+    expect(checkNoVacuousInstanceData(undefined).result).toBe("n/a");
+    expect(checkNoVacuousInstanceData("/nonexistent/X.lean").result).toBe("n/a");
+  });
+});
+
+describe("lean-docstring-honesty", () => {
+  test("fires when the docstring claims a sorry and there is none", () => {
+    const r = withLean(MOTIVATING_CASE, (p) => checkDocstringHonesty(p));
+    expect(r.result).toBe("fail");
+    expect(r.hits[0].text).toContain("canonical");
+  });
+
+  test("does NOT fire when the body really does carry a sorry", () => {
+    const src = `
+/-- Carries the conjecture as a sorry. -/
+theorem open_claim : P = Q := by
+  sorry
+`;
+    const r = withLean(src, (p) => checkDocstringHonesty(p));
+    expect(r.result).toBe("pass");
+  });
+
+  test("does NOT fire when the docstring makes no honesty claim", () => {
+    const src = `
+/-- An ordinary instance. -/
+instance ordinary : S where
+  a := 0
+  b := 0
+  a_eq_b _ := rfl
+`;
+    const r = withLean(src, (p) => checkDocstringHonesty(p));
+    expect(r.result).toBe("pass");
+  });
+
+  test("does NOT fire on a docstring that quotes the lie in order to correct it", () => {
+    // The remedy for this criterion is to rewrite the docstring explaining what
+    // really discharges the term, which means quoting the false claim. Firing
+    // on the fix would punish exactly the change the criterion asks for.
+    const src = `
+/-- The trivial model. Its docstring said "Carries the conjecture as a sorry."
+    That was false: there is no \`sorry\`, it sets both fields to zero. -/
+def canonical : S where
+  a := 0
+  b := 0
+  a_eq_b _ := rfl
+`;
+    const r = withLean(src, (p) => checkDocstringHonesty(p));
+    expect(r.result).toBe("pass");
+  });
+
+  test("a `sorry` mentioned only in a comment does not count as carrying one", () => {
+    const src = `
+/-- Carries the conjecture as a sorry. -/
+theorem fake : P = Q := by
+  -- we could sorry here but we did not
+  rfl
+`;
+    const r = withLean(src, (p) => checkDocstringHonesty(p));
+    expect(r.result).toBe("fail");
+  });
+});
+
+describe("parsers", () => {
+  test("parseFieldAssigns reads name and value, ignoring binders", () => {
+    const f = parseFieldAssigns("  confLevel _ := 0\n  agree _ := rfl\n", 10);
+    expect(f.map((x) => x.name)).toEqual(["confLevel", "agree"]);
+    expect(f.map((x) => x.value)).toEqual(["0", "rfl"]);
+    expect(f[0].line).toBe(10);
+  });
+
+  test("parseFieldAssigns is not fooled by `:` inside a type ascription", () => {
+    const f = parseFieldAssigns("  d : ∀ c, page c →ₗ[R] page c := 0\n", 1);
+    expect(f[0].name).toBe("d");
+    expect(f[0].value).toBe("0");
+  });
+
+  test("parseDecls attaches the preceding docstring", () => {
+    const d = parseDecls("/-- Doc here. -/\ninstance foo : S where\n  a := 0\n");
+    expect(d).toHaveLength(1);
+    expect(d[0].name).toBe("foo");
+    expect(d[0].kind).toBe("instance");
+    expect(d[0].docstring).toContain("Doc here");
+  });
+
+  test("parseDecls handles a multi-line docstring", () => {
+    const d = parseDecls("/-- Line one\n    line two. -/\ndef bar : S where\n  a := 0\n");
+    expect(d[0].docstring).toContain("line two");
+  });
+});

--- a/scripts/tests/qa-checkers-vacuity.test.ts
+++ b/scripts/tests/qa-checkers-vacuity.test.ts
@@ -76,6 +76,36 @@ describe("lean-no-vacuous-instance-data", () => {
     expect(r.hits[0].text).not.toContain("resolved everywhere");
   });
 
+  test("an instance at a CONCRETE carrier is not the severe form", () => {
+    // `instance foo : C SomeObject where …` binds nothing, so resolution
+    // supplies it for that one object. Its degenerate fields are a claim about
+    // that object, not about every carrier. Both survivors of the 2026-08-24
+    // demotion sweep were this shape and both had been cleared by hand.
+    const src = `
+/-- Witness at a specific nucleus. -/
+instance instR5FullWitness_helium3 : R5FullWitness LightNucleus.helium3 where
+  primal_obj := 1
+  dual_obj := 1
+  duality_gap_le := by simp
+`;
+    const r = withLean(src, (p) => checkNoVacuousInstanceData(p));
+    if (r.result === "fail") {
+      expect(r.hits[0].text).not.toContain("resolved everywhere");
+    }
+  });
+
+  test("an instance over a VARIABLE carrier IS the severe form", () => {
+    const src = `
+instance canonical (R : Type u) [CommRing R] (q : R) : S R q where
+  lhs _ := 0
+  rhs _ := 0
+  lhs_eq_rhs _ := rfl
+`;
+    const r = withLean(src, (p) => checkNoVacuousInstanceData(p));
+    expect(r.result).toBe("fail");
+    expect(r.hits[0].text).toContain("resolved everywhere");
+  });
+
   test("does NOT fire on degenerate data alone — a genuine zero object", () => {
     const src = `
 /-- The zero module is a legitimate object. -/

--- a/scripts/tests/qa-checkers-vacuity.test.ts
+++ b/scripts/tests/qa-checkers-vacuity.test.ts
@@ -23,9 +23,11 @@ import { tmpdir } from "os";
 import { join } from "path";
 import {
   checkNoVacuousInstanceData,
+  checkNoDefinitionalLaundering,
   checkDocstringHonesty,
   parseFieldAssigns,
   parseDecls,
+  parseStructureDecls,
 } from "../../content/pipeline/qa-checkers-vacuity";
 
 function withLean<T>(src: string, fn: (p: string) => T): T {
@@ -291,5 +293,490 @@ describe("parsers", () => {
   test("parseDecls handles a multi-line docstring", () => {
     const d = parseDecls("/-- Line one\n    line two. -/\ndef bar : S where\n  a := 0\n");
     expect(d[0].docstring).toContain("line two");
+  });
+
+  test("parseStructureDecls reads a class's fields and their types", () => {
+    const d = parseStructureDecls(SUBSTRATE_WIDTH_RULE);
+    expect(d).toHaveLength(1);
+    expect(d[0].kind).toBe("class");
+    expect(d[0].name).toBe("SubstrateWidthRule");
+    expect(d[0].fields.map((f) => f.name)).toEqual(["w", "is_color"]);
+    expect(d[0].fields[1].type).toBe("∀ A, w A = cableWidthColor");
+  });
+
+  test("parseStructureDecls absorbs a field type that wraps onto later lines", () => {
+    const d = parseStructureDecls(CRYSTAL_R_MATRIX);
+    expect(d[0].fields.map((f) => f.name)).toEqual([
+      "poleIndicator",
+      "pole_indicator_correct",
+    ]);
+    expect(d[0].fields[1].type).toBe("∀ rho : ℤ, poleIndicator rho = decide (rho ≤ -1)");
+  });
+
+  test("parseStructureDecls skips the header binders, which precede `where`", () => {
+    // `class C (R : Type u) [CommRing R] (q : R)` wraps onto a second line and
+    // only then reaches `where`. Reading the binders as fields would invent a
+    // field per binder group.
+    const d = parseStructureDecls(CRYSTAL_R_MATRIX);
+    expect(d[0].fields.map((f) => f.name)).not.toContain("R");
+    expect(d[0].fields.map((f) => f.name)).not.toContain("C");
+  });
+});
+
+/* ------------------------------------------------------------------ *
+ * lean-no-definitional-laundering
+ *
+ * Every fixture below is a real qou declaration, quoted from the state it
+ * was in when the 2026-08-24 hand audit read it (bean `folio-assistant-ilbh`).
+ * Four of the eight have since been repaired, and the repaired form is pinned
+ * NEGATIVELY beside the defect wherever the fix is quotable — a criterion that
+ * still fires after the prescribed remedy is worse than no criterion.
+ * ------------------------------------------------------------------ */
+
+/** `QOU/QBeta/ToroidalHarmonicsBasis.lean` — `: Prop := True`, `let` discarded. */
+const TOROIDAL_ODE = `
+/-- **Opaque stub, not the ODE.** Intended: the toroidal-harmonic ODE. -/
+def ToroidalHarmonicODE (n m : ℝ) (_F : ℝ → ℝ) (η : ℝ) : Prop :=
+  -- _F'' - (n^2 - 1/4 + (m^2 - 1/4)/sinh^2(η)) _F = 0
+  let V := n^2 - (1/4 : ℝ) + (m^2 - (1/4 : ℝ)) / (Real.sinh η)^2
+  -- Scaffolding definition to capture the relation
+  True -- Full differential operator formalism to be bridged to Mathlib
+
+/-- **Opaque stub, not the ODE.** -/
+def WeberODE (A B C : ℝ) (_F : ℝ → ℝ) (u : ℝ) : Prop :=
+  True -- Full differential operator formalism to be bridged to Mathlib
+`;
+
+/** `QOU/Interactions/AlgebraicPrimality.lean` — `: Prop := False`, as it stood. */
+const IN_TENSOR_SPAN_BEFORE = `
+def InTensorSpan (_n : ℕ) (_q : ℝ)
+    (_psi : SDPState _n _q) (_decomp : List ℕ) : Prop := False
+`;
+
+/** The 2026-08-24 repair: seal the body instead of pinning it to `False`. */
+const IN_TENSOR_SPAN_AFTER = `
+opaque InTensorSpan (_n : ℕ) (_q : ℝ)
+    (_psi : SDPState _n _q) (_decomp : List ℕ) : Prop
+`;
+
+/** `QOU/Machinery/KashiwaraCrystalBasic.lean` — a constant behind one lambda. */
+const DEMAZURE_SUBCRYSTAL = `
+/-- **\`B(Λ₁)\` carries a genuine \`DemazureSubcrystal\`** at \`level = 1\`. -/
+instance instSl2DemazureSubcrystal : DemazureSubcrystal standardSl2Crystal 1 where
+  member := fun _ => True
+  highest := false
+  highest_mem := trivial
+  highest_isHighest := fun _ => by simp [standardSl2Crystal]
+  demazure_closure := fun _ _ _ _ _ _ => trivial
+`;
+
+/** `QOU/BraidKnot/CrystalRMatrixSubLemma.lean` — the `poleIndicator` shape. */
+const CRYSTAL_R_MATRIX = `
+class CrystalRMatrixSubLemma (R : Type u) [CommRing R] (q : R)
+    [C : CrystalGraphRealization R q] where
+  /-- Pole-order indicator. -/
+  poleIndicator : ℤ → Bool
+  /-- **The proposition itself.** -/
+  pole_indicator_correct : ∀ rho : ℤ,
+    poleIndicator rho = decide (rho ≤ -1)
+
+/-- **Consistency witness.** \`poleIndicator\` is the indicator, so
+    \`pole_indicator_correct\` holds by \`rfl\` (the indicator IS the witness
+    function) — this instance introduces no \`sorry\`. -/
+instance canonical (R : Type u) [CommRing R] (q : R) :
+    let C := CrystalGraphRealization.canonical R q
+    @CrystalRMatrixSubLemma R _ q C := by
+  intro C
+  exact {
+    poleIndicator := fun rho => decide (rho ≤ -1)
+    pole_indicator_correct := fun _ => rfl
+  }
+`;
+
+/** `QOU/MassTheory/CableWidthBraneTowerLift.lean` — the same shape, `where`-form. */
+const SUBSTRATE_WIDTH_RULE = `
+class SubstrateWidthRule where
+  /-- Per-nucleon cable width as a function of nucleon count \`A\`. -/
+  w : ℕ → ℕ
+  /-- The derived width is the color count \`3\` for every \`A\`. -/
+  is_color : ∀ A, w A = cableWidthColor
+
+/-- The color rule is a genuine instance: \`w ≡ 3\`. -/
+instance colorRule : SubstrateWidthRule where
+  w := fun _ => cableWidthColor
+  is_color := fun _ => rfl
+`;
+
+/** `QOU/Archimedean/BorromeanQuark.lean` — contested by its own docstring. */
+const BORROMEAN_QUARK = `
+class BorromeanQuark where
+  /-- The baryon topological mass functional (depends on q). -/
+  topological_mass : ℝ → ℝ
+  /-- The mass functional evaluates to the volume formula at every q > 1. -/
+  volume_calibrates_mass :
+    ∀ q : ℝ, q > 1 → topological_mass q = borromean_volume / (1 - 1/q)^2
+
+/-- **Faithful instance.**  Defines \`topological_mass\` literally as the
+    topological-volume formula, so \`volume_calibrates_mass\` closes by \`rfl\`.
+    This is genuine content — the mass-calibration identity holds
+    definitionally — not a vacuous discharge. -/
+instance canonical : BorromeanQuark where
+  topological_mass := fun q => borromean_volume / (1 - 1/q)^2
+  volume_calibrates_mass := fun _ _ => rfl
+`;
+
+describe("lean-no-definitional-laundering — argument-ignoring bodies", () => {
+  test("fires on `: Prop := True` behind a discarded `let`", () => {
+    const r = withLean(TOROIDAL_ODE, (p) => checkNoDefinitionalLaundering(p));
+    expect(r.result).toBe("fail");
+    expect(r.hits.map((h) => h.text).join("\n")).toContain("ToroidalHarmonicODE");
+    expect(r.hits.map((h) => h.text).join("\n")).toContain("WeberODE");
+    expect(r.metrics?.constant_prop_defs).toBe(2);
+  });
+
+  test("fires on `: Prop := False` ignoring all four arguments", () => {
+    const r = withLean(IN_TENSOR_SPAN_BEFORE, (p) => checkNoDefinitionalLaundering(p));
+    expect(r.result).toBe("fail");
+    expect(r.hits[0].text).toContain("InTensorSpan");
+    expect(r.hits[0].text).toContain("constant `False`");
+  });
+
+  test("does NOT fire on the `opaque` repair of that same declaration", () => {
+    // Sealing the body is the fix the criterion asks for. Firing on it would
+    // make the criterion unfixable.
+    const r = withLean(IN_TENSOR_SPAN_AFTER, (p) => checkNoDefinitionalLaundering(p));
+    expect(r.result).toBe("pass");
+  });
+
+  test("does NOT fire on a `def` that genuinely computes from its arguments", () => {
+    const src = `
+def jointTraceStrands (A w : ℕ) : ℕ := A * w
+
+def ToroidalWellPosed (n m : ℝ) (F : ℝ → ℝ) (η : ℝ) : Prop :=
+  F η = n ^ 2 - m ^ 2 ∧ η > 0
+`;
+    const r = withLean(src, (p) => checkNoDefinitionalLaundering(p));
+    expect(r.result).toBe("pass");
+  });
+
+  test("does NOT fire on an argument-free `def X : Prop := True`", () => {
+    // `QOU/Infra/DirichletL.lean` `beta3IsLChi4_3` is exactly this, and it is
+    // a real defect — but it is `proof-no-trivial-true`'s `def-disguised-true`
+    // pattern, already in the registry. Reporting it twice adds noise, not
+    // signal. The boundary of THIS criterion is argument-ignoring bodies.
+    const src = `
+/-- Placeholder for the axiomatic class. -/
+def beta3IsLChi4_3 : Prop := True
+`;
+    const r = withLean(src, (p) => checkNoDefinitionalLaundering(p));
+    expect(r.result).toBe("pass");
+  });
+
+  test("counts top-level argument groups, not parentheses", () => {
+    // The arity is quoted back to the reader, so `(f : (ℕ → ℕ))` must read as
+    // one group.
+    const src = `
+def Bogus (f : (ℕ → ℕ)) [Inhabited ℕ] : Prop := True
+`;
+    const r = withLean(src, (p) => checkNoDefinitionalLaundering(p));
+    expect(r.hits[0].text).toContain("takes 2 argument groups");
+  });
+
+  test("does NOT fire when the `let` result is actually returned", () => {
+    const src = `
+def RealODE (n : ℝ) (F : ℝ → ℝ) (η : ℝ) : Prop :=
+  let V := n ^ 2 - (1 / 4 : ℝ)
+  F η = V
+`;
+    const r = withLean(src, (p) => checkNoDefinitionalLaundering(p));
+    expect(r.result).toBe("pass");
+  });
+});
+
+describe("lean-no-definitional-laundering — a constant behind a lambda", () => {
+  test("fires on `member := fun _ => True` beside a reflexivity discharge", () => {
+    const r = withLean(DEMAZURE_SUBCRYSTAL, (p) => checkNoDefinitionalLaundering(p));
+    expect(r.result).toBe("fail");
+    expect(r.hits[0].text).toContain("member := fun _ => True");
+    expect(r.hits[0].text).toContain("highest_mem");
+  });
+
+  test("the sibling criterion misses it — that is why this one exists", () => {
+    // `DEGENERATE_VALUE` is anchored `^…$`, so one `fun _ =>` defeats it.
+    // If this ever starts failing, the two criteria have stopped partitioning
+    // the defect and one of them is now redundant.
+    const r = withLean(DEMAZURE_SUBCRYSTAL, (p) => checkNoVacuousInstanceData(p));
+    expect(r.result).toBe("pass");
+  });
+
+  test("does NOT fire on a constant function with a NAMED binder", () => {
+    // `fun n => 0` may well be the intended function. The wildcard is the
+    // signal: it says the author is not looking at the argument.
+    const src = `
+instance zeroWeight : MyStructure where
+  weight := fun n => 0
+  weight_eq_zero := fun _ => rfl
+`;
+    const r = withLean(src, (p) => checkNoDefinitionalLaundering(p));
+    expect(r.result).toBe("pass");
+  });
+
+  test("does NOT fire when some law needed a real proof", () => {
+    // `verlindeData_two` in `KeystoneVerlindeSMatrixBridge.lean`: a small model
+    // exhibited to show the class is inhabited. `qDim := fun _ => 1` is its
+    // degenerate corner, not a laundering — `D_sq` and `D_ne` are proved.
+    const src = `
+/-- The n = 2 modular category over ℝ. -/
+instance verlindeData_two : VerlindeModularData ℝ where
+  conj_mem := by decide
+  qDim := fun _ => 1
+  D := Real.sqrt 2
+  D_sq := by
+    rw [Real.sq_sqrt (by norm_num : (0:ℝ) ≤ 2)]
+    rw [Finset.sum_pair (by decide : (false : Bool) ≠ true)]; norm_num
+  D_ne := by positivity
+  S0_eq := fun _ _ => rfl
+`;
+    const r = withLean(src, (p) => checkNoDefinitionalLaundering(p));
+    expect(r.result).toBe("pass");
+  });
+
+  test("does NOT fire on a declared inhabitation witness", () => {
+    // `rtData_two` in `KeystoneRTSurgeryConstruction.lean`. Every field is a
+    // one-liner, so no structural signal separates it from a laundering — only
+    // the stated intent does. The registry's own remedy for the sibling
+    // criterion asks authors to write exactly this declaration.
+    const src = `
+/-- **Non-vacuity model — the n = 2 modular category over ℚ.** Confirms
+\`RTSurgeryData\` is inhabited, so \`partitionSum\` is not vacuous. -/
+def rtData_two : RTSurgeryData Bool ℚ where
+  d := fun _ => 1
+  D := 2
+  d_vac := rfl
+  D_ne := by norm_num
+  colInv := fun _ => 1
+`;
+    const r = withLean(src, (p) => checkNoDefinitionalLaundering(p));
+    expect(r.result).toBe("pass");
+  });
+
+  test("does NOT double-report what the sibling criterion already flags", () => {
+    // `HasGeneratorAction_punit` has BOTH a bare degenerate field and a
+    // lambda-wrapped one. One report, from the criterion whose model fits.
+    const src = `
+def HasGeneratorAction_punit : S where
+  sigma_action := fun _ => 0
+  hecke_holds_witness := trivial
+  far_commute_witness := trivial
+`;
+    expect(withLean(src, (p) => checkNoVacuousInstanceData(p)).result).toBe("fail");
+    expect(withLean(src, (p) => checkNoDefinitionalLaundering(p)).result).toBe("pass");
+  });
+});
+
+describe("lean-no-definitional-laundering — data defined to BE the claim", () => {
+  test("fires on the `poleIndicator` shape, fields inside a tactic `exact { … }`", () => {
+    const r = withLean(CRYSTAL_R_MATRIX, (p) => checkNoDefinitionalLaundering(p));
+    expect(r.result).toBe("warn");
+    expect(r.hits).toHaveLength(1);
+    expect(r.hits[0].text).toContain("poleIndicator := fun rho => decide (rho ≤ -1)");
+    expect(r.hits[0].text).toContain("CrystalRMatrixSubLemma.pole_indicator_correct");
+  });
+
+  test("neither sibling check sees the `poleIndicator` shape", () => {
+    expect(withLean(CRYSTAL_R_MATRIX, (p) => checkNoVacuousInstanceData(p)).result).toBe("pass");
+  });
+
+  test("matches up to renaming of the instance's binder", () => {
+    const renamed = CRYSTAL_R_MATRIX.replace(
+      "poleIndicator := fun rho => decide (rho ≤ -1)",
+      "poleIndicator := fun x => decide (x ≤ -1)",
+    );
+    const r = withLean(renamed, (p) => checkNoDefinitionalLaundering(p));
+    expect(r.result).toBe("warn");
+    expect(r.hits).toHaveLength(1);
+  });
+
+  test("the binder rename does not collide with a numeral in the body", () => {
+    // The rename routes each binder through a placeholder. A printable one
+    // collides: sending `y → n` via `" 0 "` rewrites `g 0 y` to `g n n` and
+    // manufactures a match. Pinned because the failure mode is a false
+    // POSITIVE that looks exactly like a true one.
+    const src = `
+class Shifted where
+  f : ℕ → ℕ
+  shift : ∀ n, f n = g 0 n
+
+instance shiftedCanonical : Shifted where
+  f := fun y => g 0 y
+  shift := fun _ => rfl
+`;
+    const r = withLean(src, (p) => checkNoDefinitionalLaundering(p));
+    expect(r.result).toBe("warn");
+    expect(r.hits[0].text).toContain("`f n = g 0 n`");
+  });
+
+  test("does NOT fire when only a numeral, not the binder, lines up", () => {
+    const src = `
+class Shifted where
+  f : ℕ → ℕ
+  shift : ∀ n, f n = g 0 n
+
+instance shiftedOther : Shifted where
+  f := fun y => g 1 y
+  shift := fun _ => rfl
+`;
+    const r = withLean(src, (p) => checkNoDefinitionalLaundering(p));
+    expect(r.result).toBe("pass");
+  });
+
+  test("does NOT fire once the data is a class PARAMETER rather than a field", () => {
+    // The 2026-08-24 repair (bean `qou-2y13`): take the width as a parameter so
+    // the class can no longer choose its own datum. The instance still closes
+    // by `rfl` and must no longer be reported — the class now has models it
+    // fails on.
+    const src = `
+class SubstrateWidthRule (w : ℕ → ℕ) : Prop where
+  /-- The width is the colour count \`3\` for every nucleon count \`A\`. -/
+  is_color : ∀ A, w A = cableWidthColor
+
+instance colorRule : SubstrateWidthRule (fun _ => cableWidthColor) where
+  is_color := fun _ => rfl
+`;
+    const r = withLean(src, (p) => checkNoDefinitionalLaundering(p));
+    expect(r.result).toBe("pass");
+  });
+
+  test("fires on the pre-repair form of that same class", () => {
+    const r = withLean(SUBSTRATE_WIDTH_RULE, (p) => checkNoDefinitionalLaundering(p));
+    expect(r.result).toBe("warn");
+    expect(r.hits[0].text).toContain("w := fun _ => cableWidthColor");
+  });
+
+  test("fires on a point-free field pinned to a named constant", () => {
+    // `ArchimedeanRealizationFunctor.q0 := q_zero` with `q0_canonical : q0 =
+    // q_zero`. No lambda, no arguments, and `q0_canonical` matches no
+    // claim-name heuristic — the CLASS is what identifies the claim here.
+    const src = `
+class ArchimedeanRealizationFunctor where
+  /-- The substrate value \`q₀\` at which evaluation occurs. -/
+  q0 : ℝ
+  /-- \`q₀ > 1\`. -/
+  q0_gt_one : q0 > 1
+  /-- The substrate \`q₀\` matches the QOU canonical value. -/
+  q0_canonical : q0 = q_zero
+
+/-- Canonical instance: pin \`q₀\` to the QOU substrate value. -/
+noncomputable instance canonical : ArchimedeanRealizationFunctor where
+  q0 := q_zero
+  q0_gt_one := q_zero_gt_one
+  q0_canonical := rfl
+`;
+    const r = withLean(src, (p) => checkNoDefinitionalLaundering(p));
+    expect(r.result).toBe("warn");
+    expect(r.hits[0].text).toContain("q0 := q_zero");
+  });
+
+  test("reports the contested case at lower severity and says the author disputes it", () => {
+    const r = withLean(BORROMEAN_QUARK, (p) => checkNoDefinitionalLaundering(p));
+    // `warn`, not `fail` — the schema's "borderline; flags but does not block".
+    expect(r.result).toBe("warn");
+    expect(r.hits[0].text).toContain("REVIEW (not a verdict)");
+    expect(r.hits[0].text).toContain("docstring disputes this reading");
+  });
+
+  test("does NOT fire when the instance's data differs from the claim's RHS", () => {
+    const src = `
+class BorromeanQuark where
+  topological_mass : ℝ → ℝ
+  volume_calibrates_mass :
+    ∀ q : ℝ, q > 1 → topological_mass q = borromean_volume / (1 - 1/q)^2
+
+instance canonical : BorromeanQuark where
+  topological_mass := fun q => knotVolume q
+  volume_calibrates_mass := fun q hq => by
+    rw [knotVolume_eq_borromean q hq]
+`;
+    const r = withLean(src, (p) => checkNoDefinitionalLaundering(p));
+    expect(r.result).toBe("pass");
+  });
+
+  test("does NOT read an `=` inside a hypothesis as the field's conclusion", () => {
+    // `demazure_closure : ∀ i, i < level → ∀ v w, member v → G.f i v = some w
+    // → member w` contains an `=`. Matching it would invent an RHS the author
+    // never wrote and compare the instance against a fiction.
+    const src = `
+class DemazureSubcrystal (G : CrystalGraph) (level : ℕ) where
+  member : G.V → Prop
+  demazure_closure :
+    ∀ (i : ℕ), i < level → ∀ (v w : G.V),
+      member v → G.f i v = some w → member w
+
+instance realSubcrystal : DemazureSubcrystal standardSl2Crystal 1 where
+  member := fun v => v.weight ≤ 1
+  demazure_closure := fun _ _ _ _ h _ => le_trans h (by norm_num)
+`;
+    const r = withLean(src, (p) => checkNoDefinitionalLaundering(p));
+    expect(r.result).toBe("pass");
+  });
+
+  test("does NOT fire on a `theorem` that exhibits a record to prove an `∃`", () => {
+    // `markov_trace_product`. Building a witness IS how one proves an
+    // existential; theorem-shaped vacuity belongs to `proof-no-trivial-true`.
+    const src = `
+theorem markov_trace_product (z : R_q) (n : ℕ) (q : R_q) :
+    ∃ (mtp : MarkovTraceProduct), mtp.traceValue = Finset.univ.prod f :=
+  ⟨{
+    traceValue := Finset.univ.prod f
+    factorization := rfl
+  }, rfl⟩
+`;
+    const r = withLean(src, (p) => checkNoDefinitionalLaundering(p));
+    expect(r.result).toBe("pass");
+  });
+
+  test("does NOT fire when the class is not declared in this file", () => {
+    // Detection 3 needs the `class … where` block. Guessing across an import
+    // would produce a confident report about a declaration never read.
+    const src = `
+instance canonical : SomeImportedClass where
+  topological_mass := fun q => borromean_volume / (1 - 1/q)^2
+  volume_calibrates_mass := fun _ _ => rfl
+`;
+    const r = withLean(src, (p) => checkNoDefinitionalLaundering(p));
+    expect(r.result).toBe("pass");
+  });
+});
+
+describe("lean-no-definitional-laundering — grading and plumbing", () => {
+  test("a hard finding grades `fail`; a definitional identity alone grades `warn`", () => {
+    expect(withLean(TOROIDAL_ODE, (p) => checkNoDefinitionalLaundering(p)).result).toBe("fail");
+    expect(withLean(BORROMEAN_QUARK, (p) => checkNoDefinitionalLaundering(p)).result).toBe("warn");
+  });
+
+  test("counts each detection separately in `metrics`", () => {
+    const r = withLean(BORROMEAN_QUARK, (p) => checkNoDefinitionalLaundering(p));
+    expect(r.metrics).toEqual({
+      constant_prop_defs: 0,
+      lambda_constant_fields: 0,
+      definitional_identities: 1,
+    });
+  });
+
+  test("a clean file passes", () => {
+    const src = `
+/-- An honest instance. -/
+instance realThing : MyStructure where
+  confLevel T := T.degree + 1
+  klrTopDegree T := T.degree + 1
+  filtrations_agree _ := rfl
+`;
+    const r = withLean(src, (p) => checkNoDefinitionalLaundering(p));
+    expect(r.result).toBe("pass");
+  });
+
+  test("n/a when there is no lean file", () => {
+    expect(checkNoDefinitionalLaundering(undefined).result).toBe("n/a");
+    expect(checkNoDefinitionalLaundering("/nonexistent/X.lean").result).toBe("n/a");
   });
 });

--- a/scripts/tests/qa-checkers-vacuity.test.ts
+++ b/scripts/tests/qa-checkers-vacuity.test.ts
@@ -184,6 +184,46 @@ def canonical : S where
     expect(r.result).toBe("pass");
   });
 
+  test("does NOT fire on `sorry-free` — a false positive found in the corpus", () => {
+    // QOU/SchurWeyl/QJucysMurphy.lean `barSymJMSum_central` and
+    // QOU/AlgebraicSubstrate/qou_obstruction_reduction.lean
+    // `kappa_vanishes_iff_chi` both say "sorry-free" and were both flagged.
+    const src = `
+/-- Both are sorry-free; the fields carry the domain gap as explicit
+    hypotheses rather than as a \`sorry\`. -/
+theorem kappa_vanishes_iff_chi : P ↔ Q := by
+  exact h
+`;
+    const r = withLean(src, (p) => checkDocstringHonesty(p));
+    expect(r.result).toBe("pass");
+  });
+
+  test("does NOT fire on a PAST-TENSE sorry that has since been removed", () => {
+    // Recording the history is the docstring doing its job; reading it as a
+    // present claim flags the note precisely because it is thorough.
+    const src = `
+/-- A hypothesis-free version of this statement was carried here as a
+    \`sorry\` until 2026-08-17 (bean \`qou-gjg6\`); it is not provable by this
+    route, and it was deleted rather than left standing as proof debt. -/
+theorem barSymJMSum_central : P := by
+  exact h
+`;
+    const r = withLean(src, (p) => checkDocstringHonesty(p));
+    expect(r.result).toBe("pass");
+  });
+
+  test("STILL fires on a present-tense claim with no sorry — the guard is not a hole", () => {
+    const src = `
+/-- **Faithful instance.** Carries the explicit research-grade conjecture as a sorry. -/
+def canonical : S where
+  a := 0
+  b := 0
+  a_eq_b _ := rfl
+`;
+    const r = withLean(src, (p) => checkDocstringHonesty(p));
+    expect(r.result).toBe("fail");
+  });
+
   test("a `sorry` mentioned only in a comment does not count as carrying one", () => {
     const src = `
 /-- Carries the conjecture as a sorry. -/

--- a/scripts/tests/qa-checkers-vacuity.test.ts
+++ b/scripts/tests/qa-checkers-vacuity.test.ts
@@ -78,6 +78,56 @@ describe("lean-no-vacuous-instance-data", () => {
     expect(r.hits[0].text).not.toContain("resolved everywhere");
   });
 
+  test("does NOT fire when a data field reads its own binder", () => {
+    // `sl3DemazureLevelOne`, quoted from `QOU/Machinery/KashiwaraCrystalBasic
+    // .lean`. This is the declaration written *specifically* to give
+    // `demazure_closure` teeth — a proper sub-crystal `{0,1}` of a three-vertex
+    // crystal, whose closure is checked by exhaustion — and it fired on
+    // `highest := 0` (a vertex index, matching `DEGENERATE_VALUE`) beside
+    // `highest_mem := by decide` (matching `TRIVIAL_DISCHARGE`). Firing on the
+    // fix is the worst failure mode this criterion has.
+    const src = `
+def sl3DemazureLevelOne : DemazureSubcrystal standardSl3Crystal 1 where
+  member := fun v => v ≠ 2
+  highest := 0
+  highest_mem := by decide
+  highest_isHighest := fun i => by
+    simp only [standardSl3Crystal]
+    split <;> simp_all
+  demazure_closure := by
+    intro i hi v w hv hf
+    decide
+`;
+    const r = withLean(src, (p) => checkNoVacuousInstanceData(p));
+    expect(r.result).toBe("pass");
+  });
+
+  test("a WILDCARD binder is not argument-dependence", () => {
+    // Mutation of the pin above: `fun v => v ≠ 2` is the only thing separating
+    // it from a laundering. Discard the argument and the veto must not apply,
+    // or `mul _ _ := PUnit.unit` would clear every trivial instance in the
+    // corpus.
+    const src = `
+def sl3Bogus : DemazureSubcrystal standardSl3Crystal 1 where
+  member := fun _ => True
+  highest := 0
+  highest_mem := by decide
+`;
+    const r = withLean(src, (p) => checkNoVacuousInstanceData(p));
+    expect(r.result).toBe("fail");
+  });
+
+  test("point-full binders count too — `f x := g x`, not just lambdas", () => {
+    const src = `
+def pointFull : MyStructure where
+  weight n := n + 1
+  base := 0
+  base_eq := rfl
+`;
+    const r = withLean(src, (p) => checkNoVacuousInstanceData(p));
+    expect(r.result).toBe("pass");
+  });
+
   test("an instance at a CONCRETE carrier is not the severe form", () => {
     // `instance foo : C SomeObject where …` binds nothing, so resolution
     // supplies it for that one object. Its degenerate fields are a claim about
@@ -494,11 +544,32 @@ def RealODE (n : ℝ) (F : ℝ → ℝ) (η : ℝ) : Prop :=
 });
 
 describe("lean-no-definitional-laundering — a constant behind a lambda", () => {
-  test("fires on `member := fun _ => True` beside a reflexivity discharge", () => {
+  test("reports `member := fun _ => True` beside a reflexivity discharge", () => {
     const r = withLean(DEMAZURE_SUBCRYSTAL, (p) => checkNoDefinitionalLaundering(p));
-    expect(r.result).toBe("fail");
     expect(r.hits[0].text).toContain("member := fun _ => True");
     expect(r.hits[0].text).toContain("highest_mem");
+  });
+
+  test("grades detection 2 `warn`, not `fail` — the constant may be correct", () => {
+    // This exact declaration is the reason. `sl₂` has one simple root, so
+    // `B(Λ₁)` has two Demazure sub-crystals and the level-1 one is the whole
+    // two-vertex crystal: `fun _ => True` is the value the mathematics forces.
+    // The finding is still real — the claim fields carry no force, and the
+    // corpus docstring now says so — but there is no edit that clears it, and
+    // a critical `fail` no correct content can satisfy gets switched off.
+    const r = withLean(DEMAZURE_SUBCRYSTAL, (p) => checkNoDefinitionalLaundering(p));
+    expect(r.result).toBe("warn");
+    expect(r.hits[0].text).toContain("REVIEW (not a verdict)");
+  });
+
+  test("detection 1 is still a verdict — a tautology is wrong either way", () => {
+    // The grade split: `def F args : Prop := True` admits no reading that
+    // rescues it, so it stays `fail` where detections 2 and 3 are `warn`.
+    const src = `
+def Bogus (n : ℕ) : Prop := True
+`;
+    const r = withLean(src, (p) => checkNoDefinitionalLaundering(p));
+    expect(r.result).toBe("fail");
   });
 
   test("the sibling criterion misses it — that is why this one exists", () => {

--- a/scripts/tests/qa-criterion-hash.test.ts
+++ b/scripts/tests/qa-criterion-hash.test.ts
@@ -1,11 +1,31 @@
 import { describe, expect, test, beforeEach } from "bun:test";
-import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { mkdtempSync, writeFileSync, rmSync, existsSync } from "fs";
 import { tmpdir } from "os";
-import { join } from "path";
+import { join, resolve } from "path";
 import {
   criterionSourceHash,
   _resetCriterionHashCache,
 } from "../../content/pipeline/qa-criterion-hash";
+
+/**
+ * The PLATFORM checkout — this file's own location, NOT `process.cwd()`.
+ *
+ * The real-module guard at the bottom of this file used to build its path with
+ * `join(process.cwd(), ...)`, and `run-tests.sh` does `cd "$SCRIPT_DIR"` before
+ * `bun test`. So under the canonical runner the guard looked for the checker at
+ * `scripts/tests/content/pipeline/qa-checkers-voice.ts`, `parseFile` hit ENOENT
+ * and returned null, and the assertion failed on a null that had nothing to do
+ * with how checkers are written — the one thing the guard exists to watch. It
+ * resolved only when the suite happened to be invoked from the repo root.
+ *
+ * Same anchor as `helpers.ts`'s `REPO_ROOT`, and the right one for a PLATFORM
+ * file even when a folio embeds this repo as a `folio-assistant/` symlink:
+ * `import.meta.dir` resolves back through the symlink to the real platform
+ * path. (Anchoring CONTENT paths here would be the opposite mistake — see the
+ * `FOLIO_ROOT` note in `helpers.ts`.)
+ */
+const PLATFORM = resolve(import.meta.dir, "..", "..");
+const VOICE_CHECKERS = join(PLATFORM, "content/pipeline/qa-checkers-voice.ts");
 
 // Each case writes a throwaway checker module. Hashes are memoized by absolute
 // path, so every fixture gets a fresh temp dir as well as a cache reset.
@@ -110,13 +130,24 @@ describe("criterionSourceHash", () => {
 
   test("resolves criteria in the real voice checker module", () => {
     // Guards the fixture shape against drifting from how checkers are really
-    // written (an exported `*_AUTOMATED_CHECKERS` record of arrow dispatchers).
-    const real = join(
-      process.cwd(),
-      "content/pipeline/qa-checkers-voice.ts",
+    // written (an exported record of arrow dispatchers). What the record is
+    // NAMED is not part of that: `findCriterionEntry` matches the property key
+    // inside any object literal in the module, so the real export being a bare
+    // `AUTOMATED_CHECKERS` rather than the `*_AUTOMATED_CHECKERS` the module
+    // docstring describes makes no difference, and neither do the six
+    // `...*_AUTOMATED_CHECKERS` spreads that close it — the entry that gets
+    // hashed is one property assignment, not the record.
+    //
+    // Assert the file is THERE first. Every way of getting the path wrong —
+    // wrong anchor, a moved or renamed checker — otherwise surfaces as a bare
+    // `null` from the ENOENT path inside `parseFile`, which reads exactly like
+    // the shape drift this test is supposed to detect.
+    expect(existsSync(VOICE_CHECKERS)).toBe(true);
+    const scholarly = criterionSourceHash(
+      VOICE_CHECKERS,
+      "voice-scholarly-default",
     );
-    const scholarly = criterionSourceHash(real, "voice-scholarly-default");
-    const wall = criterionSourceHash(real, "wall-side-correct");
+    const wall = criterionSourceHash(VOICE_CHECKERS, "wall-side-correct");
     expect(scholarly).toBeTruthy();
     expect(wall).toBeTruthy();
     expect(scholarly).not.toBe(wall);

--- a/scripts/tests/validate-orphan-sidecar.test.ts
+++ b/scripts/tests/validate-orphan-sidecar.test.ts
@@ -61,6 +61,49 @@ describe("no-orphan-sidecar", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
+  test("does not flag a paper-level audit artefact that shares the extension", async () => {
+    // `qa-section-title-audit.ts` writes `content/<paper>/section-title-audit.qa.json`,
+    // keyed by paper and chapter rather than by block. It has no `.ts` by
+    // design, and four live in the qou corpus. Bean `qou-efzm` had them
+    // recorded as orphans left behind by a deleted block; the file shape says
+    // they were never blocks. Deleting them would destroy live audit state the
+    // producing tool would rewrite.
+    const dir = chapter(["alpha"]);
+    writeFileSync(
+      join(dir, "section-title-audit.qa.json"),
+      JSON.stringify({ criterion: "voice-section-title-coherence", paper: "p", chapters: {} }),
+    );
+    const { issues } = await validateObjects(dir);
+    expect(orphanIssues(issues).length).toBe(0);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("still flags a genuine orphan sitting beside a paper-level artefact", async () => {
+    // The discriminator must not become a blanket exemption for the directory.
+    const dir = chapter(["alpha"], ["ghost"]);
+    writeFileSync(
+      join(dir, "section-title-audit.qa.json"),
+      JSON.stringify({ criterion: "voice-section-title-coherence", paper: "p", chapters: {} }),
+    );
+    const { issues } = await validateObjects(dir);
+    const found = orphanIssues(issues);
+    expect(found.length).toBe(1);
+    expect(found[0].message).toContain("ghost.qa.json");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("flags an unparseable sidecar rather than excusing it", async () => {
+    // Treating unreadable as "not a block sidecar" would let a real orphan
+    // hide behind a truncated write, so the helper fails toward reporting.
+    const dir = chapter(["alpha"]);
+    writeFileSync(join(dir, "corrupt.qa.json"), "{ this is not json");
+    const { issues } = await validateObjects(dir);
+    const found = orphanIssues(issues);
+    expect(found.length).toBe(1);
+    expect(found[0].message).toContain("corrupt.qa.json");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
   test("is an error, not a warning", async () => {
     // An audit report for a block that does not exist is not a style nit — it
     // can never be refreshed and it corrupts corpus counts.

--- a/skills/folio-paper-adapter/lean-proof-vacuity-audit.md
+++ b/skills/folio-paper-adapter/lean-proof-vacuity-audit.md
@@ -243,8 +243,31 @@ Parameterising alone is not enough: it stops the class choosing its own shadow,
 but a consumer can still instantiate at the zero datum. The pair is what closes
 that.
 
-Detected mechanically by `lean-no-vacuous-instance-data` (see below), which
-looks for the conjunction of degenerate data and a reflexivity discharge.
+Detected mechanically by **two** criteria in `content/pipeline/qa-checkers-vacuity.ts`,
+which partition the defect rather than overlap — a decl the first flags is
+skipped by the second:
+
+- `lean-no-vacuous-instance-data` — degenerate data *written as a constant*
+  (`_ := 0`, `PUnit.unit`, `default`) plus a reflexivity discharge.
+- `lean-no-definitional-laundering` — data that is **not** constant and is still
+  chosen so the claim becomes `rfl`. Three shapes: an argument-ignoring body
+  (`def F (args…) : Prop := True`), a constant one lambda deep
+  (`member := fun _ => True`), and a field defined to BE the right-hand side its
+  class field compares against (`w := fun _ => cableWidthColor` under
+  `is_color : ∀ A, w A = cableWidthColor`).
+
+The two lists were measured **disjoint** on the qou corpus on 2026-08-24: a hand
+read found eight laundering sites, the constant detector found twenty-five, and
+no site appeared in both. If you are auditing for vacuity, running only one of
+them is running half the check.
+
+The third shape grades `warn`, not `fail`, and says "REVIEW (not a verdict)" in
+its own evidence. Pinning a field to a formula and observing the law then holds
+by `rfl` is a legitimate way to exhibit a model; whether the class field was a
+*constraint* the instance had to meet or a *definition* it was entitled to make
+is a question about what the class was for, and no regex answers it. Answer it
+and record the answer — do not treat the hit as a defect, and do not dismiss it
+because the docstring already argues it is fine.
 
 ## Detection heuristic (candidate grep → agent confirmation)
 

--- a/skills/folio-paper-adapter/lean-proof-vacuity-audit.md
+++ b/skills/folio-paper-adapter/lean-proof-vacuity-audit.md
@@ -202,6 +202,50 @@ proof:
 **Never** the batch anti-fix: wrapping the conclusion in a structure field and
 projecting it. That converts a *visible* gap (`sorry`) into an *invisible* one.
 
+### Demonstrating non-degeneracy — the theorem-pair pattern
+
+Step 2 requires the conditional class to be "non-degenerate", and that is where
+most of these go wrong: a class is written, a `canonical` instance sets its data
+to zero so the propositional field becomes `rfl`, and the class asserts nothing
+for anyone. Demoting `instance` → `def` stops typeclass resolution supplying it
+silently, but it does not *say* what the hypothesis is worth.
+
+**Parameterise the class over the data, then state the residual vacuity as a
+proved pair.** Worked example in
+[`QOU/Archimedean/JetOrderIndependence.lean`](../../..) — read it before
+inventing your own:
+
+```lean
+/-- The identically-zero transport error. -/
+def trivialError : TransportErrorData where
+  shadow := fun _ => 0
+  physical := fun _ => 0
+  ...
+
+/-- **The bound is vacuous at the zero error (PROVED).** So an instance for an
+    *unspecified* `E` asserts nothing: it is satisfiable. -/
+instance trivialError_bound : SurrealParallelTransportBound trivialError where ...
+
+/-- **…and non-vacuous at any error with a non-zero physical shadow (PROVED).**
+    For a specific `E` the bound is a real constraint that can fail. -/
+theorem not_bound_of_physical_ne_zero (h : E.physical N ≠ 0) :
+    ¬ Nonempty (SurrealParallelTransportBound E) := ...
+```
+
+Read together the two say exactly what an instance buys: **the hypothesis
+carries no information until the datum is pinned down, and real information as
+soon as it is.** The trap becomes a machine-checked fact instead of a latent
+one — which is strictly better than forbidding the trivial model, because a
+non-degeneracy field on the class would prevent the trivial model *and*
+prevent saying anything about it.
+
+Parameterising alone is not enough: it stops the class choosing its own shadow,
+but a consumer can still instantiate at the zero datum. The pair is what closes
+that.
+
+Detected mechanically by `lean-no-vacuous-instance-data` (see below), which
+looks for the conjunction of degenerate data and a reflexivity discharge.
+
 ## Detection heuristic (candidate grep → agent confirmation)
 
 0. **Runnable scanner (preferred).** `bun run


### PR DESCRIPTION
Four QA criteria for a single failure mode: **a check that reports success without having looked.** Purely additive — a new `content/pipeline/qa-checkers-vacuity.ts`, additions to `qa-checkers-python.ts`, and registry + sweep wiring.

`1276 pass / 0 fail` (1319 across 97 files, 43 skip), `eslint` clean, rebased onto `main` and currently `0` behind.

## The criteria

| criterion | catches | grade |
|---|---|---|
| `lean-no-vacuous-instance-data` | degenerate data **and** a reflexivity discharge in the same declaration | `fail` |
| `lean-no-definitional-laundering` | the same defect one `fun _ =>` deeper, plus data defined to *be* the claim's RHS | `fail` / `warn` |
| `lean-docstring-honesty` | a docstring asserting more than the declaration does | — |
| `assertions_are_falsifiable` | `add_assertion` passing the same expression as `computed` and `expected` | `fail` |

## Calibration, because a checker's hit count is a claim too

Every one of these was measured against the `qou` corpus and tightened against real false positives rather than shipped on its first sweep.

- **`lean-no-definitional-laundering`** first returned 26 hits; 17 were removed by five documented vetoes (a discharge lambda naming its argument is a proof, not a reflexivity; substantive tactic work anywhere in the declaration; a declared inhabitation witness is the *prescribed remedy*, not the defect).
- **`lean-no-vacuous-instance-data`** fired on `sl3DemazureLevelOne` — the declaration written *specifically* to give `DemazureSubcrystal.demazure_closure` teeth. `highest := 0` is a vertex index, not a degenerate value. Firing on the fix is this criterion's worst failure mode, so it now vetoes on argument-dependence. Removes exactly one hit corpus-wide.
  - The obvious repair (reuse the sibling's `doesRealWork` veto) was **tried and measured wrong**: 26 hits → 6, dropping true positives like `triv_hecke` on `by infer_instance`. Recorded so nobody retries it.
- **`assertions_are_falsifiable`** is regex, not AST, matching this module's no-Python-runtime contract: **98% precision, 75% recall** against an AST census over 3,254 files. It under-reports by design — a missed tautology stays a backlog item, a false one costs an author an argument with the checker. Its one false positive (`witness.py`'s own docstring illustrating the API with `computed=2.0298, expected=2.0298`) is fixed by blanking triple-quoted blocks only; blanking *all* strings would trade it for a batch of missed real ones. Both directions pinned as tests.

## Grades are deliberate

Only unambiguous defects grade `fail`. `def F args : Prop := True` is a tautology whatever the author meant. But "data is constant" does **not** establish laundering — the constant may be forced: `instSl2DemazureSubcrystal`'s `member := fun _ => True` is correct, because `sl₂` has one simple root and the level-1 Demazure sub-crystal of `B(Λ₁)` *is* the whole two-vertex crystal. That case has no edit that clears it, and a `critical` red no correct content can satisfy gets switched off rather than obeyed. So detections 2 and 3 grade `warn` and open `REVIEW (not a verdict)`.

## Impact on the corpus

Applied to `qou`, this axis found **10 blocks claiming `computation.status: "verified"` on assertions that could not fail** — all since drained — and an AST census put the corpus-wide figure at 266 of 3,482 `add_assertion` calls. The remaining backlog is now machine-visible at the gate rather than needing a census.

## Notes for review

- `scripts/pypdf_safe.py` is redundant with `main`'s `_pypdf_compat.py` — same defect (a broken `cryptography` raises pyo3's `PanicException`, a `BaseException` escaping `except ImportError`), independently found, `main`'s naming kept at the call sites. Mine is still tested and passing; removing it is cleanup, not a fix, and is left out of this PR deliberately.
- The PDF-intake commit resolved to near-empty against `main`'s newer `document` content type, which supersedes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUnKeZE2YcdjGmTEcKA2Ng

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUnKeZE2YcdjGmTEcKA2Ng)_