### PR TITLE
beans: close three verified-fixed beans, open one for the leftover

### DIFF
--- a/.beans/folio-assistant-a39g--pipelinescriptpath-is-dead-and-its-only-test-pins.md
+++ b/.beans/folio-assistant-a39g--pipelinescriptpath-is-dead-and-its-only-test-pins.md
@@ -1,0 +1,79 @@
+---
+# folio-assistant-a39g
+title: pipelineScriptPath is dead, and its only test pins the behaviour that made it dead
+status: todo
+type: task
+priority: low
+created_at: 2026-08-30T10:41:21Z
+updated_at: 2026-08-30T10:41:52Z
+---
+
+## The finding
+
+`pipelineScriptPath(script)` — `adapters/document/tools/_pipeline.ts:79` — has
+**zero production callers**. Measured corpus-wide (`grep -rn pipelineScriptPath
+--include=*.ts . | grep -v node_modules`), all four references are:
+
+- `adapters/document/tools/_pipeline.ts:79` — its own definition
+- `scripts/tests/qa-tools.test.ts:11,36,37,39` — one test, importing and
+  asserting it
+
+It was superseded by `resolvePipelineScript`, which checks the folio's
+`content/pipeline/<name>.ts` **and then the platform checkout's**, returning
+`undefined` when neither exists. Every real caller (3 of them, all in
+`_pipeline.ts` / `runPipeline`) uses the new one. The old function is already
+carrying an honest `@deprecated` docstring that says exactly this: *"it must not
+be used to decide whether a script exists."*
+
+## Why this is a hazard rather than a defect
+
+Nothing is currently wrong. `pipelineScriptPath` returns a true statement —
+where the script *would* live in this folio — and no code acts on it. The
+hazard is the test:
+
+```ts
+test("pipelineScriptPath resolves under content/pipeline with .ts", () => {
+  const p = pipelineScriptPath("qa-sweep");
+  expect(p.endsWith("/content/pipeline/qa-sweep.ts")).toBe(true);
+  expect(pipelineScriptPath("x.ts").endsWith("/content/pipeline/x.ts")).toBe(true);
+});
+```
+
+This pins the **folio-only** resolution — precisely the behaviour that caused
+the bug `resolvePipelineScript` was written to fix (a scaffolded folio with no
+`content/pipeline/` got `pipeline script not found` on every tool). So the
+suite now has a green test whose subject no production path reaches, asserting
+a semantics the codebase has deliberately moved away from. It cannot fail in a
+way anyone should care about, and it cannot catch a regression, because there
+is no live behaviour behind it.
+
+That is the class catalogued in `folio-assistant-6fnb` ("tests that cannot
+fail"), reached from the opposite direction: 6fnb's entries are tautological or
+skipped assertions; this one is a real assertion about a dead subject.
+
+## Options
+
+1. **Delete both** — the function and its test. Cheapest, and the deprecation
+   note already argues for it. Risk: it is `export`ed, so an out-of-tree
+   consumer would break; there is no published package here (folio-assistant is
+   consumed by sibling checkouts via `setup-folio-assistant.sh`, i.e. source),
+   so the blast radius is greppable and currently empty.
+2. **Keep the function, delete the test.** Retains the export for anyone who
+   genuinely wants "where would this live in the folio" without implying the
+   file exists. Removes the misleading green.
+3. **Keep both, and change the test to assert the deprecation contract** —
+   e.g. that `pipelineScriptPath` and `resolvePipelineScript` *disagree* on a
+   script that exists only in the platform. That turns a dead test into a live
+   one documenting why the second function exists.
+
+**Recommendation (my judgement, not a finding): option 3.** It costs about six
+lines, keeps the export, and converts the one artifact that currently misleads
+into the one that explains the fix. Option 1 is fine if the owner would rather
+the surface shrink.
+
+**Default if nothing is done:** nothing breaks. The function stays inert and
+correctly deprecated; the suite keeps one test that can never matter.
+
+History: split out of `folio-assistant-e1f6` at its closure (2026-08-30), where
+it was found while verifying that the shell-out resolver fix had actually
+landed.

--- a/.beans/folio-assistant-bfyw--two-audits-write-into-beans-and-todos-locations-ag.md
+++ b/.beans/folio-assistant-bfyw--two-audits-write-into-beans-and-todos-locations-ag.md
@@ -1,10 +1,11 @@
 ---
 # folio-assistant-bfyw
 title: Two audits write into .beans/ and todos/ — locations AGENTS.md forbids
-status: in-progress
+status: completed
 type: bug
+priority: normal
 created_at: 2026-08-29T06:32:29Z
-updated_at: 2026-08-29T06:32:29Z
+updated_at: 2026-08-30T10:37:02Z
 ---
 
 Revived by #144. audit-status-sections defaults to .beans/status-section-audit.json (pollutes the bean store); qa-section-title-audit writes todos/section-title-audit.json (the todos/*.json store AGENTS.md says not to stand up) and its docstring claims it is gitignored, which is false in a folio_init layout.
@@ -64,3 +65,17 @@ submodule — no stray files.
 defaults into `build/`, and that the formerly-hardcoded one honours `--out`.
 
 Gates: 1190 pass / 0 fail, tsc clean, eslint clean.
+
+
+## Closed 2026-08-30 — all four verified repointed
+
+Status was `in-progress` while the "was / now" table already recorded the work.
+Checked each of the four against the tree: zero live references to `.beans/*.json`
+or `todos/*.json` remain; all four write under `build/`, and
+`qa-section-title-audit.ts` has the `--out` flag the table promised.
+
+**One near-miss worth recording.** A naive grep reports `qa-section-title-audit.ts`
+as still carrying a forbidden path. It is a HISTORICAL COMMENT —
+`// Was hardcoded to todos/section-title-audit.json` — explaining the fix. The
+live default is `build/section-title-audit.json`. Counting comment text as a
+live path would have reopened a correctly-closed bean.

--- a/.beans/folio-assistant-e1f6--sweep-every-tool-that-shells-out-does-it-work-on-a.md
+++ b/.beans/folio-assistant-e1f6--sweep-every-tool-that-shells-out-does-it-work-on-a.md
@@ -1,10 +1,11 @@
 ---
 # folio-assistant-e1f6
 title: 'Sweep: every tool that shells out — does it work on a scaffolded folio, and what does it print when its dependency is missing?'
-status: in-progress
+status: completed
 type: task
+priority: normal
 created_at: 2026-08-29T02:41:13Z
-updated_at: 2026-08-29T02:41:13Z
+updated_at: 2026-08-30T10:37:02Z
 ---
 
 Follow-on from p9a2. Two properties per tool: (a) honest reporting when the dependency is absent, (b) actually functional on a folio_init layout.
@@ -82,3 +83,22 @@ against an empty registry is unverified. Worth a follow-up if a folio starts
 carrying references.
 
 Gates: 1181 pass / 0 fail, tsc clean, eslint clean.
+
+
+## Closed 2026-08-30 — resolution fix verified in the code
+
+Status was `in-progress` with no open items in the body. The claimed fix is
+present: `resolvePipelineScript` in `adapters/document/tools/_pipeline.ts`,
+used by 3 files, documented to try the folio's own `content/pipeline/` first
+and fall back to the platform's.
+
+**What I checked, because it looked wrong at first.** The OLD folio-only
+resolver `pipelineScriptPath` is still in that file, still a bare
+`join(REPO_ROOT, "content", "pipeline", name)` with no fallback — i.e. exactly
+the defect this bean describes. It is **dead**: zero production callers. Its
+only references are its own definition and `scripts/tests/qa-tools.test.ts`,
+which asserts the old behaviour.
+
+That leftover is not a defect but it is a hazard, and a test pinning a dead
+function's behaviour is a test that can never matter — the class
+`folio-assistant-6fnb` catalogued. Split out rather than left implicit here.

--- a/.beans/folio-assistant-p9a2--content-validate-reports-0-errors-when-the-pipelin.md
+++ b/.beans/folio-assistant-p9a2--content-validate-reports-0-errors-when-the-pipelin.md
@@ -1,10 +1,11 @@
 ---
 # folio-assistant-p9a2
 title: content_validate reports 0 errors when the pipeline never ran
-status: in-progress
+status: completed
 type: bug
+priority: normal
 created_at: 2026-08-28T20:08:28Z
-updated_at: 2026-08-28T20:08:28Z
+updated_at: 2026-08-30T10:37:02Z
 ---
 
 Found by authoring real content in folio-test. content_validate resolves validate.ts from the FOLIO's content/pipeline/, which folio_init does not create — so the spawn fails with 'Module not found', stdout is empty, the ✗/⚠ counts are 0, and the tool reports 'Validation: 0 error(s), 0 warning(s)'. A check that never looked, reporting clean.
@@ -66,3 +67,19 @@ Both were false *negatives* in reporting tools, and both survived because the
 output looked like success. Worth considering a sweep of the remaining tools
 that shell out to a pipeline, asking of each: what does this print if the
 thing it runs is missing?
+
+
+## Closed 2026-08-30 — verified, not assumed
+
+Status was `in-progress` while the body already described finished work. The
+fix is present and exercised:
+
+- `pipelineFailedToRun` and the `INCOMPLETE` label are in
+  `adapters/document/tools/validate.ts`.
+- `scripts/tests/validate-pipeline-guard.test.ts` — **7 pass / 0 fail**,
+  9 expect() calls, run just now.
+
+One note on the verification, because the first run was misleading: it failed
+with `Cannot find package 'zod'` on a fresh clone. That was the ENVIRONMENT,
+not the code — `bun install` (335 packages), then 7/7. A test failure on an
+uninstalled checkout is not evidence about the code.


### PR DESCRIPTION
Three open beans described defects that were already fixed on `main`. Rather than close them on the strength of "looks done", each was re-verified against the live tree and the closure note records the evidence, so a reader can re-check it instead of trusting the status flag.

## What was verified

**`folio-assistant-p9a2`** — *content_validate reports 0 errors when the pipeline never ran.*
`pipelineFailedToRun` and the `INCOMPLETE` verdict are present in `adapters/document/tools/validate.ts`; `scripts/tests/validate-pipeline-guard.test.ts` runs **7 pass / 0 fail**.

That suite first failed with `Cannot find package 'zod'`. That is an unprovisioned checkout, not a code defect — `bun install` (335 packages) and it is green. Recorded in the bean because a missing-dependency failure is shaped exactly like a real one, and reading it as a real one would have kept a fixed bean open.

**`folio-assistant-bfyw`** — *two audits write into `.beans/` and `todos/`.*
All four writers now target `build/`. The one apparent survivor is a **comment** describing the historical behaviour, not a live write path. It was nearly reported as a violation.

**`folio-assistant-e1f6`** — *every tool that shells out: does it work on a scaffolded folio?*
`resolvePipelineScript` (`adapters/document/tools/_pipeline.ts`) checks the folio's `content/pipeline/` and then the platform checkout, with 3 callers; `runPipeline` returns a named error rather than reporting a clean run.

## The one thing that is NOT fixed

Split into **`folio-assistant-a39g`** rather than left implicit in a closed bean, per the standing rule that a decision named in passing is a decision handed over without the means to make it.

`pipelineScriptPath` has **zero production callers** — all four references corpus-wide are its own definition plus one test. It is already honestly `@deprecated`. The hazard is the test, which pins the **folio-only** resolution that `resolvePipelineScript` exists to replace, so the suite carries a green assertion about a dead subject asserting semantics the codebase moved away from. That is the `folio-assistant-6fnb` class reached from the other direction.

`a39g` carries three options with costs and a stated recommendation (convert the test into one that asserts the deprecation contract), and names the no-op default: nothing breaks if this is never done.

## Verification

Beans-only change — no production code touched. `git diff --stat` is three modified `.beans/*.md` and one new one.

---
_Generated by [Claude Code](https://claude.ai/code/session_018xG9UuU6DfXN4rghMa3Dif)_