### PR TITLE
a39g: make the dead pipelineScriptPath test assert the deprecation contract

### DIFF
--- a/.beans/folio-assistant-a39g--pipelinescriptpath-is-dead-and-its-only-test-pins.md
+++ b/.beans/folio-assistant-a39g--pipelinescriptpath-is-dead-and-its-only-test-pins.md
@@ -1,11 +1,11 @@
 ---
 # folio-assistant-a39g
 title: pipelineScriptPath is dead, and its only test pins the behaviour that made it dead
-status: todo
+status: completed
 type: task
 priority: low
 created_at: 2026-08-30T10:41:21Z
-updated_at: 2026-08-30T10:41:52Z
+updated_at: 2026-08-30T14:24:38Z
 ---
 
 ## The finding
@@ -77,3 +77,45 @@ correctly deprecated; the suite keeps one test that can never matter.
 History: split out of `folio-assistant-e1f6` at its closure (2026-08-30), where
 it was found while verifying that the shell-out resolver fix had actually
 landed.
+
+
+## CLOSED 2026-08-30 — option 3 taken
+
+Converted the dead test into one that asserts the **deprecation contract**, per
+the recommendation above. `pipelineScriptPath` keeps its export and its
+`@deprecated` note; what changed is what the suite asserts about it.
+
+**The discriminator is a script name that exists nowhere**, which needs no
+fixture and holds under both folio layouts:
+
+- `pipelineScriptPath(nowhere)` → a folio-rooted path, always, **without
+  touching the filesystem**.
+- `resolvePipelineScript(nowhere)` → `undefined`.
+- `runPipeline(nowhere)` → `ok: false`, error contains
+  `"pipeline script not found"` — which is *why* the routing matters: a caller
+  trusting the first would spawn a missing file.
+
+That turns the one artifact that misled into the one that explains the fix, and
+it now fails in both directions that matter — if someone "fixes"
+`pipelineScriptPath` to do an existence check (silently making it a second
+resolver), or if `resolvePipelineScript` regresses to returning a path blindly.
+
+### Proved live by mutation, not assumed
+
+A test that passes is not evidence it can fail — that is the whole `6fnb`
+class. So the regression was actually introduced:
+
+    mutant: resolvePipelineScript returns `inPlatform` unconditionally
+      -> 6 pass, 2 fail
+    restored
+      -> 8 pass, 0 fail   (was 7 before this change)
+
+The mutant is also caught by the pre-existing `runPipeline returns a structured
+error for a missing script` test, so there is redundancy here rather than sole
+coverage — worth stating plainly rather than claiming this test is the only
+guard.
+
+**Not done, and deliberately:** `pipelineScriptPath` still has zero production
+callers. Option 1 (delete both) stays available and is a one-line follow-up if
+the export is ever confirmed unused out of tree. The function is honest and
+inert; the misleading part was the test, and that is what was fixed.

--- a/scripts/tests/qa-tools.test.ts
+++ b/scripts/tests/qa-tools.test.ts
@@ -9,6 +9,7 @@
 import { test, expect, describe } from "bun:test";
 import {
   pipelineScriptPath,
+  resolvePipelineScript,
   tryParseJson,
   runPipeline,
   asToolText,
@@ -33,10 +34,48 @@ type ToolHandler = (
 
 
 describe("_pipeline helper", () => {
-  test("pipelineScriptPath resolves under content/pipeline with .ts", () => {
+  test("pipelineScriptPath names a folio path and appends .ts", () => {
     const p = pipelineScriptPath("qa-sweep");
     expect(p.endsWith("/content/pipeline/qa-sweep.ts")).toBe(true);
     expect(pipelineScriptPath("x.ts").endsWith("/content/pipeline/x.ts")).toBe(true);
+  });
+
+  // THE DEPRECATION CONTRACT — this is what keeps the test above meaningful.
+  //
+  // `pipelineScriptPath` is @deprecated and has zero production callers; every
+  // live caller uses `resolvePipelineScript`. Asserting the old function's
+  // behaviour on its own therefore pinned a dead subject, and worse, pinned the
+  // FOLIO-ONLY resolution that the new function exists to replace: resolving
+  // against the folio alone is the defect that made every pipeline-backed tool
+  // fail on a scaffolded folio (see `resolvePipelineScript`'s docstring).
+  //
+  // So assert the DIFFERENCE instead. The discriminator is a name that exists
+  // nowhere, which needs no fixture and holds under both folio layouts:
+  //
+  //   pipelineScriptPath   answers "where WOULD this live in this folio"
+  //                        -> a path, always, without touching the filesystem
+  //   resolvePipelineScript answers "where IS it, here or in the platform"
+  //                        -> undefined when the answer is nowhere
+  //
+  // This fails if anyone "fixes" pipelineScriptPath to do an existence check
+  // (making it silently a second resolver), or if resolvePipelineScript
+  // regresses to returning a path blindly. Bean folio-assistant-a39g.
+  test("pipelineScriptPath vs resolvePipelineScript: the deprecation contract", () => {
+    const nowhere = "definitely-not-a-real-pipeline-script-a39g";
+
+    // The deprecated one never consults the filesystem: it answers for a
+    // script that does not exist, in this folio or anywhere else.
+    const named = pipelineScriptPath(nowhere);
+    expect(named.endsWith(`/content/pipeline/${nowhere}.ts`)).toBe(true);
+
+    // The live one does consult it, and says so honestly.
+    expect(resolvePipelineScript(nowhere)).toBeUndefined();
+
+    // Which is exactly why runPipeline must route through the second, not the
+    // first: a caller that trusted `named` above would spawn a missing file.
+    const res = runPipeline(nowhere);
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain("pipeline script not found");
   });
 
   test("tryParseJson extracts JSON after a banner, else undefined", () => {


### PR DESCRIPTION
Closes `folio-assistant-a39g`, taking option 3 of the three the bean offered.

## The problem

The test pinned `pipelineScriptPath`'s **folio-only** resolution — a function with **zero production callers**, asserting the exact semantics that `resolvePipelineScript` was written to replace. A green assertion about a dead subject, stating the behaviour that made every pipeline-backed tool fail on a scaffolded folio.

That is the `folio-assistant-6fnb` class ("tests that cannot fail") reached from the other direction: not a tautology, but a real assertion about something nothing reaches.

## The change

Keep the export and its honest `@deprecated` note; assert the **difference** instead. The discriminator is a script name that exists nowhere, so no fixture is needed and it holds under both folio layouts:

| call | result |
|---|---|
| `pipelineScriptPath(nowhere)` | a folio-rooted path, always, **without touching the filesystem** |
| `resolvePipelineScript(nowhere)` | `undefined` |
| `runPipeline(nowhere)` | `ok: false`, error contains `"pipeline script not found"` |

That last row is the point of the routing: a caller trusting the first would spawn a missing file.

It now fails in both directions that matter — if someone "fixes" `pipelineScriptPath` to do an existence check (silently making it a second resolver), or if `resolvePipelineScript` regresses to returning a path blindly.

## Proved live by mutation, not assumed

A test that passes is not evidence that it can fail — which is the entire class this came from. So I introduced the regression:

    mutant: resolvePipelineScript returns `inPlatform` unconditionally
      →  6 pass, 2 fail
    restored
      →  8 pass, 0 fail        (7 before this change)

**Stated against myself:** the mutant is *also* caught by the pre-existing `runPipeline returns a structured error for a missing script` test. So this is redundancy, not sole coverage. Claiming sole coverage would overstate what the mutation actually showed.

## Not done, deliberately

`pipelineScriptPath` still has zero production callers. Option 1 (delete both) remains available as a one-line follow-up if the export is ever confirmed unused out of tree. The function itself was honest and inert — the **test** was the misleading part, and that is what this fixes.

## Verification

`bun test scripts/tests/qa-tools.test.ts` → **8 pass / 0 fail**, 43 expect() calls. Mutation run above. No production code touched: the diff is one test file.

---
_Generated by [Claude Code](https://claude.ai/code/session_018xG9UuU6DfXN4rghMa3Dif)_