### PR TITLE
propagation-audit: resolve lean.ref by grep fallback, not by decl-as-path

### DIFF
--- a/content/pipeline/conjectural-propagation-audit.ts
+++ b/content/pipeline/conjectural-propagation-audit.ts
@@ -19,7 +19,7 @@
  * Definitions are exempt — they name constructions, not logical
  * claims.
  */
-import { readFile } from "node:fs/promises";
+import { readFile, readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { leanPackageByName } from "../../schemas/lean-packages.ts";
 import { findContentRepoRoot } from "./repo-root";
@@ -73,12 +73,60 @@ const PROVABLE = new Set(["theorem", "proposition", "lemma", "corollary"]);
  * CLAUDE.md §3b-cond. Returns true iff EITHER:
  *   (a) the `.lean` sibling contains a `class` declaration, OR
  *   (b) the lean.ref-resolved file under `<paper>/lean/<Decl/Path>.lean`
- *       contains a `class` declaration.
+ *       contains a `class` declaration, or
+ *   (c) the file that actually *declares* the ref's final segment,
+ *       located by searching the package's Lake root, contains one.
  *
  * The fallback (b) is needed because not every block keeps its
  * Lean implementation as a direct sibling — many live under the
  * Lake-package directory structure (qou:QOU.X.Y → lean/QOU/X/Y.lean).
+ *
+ * (c) is needed because a `lean.ref` is a **namespace + declaration**
+ * path, not a file path, and (b) appends the declaration name as a
+ * final path segment. That only resolves when the file happens to be
+ * named after the declaration it holds. Measured on
+ * `content/quantum-observable-universe` (2026-09-03): (b) resolved to a
+ * **non-existent** file for all seven conjectures then reported as
+ * blocking, and three of those seven — `GradedMarkovTraceExistence`
+ * (`QOU/IwahoriHecke/MarkovTrace.lean:93`), `KashaevSurreal`
+ * (`QOU/AppendixSurreals/Conjectures.lean:463`) and
+ * `TowerGeometricLowerBound`
+ * (`QOU/Mass/LevelSelectionLogarithmic.lean:48`) — already had exactly
+ * the `class` the audit was reporting as absent. This is candidate (3),
+ * the grep fallback, of the `lean.ref` resolution order the content
+ * convention already specifies (AGENTS.md §0a); the audit implemented
+ * only (1) and (2).
+ *
+ * Note the blast radius is smaller than the false-positive count: those
+ * three accounted for 22 conjecture-instances but only **5** violator
+ * blocks, because most of the affected blocks are independently blocked
+ * by a genuinely un-axiomatised conjecture in the same cone.
  */
+/**
+ * Every `.lean` under a Lake root, cached per root. Built once and
+ * reused: (c) below would otherwise walk the tree per conjecture.
+ */
+const LEAN_FILES = new Map<string, string[]>();
+async function leanFilesUnder(root: string): Promise<string[]> {
+  const hit = LEAN_FILES.get(root);
+  if (hit) return hit;
+  const out: string[] = [];
+  const walk = async (dir: string) => {
+    let entries;
+    try { entries = await readdir(dir, { withFileTypes: true }); }
+    catch { return; }
+    for (const e of entries) {
+      if (e.name === ".lake" || e.name === "build") continue;
+      const p = join(dir, e.name);
+      if (e.isDirectory()) await walk(p);
+      else if (e.name.endsWith(".lean")) out.push(p);
+    }
+  };
+  await walk(root);
+  LEAN_FILES.set(root, out);
+  return out;
+}
+
 async function isClassAxiomatised(conjBlock: Block): Promise<boolean> {
   const checkText = (text: string) => /\bclass\s+\w+/.test(text);
 
@@ -105,11 +153,36 @@ async function isClassAxiomatised(conjBlock: Block): Promise<boolean> {
       pkg.lakeRoot,
       declPath.replace(/\./g, "/") + ".lean",
     );
-    const text = await readFile(leanFile, "utf8");
-    return checkText(text);
+    try {
+      const text = await readFile(leanFile, "utf8");
+      return checkText(text);
+    } catch { /* (b) missed — a lean.ref is a namespace path, not a
+                 file path. Fall through to the grep fallback. */ }
+
+    // (c) grep fallback: find the file that declares the ref's final
+    // segment. Matches the `lean.ref` resolution order in AGENTS.md §0a.
+    const decl = declPath.split(".").pop()!;
+    if (!decl) return false;
+    const declRe = new RegExp(
+      String.raw`^\s*(?:@\[[^\]]*\]\s*)?(?:noncomputable\s+|private\s+|protected\s+|scoped\s+)*` +
+      String.raw`(?:class|structure|theorem|lemma|def|abbrev|instance|axiom|opaque)\s+` +
+      escapeRe(decl) + String.raw`\b`,
+      "m",
+    );
+    for (const f of await leanFilesUnder(join(REPO_ROOT, pkg.lakeRoot))) {
+      let text: string;
+      try { text = await readFile(f, "utf8"); } catch { continue; }
+      if (declRe.test(text)) return checkText(text);
+    }
+    return false;
   } catch {
     return false;
   }
+}
+
+/** Escape a declaration name for use inside a RegExp. */
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 /**

--- a/content/pipeline/q-usage-audit.ts
+++ b/content/pipeline/q-usage-audit.ts
@@ -108,8 +108,23 @@ const paperFilter = paperArg(args);
 const KNOWN_FLAGS = new Set([
   "--no-write", "--strict", "--json", "--no-orphans", "--chapter", "--paper",
 ]);
+/**
+ * The flags that consume the token after them. Derived by scanning `args`
+ * rather than from a per-flag index binding: the `--paper` sweep of #151
+ * replaced this file's `paperFilterIdx` with `paperArg(args)` and left the
+ * set below still naming it, so the module failed to load outright with
+ * `ReferenceError: paperFilterIdx is not defined` — taking every
+ * `q-usage-audit` invocation and its CLI test down with it.
+ *
+ * Re-adding a bare `indexOf` on the flag name is NOT the fix: that is exactly
+ * the unguarded idiom `scripts/tests/cli-args-paper-guard.test.ts` forbids,
+ * and it fails that test — which is text-based, so even naming the idiom
+ * verbatim in a comment trips it. Scanning for the flag tokens gets the
+ * indices without re-introducing the idiom, and handles a repeated flag.
+ */
+const VALUE_FLAGS = new Set(["--chapter", "--paper"]);
 const flagValueIdx = new Set(
-  [chapterFilterIdx, paperFilterIdx].filter((i) => i >= 0).map((i) => i + 1),
+  args.flatMap((a, i) => (VALUE_FLAGS.has(a) ? [i + 1] : [])),
 );
 const unknownArgs = args.filter(
   (a, i) => !KNOWN_FLAGS.has(a) && !flagValueIdx.has(i),


### PR DESCRIPTION
Two commits. The first is the point of the PR; the second unblocks its CI by fixing a failure that is on `main`.

## 1 · The defect

`conjectural-propagation-audit.ts::isClassAxiomatised` resolved a conjecture block's Lean two ways:

1. the sibling `.lean`, then
2. `PAPER/lean/DECL/PATH.lean` — the `lean.ref` decl path with dots turned into slashes.

Route (2) appends the **declaration name** as a final path segment. But a `lean.ref` is a *namespace-plus-declaration* path, not a file path, so (2) only resolves when the file happens to be named after the declaration it holds.

*(An earlier revision of this body rendered that path as `/.lean` — the angle brackets I originally used were stripped somewhere between the API and the stored body. Rewritten without them.)*

## Measurement

Run against `litlfred/qou` `content/quantum-observable-universe` (3516 blocks), 2026-09-03. Route (2) resolved to a **non-existent file for all seven** conjectures the audit reported as blocking:

| conjecture | route (2) resolved to | reality |
|---|---|---|
| `gs-graded-markov-trace-existence` | `QOU/IwahoriHecke/MarkovTrace/GradedMarkovTraceExistence.lean` — absent | `class` at `QOU/IwahoriHecke/MarkovTrace.lean:93` |
| `kashaev-surreal` | `QOU/AppendixSurreals/KashaevSurreal.lean` — absent | `class` at `QOU/AppendixSurreals/Conjectures.lean:463` |
| `tower-geometric-lower-bound` | `QOU/Mass/LevelSelection/TowerGeometricLowerBound.lean` — absent | `class` at `QOU/Mass/LevelSelectionLogarithmic.lean:48` |
| `magic-numbers-from-q` | `QOU/AtomicMass/magic_numbers_from_q.lean` — absent | `QOU/AtomicMass/MagicNumbersFromQ.lean`, genuinely no class |
| `b1-hyperbolic-rows-theorem` | absent | `QOU/AppendixSurreals/B1HyperbolicRowsTheorem.lean`, genuinely no class |
| `shell-transition-knot` | absent | decl `stability_pairs_correct` not located in the Lake tree |
| `im-q-physical-role` | absent | genuinely no class |

So three of seven already carried exactly the `class` the audit was reporting as absent.

## The fix

Adds route (c): locate the file that actually *declares* the ref's final segment by searching the package's Lake root, then test that file. This is candidate (3) — the grep fallback — of the `lean.ref` resolution order the content convention already specifies; the audit implemented only (1) and (2). The file list is walked once per Lake root and cached.

## Effect

| | before | after |
|---|---|---|
| class-axiomatised conjectures | 147 | **165** |
| violators | 34 | **29** |
| conditional-on-class | 130 | 135 |

**The violator drop is deliberately much smaller than the false-positive count** — 22 conjecture-instances but only 5 blocks — because most affected blocks are independently blocked by a genuinely un-axiomatised conjecture in the same cone. This is a correction to the audit's *reasons*, not a way to make the number go down.

The remaining 29 trace to four conjectures: `magic-numbers-from-q` (17), `b1-hyperbolic-rows-theorem` (7), `shell-transition-knot` (4), `im-q-physical-role` (1) — all four genuinely lacking a class.

---

## 2 · `q-usage-audit.ts` does not load at all on `main` — fixed here

`TypeScript — tests, lint, types (hard)` was failing **identically on `main`** and on this PR's first commit: `1290 pass / 59 skip / 3 fail / 2 errors / 9833 expect() calls` on both ([main @ 93e476b](https://github.com/litlfred/folio-assistant/actions/runs/33353910007), [this PR @ c0fd332](https://github.com/litlfred/folio-assistant/actions/runs/33714476881)).

Cause:

```
ReferenceError: paperFilterIdx is not defined
  at content/pipeline/q-usage-audit.ts:112:36
```

The `--paper` guard sweep of #151 replaced this file's `paperFilterIdx` with the guarded `paperArg(args)` — correct — but left the `flagValueIdx` set below still naming the removed binding. A module that throws at top level takes every invocation with it.

**Re-adding a bare index lookup on the flag name is not the fix** — that is the exact idiom `scripts/tests/cli-args-paper-guard.test.ts` forbids, and trying it turned one red test into a different red test. Note for the next person: that detector is text-based, so even naming the idiom verbatim *inside a comment* trips it. `flagValueIdx` is now derived by scanning `args` for the tokens that consume the next argument — no re-introduced idiom, and it handles a repeated flag, which the two-index version did not.

**That one fix cleared all three failures and both errors.** The other two failures were never named in the truncated log; they were other tests importing the same non-loading module.

## Verification

**All six checks green on `0582ef3`**, `TypeScript — tests, lint, types (hard)` included — the first green run this branch has had, and `main` is still red for the cause fixed here.

Reproduced before fixing, then showed the same checks passing:

| | before | after |
|---|---|---|
| `q-usage-audit-roots.test.ts` | 6 pass, **1 fail** | **7 pass, 0 fail** |
| `cli-args-paper-guard.test.ts` | 8 pass, 0 fail | **8 pass, 0 fail** |

CLI smoke — all three behaviours intact: a positional path argument → exit **64**; `--paper NAME --no-write --json` → exit **0**, no false `unrecognised`, witness JSON on stdout, content working tree **unchanged**; `--paper --no-write` → refused by `requireFlagValue`.

The propagation-audit change itself has no CI gate; it was verified by running the audit on the qou folio before and after (the 34/29 and 147/165 figures are that run), and each of the three recovered classes was confirmed by reading the named file and line.

Paired with litlfred/qou#6426, which consumes these numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K4y5xEFSrp6KwheV9kpPDG