### PR TITLE
Regenerate the skill-instructions mirror — I merged #153 with this check red

### DIFF
--- a/docs/reference/skill-instructions/todo-manager.md
+++ b/docs/reference/skill-instructions/todo-manager.md
@@ -46,6 +46,92 @@ Note: the npm package named `beans` is an unrelated abandoned tool — do **not*
    `beans update <child-id> --parent <session-id>`
 3. **No manual `.md` checklists:** Never use `session-beans.md` or raw Markdown `- [ ]` checklists to track global tasks. Always use the `beans` CLI to prevent namespace pollution and maintain the official project tracking.
 4. **Check before you create:** `beans create` is **not** idempotent. Run the existence check below before every `beans create` — no exceptions, including the session milestone.
+5. **Brief before you work:** claiming a bean records *which* item is taken; the opening brief records what it is taken **for**. Write it before the first tool call, in the chat. See §"Opening brief" below.
+
+## Opening brief
+
+**Claiming a bean records the work. Briefing it is what makes the work
+resumable.** Both are required, and the brief comes first — before the first
+tool call, in the chat, not in the commit.
+
+AGENTS.md §"Opening a bean or a topic" states the rule and when it applies.
+This is the shape.
+
+### The four parts
+
+**1. The problem, stated for someone who was not here.** Expand every
+identifier on first use. Not "fixing `qou-93hu`" but "bean `qou-93hu` — the
+`CriticalExponent` conjecture carrier, whose only field is `(3 * 4 : ℕ) = 12`, a
+closed numeral identity with no exponent variable in it, so the class constrains
+nothing."
+
+**2. What you know, and how you know it.** Every number with its provenance:
+
+| provenance | how to say it |
+|---|---|
+| measured this session | "measured just now: 22 of 22 seeded, 0 missed" |
+| carried from a prior session | "recorded 2026-08-24 as 43 drifted; not re-measured" |
+| asserted by a bean or a doc | "bean `qou-q7lf` says X — **unverified**" |
+
+That third row is the one that bites. A sibling's bean is not a primary source,
+and neither is a source file's `## Status` note; both go stale, and a specific,
+recent, confidently-worded bean is exactly the kind that gets believed.
+
+**3. The route and the gate.** How you plan to do it, what you will verify
+against, and **what would falsify the approach**. A plan with no failure mode is
+not a plan; it is an intention. If the gate is a script, name it and its
+expected output.
+
+**4. What you are NOT doing.** The adjacent defect you are leaving, the scope
+you decline to widen into, the thing you will flag rather than fix. Stating it
+up front is what stops it becoming either silent scope creep or a silent
+omission — and it puts the scope call where it can still be argued with, which
+is before the diff.
+
+### Worked example
+
+> **Starting `qou-93hu`** — the `CriticalExponent` §3b-cond hypothesis class in
+> `lean/QOU/AlgebraicSubstrate/ConditionalClasses.lean`.
+>
+> **The problem.** Its single field is `alpha_three_eq_four : (3 * 4 : ℕ) = 12`
+> — a closed numeral identity with the values already substituted in, so no
+> exponent variable occurs in it and `rfl` proves it whatever the physics. Four
+> sibling carriers in the same file are vacuous too, but they are at least the
+> right *shape* (parameter-quantified inequalities); this one has no quantifier
+> and no free variable at all.
+>
+> **What I know.** Measured this session: bound as `[C]` in 5 files; the probe
+> baseline records it `proved-vacuous`; the class's own docstring already claims
+> "α = 4/3", so the target value is not something I need to invent. Not
+> measured: whether any downstream proof depends on the field's *current* type.
+>
+> **Route.** Make α a class parameter — `class CriticalExponent (α : ℝ) : Prop
+> where alpha_eq : α = 4/3`. A `Prop` class cannot carry data, so α must be a
+> parameter, not a field. Gate: lean-direct exit 0 on all three affected
+> modules, plus a content probe proving `¬ CriticalExponent 2` — because
+> inhabitability at 4/3 alone would not show the class constrains anything.
+> **Falsifier:** if `¬ CriticalExponent 2` will not go through, the encoding is
+> not doing what I claim and I stop.
+>
+> **Not doing.** The other four carriers need analytic setup their docstrings
+> only gesture at — the author's mathematics, not a cleanup. Also leaving the
+> separate `CriticalExponent` in `core-levi-form.lean`, a different carrier in a
+> different namespace.
+
+~200 words, and it would have let a reader stop the work, redirect it, or pick
+it up cold.
+
+### The failure this prevents
+
+An agent that has spent an hour inside a problem writes in the private
+vocabulary it built along the way, and a reader — the author, or the next agent
+— has to reconstruct that vocabulary before evaluating anything. The brief is
+written at the one moment when the agent still knows which parts are
+non-obvious, because it has just finished finding them out.
+
+**Cheapest correct move when you do not want to spend the words: do not start
+the topic.** A task you cannot brief is one you have not understood well enough
+to begin.
 
 ## Check before you create — `beans create` is not idempotent (STRICT)
 


### PR DESCRIPTION
One generated file. Fixes a red check on `main` that **I put there**.

## What happened

`TypeScript — tests, lint, types (hard)` failed at 07:54:11Z on head `184a94d` of #153, and I merged that exact head at 08:04:46Z.

I checked mergeability and the qou-side guards, and never looked for check runs on **this** repo — because I had spent the session operating on "this org has no live CI". That belief came from qou's `workflow_dispatch`-only setup and from the same `qou-gwe9` over-generalisation I spent the morning correcting. `folio-assistant` does run CI, and it caught me.

## The failure, reproduced locally before fixing

```
generated docs are STALE (1 file(s)); re-run without --check:
  docs/reference/skill-instructions/todo-manager.md
```

`scripts/gen-skill-docs.ts` mirrors skill bodies into `docs/reference/skill-instructions/`. I edited `todo-manager.md` in #153 and didn't regenerate.

## Verification

| step | result |
|---|---|
| `gen-skill-docs.ts --check` before | **STALE (1 file)** — reproduces the CI failure exactly |
| `gen-skill-docs.ts` (regenerate) | wrote the mirror |
| `gen-skill-docs.ts --check` after | **"generated docs are up to date"** |

Diff is the one generated file; nothing hand-edited.

## The bit worth keeping

#153 was a docs PR arguing for writing things down accurately. Copilot flagged that its **two** `todo-manager.md` copies had drifted; I synced those two — and there is a **third**, generated, which is what went red.

That is the PR's own thesis landing on its author: a claim about "both copies" needs the count *measured*, not assumed. The AGENTS.md note I added there says two copies exist and differ by 186 lines. It should say three, and I'll correct it once this is green rather than stack another unverified claim on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Z68SqSiD978gaNt1uW6Kt

---
_Generated by [Claude Code](https://claude.ai/code/session_012Z68SqSiD978gaNt1uW6Kt)_