### PR TITLE
q-usage-audit: refuse unknown args; stop walking .lake into the orphan scan

### DIFF
--- a/content/pipeline/q-usage-audit.ts
+++ b/content/pipeline/q-usage-audit.ts
@@ -71,8 +71,6 @@ const PLATFORM_ROOT = resolve(SCRIPT_DIR, "..", "..");
  * the seven `q-usage-*` criteria unrefreshable in every downstream sidecar.
  * Observed live on qou #4673.
  */
-const REPO_ROOT = findContentRepoRoot();
-
 // ── CLI args ────────────────────────────────────────────────────
 
 const args = process.argv.slice(2);
@@ -84,6 +82,56 @@ const chapterFilterIdx = args.indexOf("--chapter");
 const chapterFilter = chapterFilterIdx >= 0 ? args[chapterFilterIdx + 1] : undefined;
 const paperFilterIdx = args.indexOf("--paper");
 const paperFilter = paperFilterIdx >= 0 ? args[paperFilterIdx + 1] : undefined;
+
+/**
+ * Reject anything this tool does not understand, instead of ignoring it.
+ *
+ * This audit is CORPUS-WIDE by design — it walks every paper and rewrites a
+ * sidecar per block. Its only scoping is `--paper` / `--chapter`; there is no
+ * positional interface and never has been. Silently discarding an unrecognised
+ * argument therefore turns a caller who *believes* they scoped the run into a
+ * caller who rewrites the whole corpus.
+ *
+ * That is not hypothetical. Invoked as
+ *
+ *     q-usage-audit.ts content/<paper>/braids-and-knots/why-b3.md
+ *
+ * intending to refresh ONE block, it ignored the path and modified **3,573
+ * sidecars**, created untracked `.qa.json` files for blocks that had none, and
+ * emitted a witness — the mass-refresh the content repo's own idle-pass policy
+ * forbids ("cap ≤ 10 sidecars per pass"; "never mass-refresh"). Reverting it
+ * was possible only because the tree was otherwise clean. qou bean `qou-fx71`.
+ *
+ * Exiting non-zero here costs a caller one error message; the alternative cost
+ * a full revert.
+ */
+const KNOWN_FLAGS = new Set([
+  "--no-write", "--strict", "--json", "--no-orphans", "--chapter", "--paper",
+]);
+const flagValueIdx = new Set(
+  [chapterFilterIdx, paperFilterIdx].filter((i) => i >= 0).map((i) => i + 1),
+);
+const unknownArgs = args.filter(
+  (a, i) => !KNOWN_FLAGS.has(a) && !flagValueIdx.has(i),
+);
+if (unknownArgs.length > 0) {
+  console.error(
+    `q-usage-audit: unrecognised argument(s): ${unknownArgs.join(", ")}\n` +
+      `\nThis audit is corpus-wide and has no positional/per-file interface.\n` +
+      `Scope it with:  --paper <name>   --chapter <name>\n` +
+      `Other flags:    --no-write  --strict  --json  --no-orphans\n` +
+      `\nRefusing to run: a discarded scope argument would rewrite every\n` +
+      `sidecar in the corpus (measured: 3,573). See qou bean qou-fx71.`,
+  );
+  // EX_USAGE (sysexits.h). NOT 2 -- this tool already exits 2 for "no content
+  // repo found", and a caller scripting around it must be able to tell a bad
+  // argument from a bad working directory.
+  process.exit(64);
+}
+
+// ── Content repo discovery (AFTER args are validated) ───────────
+
+const REPO_ROOT = findContentRepoRoot();
 
 /**
  * Papers to audit: `--paper <name>` if given, else every paper in the

--- a/content/pipeline/qa-utils.ts
+++ b/content/pipeline/qa-utils.ts
@@ -549,6 +549,19 @@ export function listPackageLeanFiles(repoRoot: string): string[] {
       while (stack.length) {
         const dir = stack.pop()!;
         for (const e of readdirSync(dir, { withFileTypes: true })) {
+          // `.lake/` is Lake's BUILD DIRECTORY: vendored third-party sources
+          // (Mathlib, Batteries, …) plus build output. Measured on qou
+          // 2026-08-30: 8,013 of the 10,412 `.lean` files under the Lake root
+          // live there — 77 %. Walking them makes every consumer audit its own
+          // dependencies: the q-usage audit reported `wall-base-ring-minimal`
+          // findings against `.lake/packages/mathlib/Mathlib/Algebra/CharP/*`,
+          // "…and 1474 more".
+          //
+          // This function's own contract is why the exclusion is correct and
+          // not merely convenient: it feeds "orphan-coverage scans that audit
+          // Lean files reachable by NO block's `lean.ref`". A Mathlib file is
+          // not an orphan of this corpus — it is not ours to cover.
+          if (e.isDirectory() && e.name === ".lake") continue;
           const full = join(dir, e.name);
           if (e.isDirectory()) stack.push(full);
           else if (e.isFile() && e.name.endsWith(".lean")) out.push(full);
@@ -560,6 +573,7 @@ export function listPackageLeanFiles(repoRoot: string): string[] {
   }
   return out;
 }
+
 
 // ── Block discovery ─────────────────────────────────────────────
 


### PR DESCRIPTION
Two defects in `q-usage-audit.ts` / `qa-utils.ts`, both found by running the tool against `litlfred/qou`, both measured before and after. Filed there as bean `qou-fx71`.

## 1. Unknown arguments were silently discarded

This audit is **corpus-wide by design** — it walks every paper and rewrites a sidecar per block. Its only scoping is `--paper` / `--chapter`; there is **no positional interface and never has been**. `args` is read only via `.includes()` and `.indexOf()`, so a positional path was dropped without a word.

That turns a caller who *believes* they scoped the run into one who rewrites the whole corpus. **Not hypothetical** — invoked as

```
q-usage-audit.ts content/<paper>/braids-and-knots/why-b3.md
```

intending to refresh **one** block, it modified **3,573 sidecars**, created untracked `.qa.json` files for blocks that had none, and emitted a witness. That is the mass-refresh the content repo's own idle-pass policy forbids ("cap ≤ 10 sidecars per pass"; "never mass-refresh"). Reverting was only possible because the tree was otherwise clean.

Now it exits **`EX_USAGE` (64)** naming the offending argument. **64, not 2**, deliberately: this tool already exits 2 for *"no content repo found"*, and a caller scripting around it must be able to tell a bad argument from a bad working directory.

Argument parsing also moved **above `findContentRepoRoot()`** — validation before filesystem discovery, which is the right order and is what makes the guard testable without a content repo.

## 2. `listPackageLeanFiles` walked `.lake/` — the vendored dependencies

Its own docstring states the contract: it feeds *"orphan-coverage scans that audit Lean files reachable by **no** block's `lean.ref`"*. A Mathlib file is not an orphan of this corpus — it is not ours to cover.

Measured on qou, `--no-write`, identical invocation, fix off vs on:

| | files scanned | `.lake` findings |
|---|---|---|
| **off** | **10,444** | **80** |
| **on** | **2,431** | **0** |

The 8,013 difference is exactly the count of `*.lean` under `.lake/` — **77 % of the Lake root**. Before the fix the audit reported `wall-base-ring-minimal` against `.lake/packages/mathlib/Mathlib/Algebra/CharP/*`, "…and 1474 more".

## A correction to my own testing, since it nearly buried defect 2

My first comparison held `--paper` fixed and reported **0 `.lake` paths with *and* without the fix** — i.e. it appeared to refute the fix. That control cell was broken: the fix-off run never emitted a `lean-tree-scanned` line at all, so I was comparing a real 0 against a run that had not completed the orphan scan. The clean 2×2 above is the corrected measurement, and it is corroborated independently by the 8,013 file count.

## Verification

- `tsc --noEmit` clean on both files
- positional argument → **exit 64**, message names the argument
- `--paper …`, `--paper … --chapter …`, and bare `--no-write --json` → **exit 0** (confirming `--chapter`'s *value* is not read as an unknown argument)
- `--no-write` leaves the content tree untouched — 0 files changed
- both fixes exercised against real content in `litlfred/qou`, not a fixture

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dg8mp4qbyoc98KExM2e7HG)_