### PR TITLE
Brief a bean before you start it, not after

### DIFF
--- a/.claude/skills/local/todo-manager.md
+++ b/.claude/skills/local/todo-manager.md
@@ -56,10 +56,95 @@ sessions don't pick the same item; never resolve or delete a sibling's bean. See
   workflow (the `todo-review` skill over `feedback/<paper>/*.ts`), not the agent
   work-plan. Don't conflate the two.
 
+## Opening brief
+
+**Claiming a bean records the work. Briefing it is what makes the work
+resumable.** Both are required, and the brief comes first — before the first
+tool call, in the chat, not in the commit.
+
+AGENTS.md §"Opening a bean or a topic" states the rule and when it applies.
+This is the shape.
+
+### The four parts
+
+**1. The problem, stated for someone who was not here.** Expand every
+identifier on first use. Not "fixing `qou-93hu`" but "bean `qou-93hu` — the
+`CriticalExponent` conjecture carrier, whose only field is `(3 * 4 : ℕ) = 12`, a
+closed numeral identity with no exponent variable in it, so the class constrains
+nothing."
+
+**2. What you know, and how you know it.** Every number with its provenance:
+
+| provenance | how to say it |
+|---|---|
+| measured this session | "measured just now: 22 of 22 seeded, 0 missed" |
+| carried from a prior session | "recorded 2026-08-24 as 43 drifted; not re-measured" |
+| asserted by a bean or a doc | "bean `qou-q7lf` says X — **unverified**" |
+
+That third row is the one that bites. A sibling's bean is not a primary source,
+and neither is a source file's `## Status` note; both go stale, and a specific,
+recent, confidently-worded bean is exactly the kind that gets believed.
+
+**3. The route and the gate.** How you plan to do it, what you will verify
+against, and **what would falsify the approach**. A plan with no failure mode is
+not a plan; it is an intention. If the gate is a script, name it and its
+expected output.
+
+**4. What you are NOT doing.** The adjacent defect you are leaving, the scope
+you decline to widen into, the thing you will flag rather than fix. Stating it
+up front is what stops it becoming either silent scope creep or a silent
+omission.
+
+### Worked example
+
+> **Starting `qou-93hu`** — the `CriticalExponent` §3b-cond hypothesis class in
+> `lean/QOU/AlgebraicSubstrate/ConditionalClasses.lean`.
+>
+> **The problem.** Its single field is `alpha_three_eq_four : (3 * 4 : ℕ) = 12`
+> — a closed numeral identity with the values already substituted in, so no
+> exponent variable occurs in it and `rfl` proves it whatever the physics. Four
+> sibling carriers in the same file are vacuous too, but they are at least the
+> right *shape* (parameter-quantified inequalities); this one has no quantifier
+> and no free variable at all.
+>
+> **What I know.** Measured this session: the carrier is bound as `[C]` in 5
+> files; the probe baseline records it `proved-vacuous`; the class's own
+> docstring already claims "α = 4/3", so the target value is not something I
+> need to invent. Not measured: whether any downstream proof depends on the
+> field's *current* type.
+>
+> **Route.** Make α a class parameter — `class CriticalExponent (α : ℝ) : Prop
+> where alpha_eq : α = 4/3`. A `Prop` class cannot carry data, so α must be a
+> parameter, not a field. Gate: lean-direct exit 0 on all three affected
+> modules, plus a content probe proving `¬ CriticalExponent 2` — because
+> inhabitability at 4/3 alone would not show the class constrains anything.
+> **Falsifier:** if `¬ CriticalExponent 2` will not go through, the encoding is
+> not doing what I claim and I stop.
+>
+> **Not doing.** The other four carriers need analytic setup their docstrings
+> only gesture at — that is the author's mathematics, not a cleanup. Also
+> leaving the separate `CriticalExponent` in `core-levi-form.lean`, which is a
+> different carrier in a different namespace.
+
+That brief is ~200 words and would have let a reader stop the work, redirect it,
+or pick it up cold. Note the last line especially: the scope call is visible
+*before* the diff, which is where it can still be argued with.
+
+### The failure this prevents
+
+An agent that has spent an hour inside a problem writes in the private
+vocabulary it built along the way, and a reader — the author, or the next agent
+— has to reconstruct that vocabulary before they can evaluate anything. The
+brief is written at the one moment when the agent still knows which parts are
+non-obvious, because it has just finished finding them out.
+
 ## Coordination discipline
 
 1. **Claim before you work.** Mark the bean `in-progress` so sibling sessions
    working the same goal do not duplicate the effort.
+1a. **Brief it in the same turn you claim it** (§"Opening brief" above). The
+   claim tells a sibling the item is taken; the brief tells them, and the
+   author, what it is being taken *for*.
 2. **One source of truth per concern.** Do not fork a bean into a parallel
    `todos/*.json` queue; link to the queue from the bean instead.
 3. **Move wiring and script together.** When relocating a hook-backed script,

--- a/.claude/skills/local/todo-manager.md
+++ b/.claude/skills/local/todo-manager.md
@@ -93,7 +93,8 @@ expected output.
 **4. What you are NOT doing.** The adjacent defect you are leaving, the scope
 you decline to widen into, the thing you will flag rather than fix. Stating it
 up front is what stops it becoming either silent scope creep or a silent
-omission.
+omission — and it puts the scope call where it can still be argued with, which
+is before the diff.
 
 ### Worked example
 
@@ -107,11 +108,10 @@ omission.
 > right *shape* (parameter-quantified inequalities); this one has no quantifier
 > and no free variable at all.
 >
-> **What I know.** Measured this session: the carrier is bound as `[C]` in 5
-> files; the probe baseline records it `proved-vacuous`; the class's own
-> docstring already claims "α = 4/3", so the target value is not something I
-> need to invent. Not measured: whether any downstream proof depends on the
-> field's *current* type.
+> **What I know.** Measured this session: bound as `[C]` in 5 files; the probe
+> baseline records it `proved-vacuous`; the class's own docstring already claims
+> "α = 4/3", so the target value is not something I need to invent. Not
+> measured: whether any downstream proof depends on the field's *current* type.
 >
 > **Route.** Make α a class parameter — `class CriticalExponent (α : ℝ) : Prop
 > where alpha_eq : α = 4/3`. A `Prop` class cannot carry data, so α must be a
@@ -122,27 +122,30 @@ omission.
 > not doing what I claim and I stop.
 >
 > **Not doing.** The other four carriers need analytic setup their docstrings
-> only gesture at — that is the author's mathematics, not a cleanup. Also
-> leaving the separate `CriticalExponent` in `core-levi-form.lean`, which is a
-> different carrier in a different namespace.
+> only gesture at — the author's mathematics, not a cleanup. Also leaving the
+> separate `CriticalExponent` in `core-levi-form.lean`, a different carrier in a
+> different namespace.
 
-That brief is ~200 words and would have let a reader stop the work, redirect it,
-or pick it up cold. Note the last line especially: the scope call is visible
-*before* the diff, which is where it can still be argued with.
+~200 words, and it would have let a reader stop the work, redirect it, or pick
+it up cold.
 
 ### The failure this prevents
 
 An agent that has spent an hour inside a problem writes in the private
 vocabulary it built along the way, and a reader — the author, or the next agent
-— has to reconstruct that vocabulary before they can evaluate anything. The
-brief is written at the one moment when the agent still knows which parts are
+— has to reconstruct that vocabulary before evaluating anything. The brief is
+written at the one moment when the agent still knows which parts are
 non-obvious, because it has just finished finding them out.
+
+**Cheapest correct move when you do not want to spend the words: do not start
+the topic.** A task you cannot brief is one you have not understood well enough
+to begin.
 
 ## Coordination discipline
 
 1. **Claim before you work.** Mark the bean `in-progress` so sibling sessions
    working the same goal do not duplicate the effort.
-1a. **Brief it in the same turn you claim it** (§"Opening brief" above). The
+   **Brief it in the same turn you claim it** (§"Opening brief" above). The
    claim tells a sibling the item is taken; the brief tells them, and the
    author, what it is being taken *for*.
 2. **One source of truth per concern.** Do not fork a bean into a parallel

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -353,6 +353,83 @@ bean list parsed from `.beans/`, plus how far the default branch has moved and
 recent sibling `claude/*` branch activity). Heavy triage of new commits belongs in
 a background subagent, not the foreground.
 
+## Opening a bean or a topic — brief it before you touch anything (STRICT)
+
+**When you begin work on a bean, or on any topic large enough to be one, open
+that turn with a brief.** Not after the first tool call, not folded into the
+report at the end — before the work, in the chat, where the author and the next
+agent will read it.
+
+The brief answers three questions, in this order:
+
+1. **What am I doing, and why is it worth doing?** State the problem in terms
+   someone outside this session can evaluate. Expand every identifier on first
+   use — a bean ID, a witness stem, a Lean declaration and a field name are all
+   opaque without their gloss.
+2. **What do I already know?** The measurements you are relying on, with their
+   provenance: measured this session, carried from a prior one, or asserted by a
+   bean you have not verified. A number without its date and command is a claim,
+   not evidence.
+3. **How do I plan to do it, and how will I know it worked?** The route, the
+   gate you will verify against, and — the part that gets dropped — **what would
+   falsify the approach**. If you cannot say what a failure would look like, you
+   do not yet have a plan.
+
+Then say what you are **not** doing and why: the adjacent thing you are
+deliberately leaving, the scope you are declining to widen into.
+
+### Why this is a rule and not a style preference
+
+**Sessions end mid-thread.** Containers are reclaimed, context windows fill, a
+branch is picked up days later by an agent with none of the reasoning that
+produced it. The bean body and the commit are durable; the chain of inference
+that made them sensible is not, unless it is written down at the point where it
+was still obvious. An agent resuming cold should be able to read the brief and
+continue — not reconstruct the predecessor's rabbit hole first.
+
+**It catches wrong work before it is done rather than after.** A route stated in
+advance can be corrected by the author in one line. The same route discovered in
+a finished diff costs a review cycle and, often, a revert.
+
+**It is the same discipline as the `AskUserQuestion` frame, applied to work
+instead of decisions.** That rule exists because a terse question forces the
+author to type follow-ups asking for context the agent already had. A terse
+*start* does the same thing one step earlier.
+
+### Proportionality, so this does not become ceremony
+
+The brief scales with the work, and the trigger is **irreversibility and
+surprise**, not line count.
+
+- **A one-line fix with an obvious route needs no brief.** Say what you are
+  doing and do it.
+- **Anything touching a shipped gate, a shared artifact, a Lean declaration
+  with consumers, or a number a reader sees — brief it.**
+- **Anything where you expect to be wrong some of the time — brief it**, and say
+  where you expect to be wrong. Research is the case this is most valuable for
+  and most often skipped, on the grounds that the outcome is unknown. The
+  unknown outcome is the reason to write down the route.
+
+### What a thin brief looks like, and why it fails
+
+> Starting `qou-93hu` — fixing CriticalExponent.
+
+Names the bean and nothing else. It does not say the field is a closed numeral
+identity with no exponent variable in it, so a reader cannot tell whether this
+is cosmetic or load-bearing; it does not say the class signature changes, so
+nobody can warn that every binder in two consumer modules moves with it; and it
+does not say what "fixed" will be checked against, so the agent is free to
+declare victory on a compile. Each of those omissions is a place the author
+could have intervened for the cost of reading one sentence.
+
+**Cheapest correct move when you do not want to spend the words: do not start
+the topic.** A task you cannot brief is a task you have not understood well
+enough to begin, and beginning it anyway is how a session produces work that has
+to be unwound.
+
+Full protocol, with the worked example: `.claude/skills/local/todo-manager.md`
+§"Opening brief".
+
 ## More
 
 - **`uses[]` and `interprets` are the EDITORIAL relation** — what a *reader*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -427,8 +427,18 @@ the topic.** A task you cannot brief is a task you have not understood well
 enough to begin, and beginning it anyway is how a session produces work that has
 to be unwound.
 
-Full protocol, with the worked example: `.claude/skills/local/todo-manager.md`
+Full protocol, with the worked example:
+[`skills/folio-core/todo-manager.md`](skills/folio-core/todo-manager.md)
 §"Opening brief".
+
+> **Two `todo-manager.md` exist and they have diverged — noted, not resolved
+> here.** `skills/folio-core/todo-manager.md` (3 inbound references, and the one
+> this file's other links point at) and `.claude/skills/local/todo-manager.md`
+> (5 inbound references) differ by **186 lines** as of 2026-08-30. §"Opening
+> brief" was added to both so this change does not widen the gap, but which copy
+> is canonical is a question for whoever owns the skills layout — resolving a
+> 186-line divergence as a side effect of an unrelated edit is how one of them
+> quietly becomes wrong.
 
 ## More
 

--- a/skills/folio-core/todo-manager.md
+++ b/skills/folio-core/todo-manager.md
@@ -46,6 +46,92 @@ Note: the npm package named `beans` is an unrelated abandoned tool — do **not*
    `beans update <child-id> --parent <session-id>`
 3. **No manual `.md` checklists:** Never use `session-beans.md` or raw Markdown `- [ ]` checklists to track global tasks. Always use the `beans` CLI to prevent namespace pollution and maintain the official project tracking.
 4. **Check before you create:** `beans create` is **not** idempotent. Run the existence check below before every `beans create` — no exceptions, including the session milestone.
+5. **Brief before you work:** claiming a bean records *which* item is taken; the opening brief records what it is taken **for**. Write it before the first tool call, in the chat. See §"Opening brief" below.
+
+## Opening brief
+
+**Claiming a bean records the work. Briefing it is what makes the work
+resumable.** Both are required, and the brief comes first — before the first
+tool call, in the chat, not in the commit.
+
+AGENTS.md §"Opening a bean or a topic" states the rule and when it applies.
+This is the shape.
+
+### The four parts
+
+**1. The problem, stated for someone who was not here.** Expand every
+identifier on first use. Not "fixing `qou-93hu`" but "bean `qou-93hu` — the
+`CriticalExponent` conjecture carrier, whose only field is `(3 * 4 : ℕ) = 12`, a
+closed numeral identity with no exponent variable in it, so the class constrains
+nothing."
+
+**2. What you know, and how you know it.** Every number with its provenance:
+
+| provenance | how to say it |
+|---|---|
+| measured this session | "measured just now: 22 of 22 seeded, 0 missed" |
+| carried from a prior session | "recorded 2026-08-24 as 43 drifted; not re-measured" |
+| asserted by a bean or a doc | "bean `qou-q7lf` says X — **unverified**" |
+
+That third row is the one that bites. A sibling's bean is not a primary source,
+and neither is a source file's `## Status` note; both go stale, and a specific,
+recent, confidently-worded bean is exactly the kind that gets believed.
+
+**3. The route and the gate.** How you plan to do it, what you will verify
+against, and **what would falsify the approach**. A plan with no failure mode is
+not a plan; it is an intention. If the gate is a script, name it and its
+expected output.
+
+**4. What you are NOT doing.** The adjacent defect you are leaving, the scope
+you decline to widen into, the thing you will flag rather than fix. Stating it
+up front is what stops it becoming either silent scope creep or a silent
+omission — and it puts the scope call where it can still be argued with, which
+is before the diff.
+
+### Worked example
+
+> **Starting `qou-93hu`** — the `CriticalExponent` §3b-cond hypothesis class in
+> `lean/QOU/AlgebraicSubstrate/ConditionalClasses.lean`.
+>
+> **The problem.** Its single field is `alpha_three_eq_four : (3 * 4 : ℕ) = 12`
+> — a closed numeral identity with the values already substituted in, so no
+> exponent variable occurs in it and `rfl` proves it whatever the physics. Four
+> sibling carriers in the same file are vacuous too, but they are at least the
+> right *shape* (parameter-quantified inequalities); this one has no quantifier
+> and no free variable at all.
+>
+> **What I know.** Measured this session: bound as `[C]` in 5 files; the probe
+> baseline records it `proved-vacuous`; the class's own docstring already claims
+> "α = 4/3", so the target value is not something I need to invent. Not
+> measured: whether any downstream proof depends on the field's *current* type.
+>
+> **Route.** Make α a class parameter — `class CriticalExponent (α : ℝ) : Prop
+> where alpha_eq : α = 4/3`. A `Prop` class cannot carry data, so α must be a
+> parameter, not a field. Gate: lean-direct exit 0 on all three affected
+> modules, plus a content probe proving `¬ CriticalExponent 2` — because
+> inhabitability at 4/3 alone would not show the class constrains anything.
+> **Falsifier:** if `¬ CriticalExponent 2` will not go through, the encoding is
+> not doing what I claim and I stop.
+>
+> **Not doing.** The other four carriers need analytic setup their docstrings
+> only gesture at — the author's mathematics, not a cleanup. Also leaving the
+> separate `CriticalExponent` in `core-levi-form.lean`, a different carrier in a
+> different namespace.
+
+~200 words, and it would have let a reader stop the work, redirect it, or pick
+it up cold.
+
+### The failure this prevents
+
+An agent that has spent an hour inside a problem writes in the private
+vocabulary it built along the way, and a reader — the author, or the next agent
+— has to reconstruct that vocabulary before evaluating anything. The brief is
+written at the one moment when the agent still knows which parts are
+non-obvious, because it has just finished finding them out.
+
+**Cheapest correct move when you do not want to spend the words: do not start
+the topic.** A task you cannot brief is one you have not understood well enough
+to begin.
 
 ## Check before you create — `beans create` is not idempotent (STRICT)
 


### PR DESCRIPTION
Docs only — AGENTS.md plus both copies of `todo-manager.md`.

## The gap

Nothing in this repo asked an agent to say what it was about to do. AGENTS.md covered **claiming** a bean and surfacing the work-plan at session start; both answer *which* item is being worked, neither answers what it is being worked **for**.

Adds AGENTS.md §"Opening a bean or a topic — brief it before you touch anything" and `todo-manager.md` §"Opening brief": before the first tool call, in the chat, say what the problem is in terms a reader outside the session can evaluate, what you already know and with what provenance, the route plus the gate you will verify against **and what would falsify it**, and what you are deliberately **not** doing.

## The three parts that get dropped

- **Provenance per number** — measured this session / carried from a prior one / asserted by a bean you have not verified. The third row is the one that bites: a sibling's bean is not a primary source, and a specific, recent, confidently-worded one is exactly the kind that gets believed.
- **A falsifier** — a plan with no stated failure mode is an intention, not a route. If you cannot say what "this approach is wrong" would look like, you do not have one yet.
- **What you are not doing** — stating the declined scope up front keeps it from becoming either silent creep or a silent omission, and puts the scope call where it can still be argued with: before the diff.

## Proportionality

Explicit, so this does not become ceremony. The trigger is **irreversibility and surprise, not line count**. A one-line fix with an obvious route needs no brief. Anything touching a shipped gate, a shared artifact, a declaration with consumers, or a number a reader sees does. So does anything where you expect to be wrong some of the time — research is the case this is most valuable for and most often skipped, on the grounds that the outcome is unknown, which is the reason to write the route down rather than not to.

Carries a worked ~200-word brief and a thin counter-example showing what each omission costs a reader.

## One finding, recorded rather than fixed

**Two `todo-manager.md` exist and have diverged by 186 lines.** `skills/folio-core/todo-manager.md` (3 inbound refs, and where AGENTS.md's other links point) and `.claude/skills/local/todo-manager.md` (5 inbound refs) are both live, both real files, not symlinks.

I hit it the hard way: I wrote the section into `.claude/skills/local/` first, and the rebase onto main showed AGENTS.md citing the other path. The section is now in **both**, so this change does not widen the gap — but which copy is canonical is a skills-layout question, and resolving a 186-line divergence as a side effect of an unrelated docs edit is precisely how one copy quietly becomes the wrong one. Noted in AGENTS.md beside the pointer so the next reader sees it instead of picking at random.

## Verification

Docs only; no code, no schema, no pipeline. Rebased onto `origin/main` (+273) with zero conflicts. Section present in all three files (`AGENTS.md`, both `todo-manager.md`). Sixty pre-existing dirty `script-sidecars/*.json` in the clone were left untouched and are not in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Z68SqSiD978gaNt1uW6Kt

---
_Generated by [Claude Code](https://claude.ai/code/session_012Z68SqSiD978gaNt1uW6Kt)_