### PR TITLE
Four block kinds restated BlockBase instead of extending it

### DIFF
--- a/schemas/constraints.ts
+++ b/schemas/constraints.ts
@@ -588,82 +588,54 @@ export const SimulatorSchema = BlockBaseSchema.extend({
   views: z.array(SimulatorViewSchema).optional(),
 });
 
-export const ProseSchema = z.object({
+// ── prose / equation / diagram / table ───────────────────────────
+//
+// These four RESTATED the base fields instead of extending
+// `BlockBaseSchema`, and restating is how they kept losing fields. The
+// 2026-08-24 grant (bean `folio-assistant-5nle`) added `authorNotes` to all
+// four by hand and stopped there; `defines` was still missing from all four,
+// and `cites` / `simulator` / `computation` from three of them. A zod object
+// is non-strict, so every one of those was accepted at authoring time and
+// silently stripped — no error, no warning from the schema itself.
+//
+// `defines` is the one that bites. AGENTS.md §4c REQUIRES every glossary
+// term to be declared in `defines[]`, and the `defterm-declared` rule reads
+// that array; on these four kinds it was being discarded before the rule ever
+// saw it, so a `table` or `prose` block introducing a term could not be
+// declared at all.
+//
+// The same defect has a scar in this file's neighbour: see `BLOCK_KINDS` in
+// schemas/types.ts, where `algorithm` and `table` were added to the union and
+// never propagated to five hand-maintained lists, excluding 461 qou blocks
+// from every sweep. Restating a set that already exists is the shared cause.
+//
+// So: extend the base, and add only what is genuinely kind-specific. A field
+// added to `BlockBaseSchema` from now on reaches these four automatically.
+export const ProseSchema = BlockBaseSchema.extend({
   kind: z.literal("prose"),
+  // Deliberately NOT `labelForKind("prose")` — prose blocks carry free-form
+  // labels (`intro-...`, `rem:...`), so the prefix rule does not apply.
   label: z.string().optional(),
-  title: z.string().optional(),
-  cites: z.array(z.string()).optional(),
-  tags: z.array(z.string()).optional(),
-  uses: z.array(z.string()).optional(),
-  foreshadows: z.array(z.string()).optional(),
-  companions: CompanionsSchema.optional(),
-  rendered: z.array(RenderedAssetSchema).optional(),
-  meta: z.record(z.string(), z.unknown()).optional(),
-  // GRANTED 2026-08-24 (bean folio-assistant-5nle). These four schemas are
-  // non-strict, so a block declaring `authorNotes` had the key silently
-  // stripped and the note was neither rendered nor reported. See
-  // `BlockBase.authorNotes` in schemas/types.ts.
-  authorNotes: z.array(AuthorNoteSchema).optional(),
-
 });
 
-export const EquationSchema = z.object({
+export const EquationSchema = BlockBaseSchema.extend({
   kind: z.literal("equation"),
   label: labelForKind("equation").optional(),
-  title: z.string().optional(),
   tex: z.string().optional(),
-  tags: z.array(z.string()).optional(),
-  uses: z.array(z.string()).optional(),
-  foreshadows: z.array(z.string()).optional(),
-  companions: CompanionsSchema.optional(),
-  rendered: z.array(RenderedAssetSchema).optional(),
-  meta: z.record(z.string(), z.unknown()).optional(),
-  // GRANTED 2026-08-24 (bean folio-assistant-5nle). These four schemas are
-  // non-strict, so a block declaring `authorNotes` had the key silently
-  // stripped and the note was neither rendered nor reported. See
-  // `BlockBase.authorNotes` in schemas/types.ts.
-  authorNotes: z.array(AuthorNoteSchema).optional(),
-
 });
 
-export const DiagramSchema = z.object({
+export const DiagramSchema = BlockBaseSchema.extend({
   kind: z.literal("diagram"),
   label: labelForKind("diagram").optional(),
-  title: z.string().optional(),
   tex: z.string().optional(),
   caption: z.string().optional(),
-  tags: z.array(z.string()).optional(),
-  uses: z.array(z.string()).optional(),
-  foreshadows: z.array(z.string()).optional(),
-  companions: CompanionsSchema.optional(),
-  rendered: z.array(RenderedAssetSchema).optional(),
-  meta: z.record(z.string(), z.unknown()).optional(),
-  // GRANTED 2026-08-24 (bean folio-assistant-5nle). These four schemas are
-  // non-strict, so a block declaring `authorNotes` had the key silently
-  // stripped and the note was neither rendered nor reported. See
-  // `BlockBase.authorNotes` in schemas/types.ts.
-  authorNotes: z.array(AuthorNoteSchema).optional(),
-
 });
 
-export const TableSchema = z.object({
+export const TableSchema = BlockBaseSchema.extend({
   kind: z.literal("table"),
   label: labelForKind("table").optional(),
   tex: z.string().optional(),
   caption: z.string().optional(),
-  title: z.string().optional(),
-  tags: z.array(z.string()).optional(),
-  uses: z.array(z.string()).optional(),
-  foreshadows: z.array(z.string()).optional(),
-  computation: ComputationSchema.optional(),
-  companions: CompanionsSchema.optional(),
-  rendered: z.array(RenderedAssetSchema).optional(),
-  meta: z.record(z.string(), z.unknown()).optional(),
-  // GRANTED 2026-08-24 (bean folio-assistant-5nle). These four schemas are
-  // non-strict, so a block declaring `authorNotes` had the key silently
-  // stripped and the note was neither rendered nor reported. See
-  // `BlockBase.authorNotes` in schemas/types.ts.
-  authorNotes: z.array(AuthorNoteSchema).optional(),
 });
 
 /** Discriminated union — validates any Block. */

--- a/schemas/types.ts
+++ b/schemas/types.ts
@@ -940,151 +940,77 @@ export interface SimulatorBlock extends BlockBase {
 // ── Prose (non-environment content) ──────────────────────────────
 
 /**
+ * The four kinds below — `prose`, `equation`, `diagram`, `table` — differ
+ * from the other eleven only in that their `label` is OPTIONAL. Everything
+ * else they carry is `BlockBase`, so they extend it (minus `label`) rather
+ * than restating it.
+ *
+ * ## They used to restate it, and restating is how they kept losing fields
+ *
+ * Each was a standalone interface listing its own field set, and the set was
+ * always a little behind. The record is in the field comments this change
+ * replaces: `EquationBlock` was the only member of the `Block` union with
+ * neither `uses` nor a base supplying it; `tags` was in the Zod schema and
+ * not the type; then on 2026-08-24 `authorNotes` had to be granted to all
+ * four by hand (bean `folio-assistant-5nle`), after qou #5115 found five
+ * real author notes being discarded.
+ *
+ * That grant fixed the field it was about and left the mechanism in place.
+ * Measured after it, `defines` was still absent from all four, and `cites`,
+ * `simulator` and `computation` from three. A Zod object is non-strict, so
+ * each of those was accepted at authoring time and silently stripped.
+ *
+ * `defines` is the one that bites: AGENTS.md §4c requires every glossary
+ * term to be declared in `defines[]`, and the `defterm-declared` rule reads
+ * that array — so a `table` or `prose` block introducing a term could not
+ * declare it at all, and the omission looked like an authoring choice.
+ *
+ * The identical defect has a scar two hundred lines down: see `BLOCK_KINDS`,
+ * where `algorithm` and `table` reached the union and never reached five
+ * hand-maintained copies of it, excluding 461 qou blocks — 13% of the corpus
+ * — from every sweep. Restating a set that already exists is the shared
+ * cause, and `_blockKindsAreExhaustive` is the fix that was applied there.
+ *
+ * Extending is the same fix here: a field added to `BlockBase` now reaches
+ * these four, and cannot be forgotten one at a time.
+ */
+type OptionalLabelBlockBase = Omit<BlockBase, "label">;
+
+/**
  * Freeform narrative text between environments.
  * Content lives entirely in the sibling .md file.
  */
-export interface ProseBlock {
+export interface ProseBlock extends OptionalLabelBlockBase {
   kind: "prose";
-  /** Optional label for cross-referencing. */
-  label?: string;
-  /** Optional section-style title rendered as a paragraph heading. */
-  title?: string;
-  /** Labels of content blocks this prose depends on (for the dependency graph). */
-  uses?: string[];
-  /** Subset of `uses[]` that points deliberately forward — see `BlockBase.foreshadows`. */
-  foreshadows?: string[];
-  /** Bibliography keys cited by this block. */
-  cites?: string[];
-  tags?: string[];
-  companions?: Companions;
-  /** Pre-rendered assets for ```tex blocks. */
-  rendered?: RenderedAsset[];
-  meta?: Record<string, unknown>;
   /**
-   * Author-tracking notes — see `BlockBase.authorNotes` for the full
-   * contract and the `kind` taxonomy.
-   *
-   * GRANTED 2026-08-24. `prose`, `equation`, `diagram` and `table` do not
-   * extend `BlockBase`; they are standalone interfaces with deliberately
-   * small field sets, and this one was simply missing from all four. The
-   * Zod schemas are non-strict, so a block declaring it had the key
-   * SILENTLY STRIPPED before anything downstream saw it -- the note was
-   * neither rendered, nor validated, nor reported, and the author had no
-   * way to tell. Five real notes were being discarded that way in qou
-   * (`fine-structure-data`, `tm-interaction-completeness`,
-   * `millennium-bounds-via-surreals-intro`,
-   * `hecke-log-decomposition-table-data`,
-   * `q-beta-form-a-n1-symbolic-table-data`); qou #5115 found them and
-   * deliberately left them, because deleting the key destroys authored
-   * prose and granting the field is a schema decision.
-   *
-   * There is no reason a standalone kind cannot carry one: an author note
-   * is editorial metadata ABOUT a block, not content within it, and the
-   * render default is SKIP either way. Same shape of fix as the earlier
-   * `uses`/`tags` pass recorded on `EquationBlock.uses`.
+   * Optional, and free-form: prose labels are not required to carry a
+   * `kind:` prefix, unlike every other labelled block.
    */
-  authorNotes?: AuthorNote[];
-
+  label?: string;
 }
 
 // ── Display math / equations ─────────────────────────────────────
 
 /** Standalone display equation. Short TeX can live inline; complex in .md. */
-export interface EquationBlock {
+export interface EquationBlock extends OptionalLabelBlockBase {
   kind: "equation";
   /** Equation label (e.g. "eq:snake-identities"). */
   label?: string;
-  /** Optional display title. */
-  title?: string;
-  tags?: string[];
-  /** Editorial dependencies — see `BlockBase.uses`. Equation was the ONLY
-   *  member of the `Block` union carrying neither `uses` nor a base that
-   *  supplies it; its three standalone siblings (`prose`, `diagram`, `table`)
-   *  all declare it. `tags` was likewise present in the Zod schema and absent
-   *  here. */
-  uses?: string[];
-  /** Subset of `uses[]` that points deliberately forward — see `BlockBase.foreshadows`. */
-  foreshadows?: string[];
   /** Inline TeX for the equation (short enough to live in .ts). */
   tex?: string;
-  companions?: Companions;
-  /** Pre-rendered equation (e.g. SVG from MathJax/KaTeX server). */
-  rendered?: RenderedAsset[];
-  meta?: Record<string, unknown>;
-  /**
-   * Author-tracking notes — see `BlockBase.authorNotes` for the full
-   * contract and the `kind` taxonomy.
-   *
-   * GRANTED 2026-08-24. `prose`, `equation`, `diagram` and `table` do not
-   * extend `BlockBase`; they are standalone interfaces with deliberately
-   * small field sets, and this one was simply missing from all four. The
-   * Zod schemas are non-strict, so a block declaring it had the key
-   * SILENTLY STRIPPED before anything downstream saw it -- the note was
-   * neither rendered, nor validated, nor reported, and the author had no
-   * way to tell. Five real notes were being discarded that way in qou
-   * (`fine-structure-data`, `tm-interaction-completeness`,
-   * `millennium-bounds-via-surreals-intro`,
-   * `hecke-log-decomposition-table-data`,
-   * `q-beta-form-a-n1-symbolic-table-data`); qou #5115 found them and
-   * deliberately left them, because deleting the key destroys authored
-   * prose and granting the field is a schema decision.
-   *
-   * There is no reason a standalone kind cannot carry one: an author note
-   * is editorial metadata ABOUT a block, not content within it, and the
-   * render default is SKIP either way. Same shape of fix as the earlier
-   * `uses`/`tags` pass recorded on `EquationBlock.uses`.
-   */
-  authorNotes?: AuthorNote[];
-
 }
 
 // ── Diagrams ─────────────────────────────────────────────────────
 
 /** Commutative diagram or figure. Source is tikzcd or other diagram TeX. */
-export interface DiagramBlock {
+export interface DiagramBlock extends OptionalLabelBlockBase {
   kind: "diagram";
   /** Diagram label (e.g. "fig:monoidal-structure"). */
   label?: string;
-  /** Optional display title (rendered as a figure heading). */
-  title?: string;
   /** tikzcd or diagram TeX source (can live inline for short diagrams). */
   tex?: string;
   /** Caption text (rendered below diagram in LaTeX). */
   caption?: string;
-  tags?: string[];
-  /** Labels of content blocks this diagram depends on (for the dependency graph). */
-  uses?: string[];
-  /** Subset of `uses[]` that points deliberately forward — see `BlockBase.foreshadows`. */
-  foreshadows?: string[];
-  companions?: Companions;
-  /** Pre-rendered diagram (e.g. SVG from tikzcd server-side render). */
-  rendered?: RenderedAsset[];
-  meta?: Record<string, unknown>;
-  /**
-   * Author-tracking notes — see `BlockBase.authorNotes` for the full
-   * contract and the `kind` taxonomy.
-   *
-   * GRANTED 2026-08-24. `prose`, `equation`, `diagram` and `table` do not
-   * extend `BlockBase`; they are standalone interfaces with deliberately
-   * small field sets, and this one was simply missing from all four. The
-   * Zod schemas are non-strict, so a block declaring it had the key
-   * SILENTLY STRIPPED before anything downstream saw it -- the note was
-   * neither rendered, nor validated, nor reported, and the author had no
-   * way to tell. Five real notes were being discarded that way in qou
-   * (`fine-structure-data`, `tm-interaction-completeness`,
-   * `millennium-bounds-via-surreals-intro`,
-   * `hecke-log-decomposition-table-data`,
-   * `q-beta-form-a-n1-symbolic-table-data`); qou #5115 found them and
-   * deliberately left them, because deleting the key destroys authored
-   * prose and granting the field is a schema decision.
-   *
-   * There is no reason a standalone kind cannot carry one: an author note
-   * is editorial metadata ABOUT a block, not content within it, and the
-   * render default is SKIP either way. Same shape of fix as the earlier
-   * `uses`/`tags` pass recorded on `EquationBlock.uses`.
-   */
-  authorNotes?: AuthorNote[];
-
 }
 
 /**
@@ -1093,7 +1019,7 @@ export interface DiagramBlock {
  * rather than inlined in a remark or proposition, so they can be
  * labelled and cross-referenced independently.
  */
-export interface TableBlock {
+export interface TableBlock extends OptionalLabelBlockBase {
   kind: "table";
   /** Table label (e.g. "tbl:mass-predictions"). */
   label?: string;
@@ -1101,44 +1027,6 @@ export interface TableBlock {
   tex?: string;
   /** Caption text (rendered above table in LaTeX). */
   caption?: string;
-  /** Title for the table (rendered as bold header). */
-  title?: string;
-  tags?: string[];
-  /** Blocks that this table summarises data from. */
-  uses?: string[];
-  /** Subset of `uses[]` that points deliberately forward — see `BlockBase.foreshadows`. */
-  foreshadows?: string[];
-  /** Witness/script the table values are derived from (mirrors RemarkBlock).
-   *  Lets tables that cite `:val[…]` literals declare the upstream witness
-   *  dep, same as remark/proof/definition blocks. */
-  computation?: Computation;
-  companions?: Companions;
-  rendered?: RenderedAsset[];
-  meta?: Record<string, unknown>;
-  /**
-   * Author-tracking notes — see `BlockBase.authorNotes` for the full
-   * contract and the `kind` taxonomy.
-   *
-   * GRANTED 2026-08-24. `prose`, `equation`, `diagram` and `table` do not
-   * extend `BlockBase`; they are standalone interfaces with deliberately
-   * small field sets, and this one was simply missing from all four. The
-   * Zod schemas are non-strict, so a block declaring it had the key
-   * SILENTLY STRIPPED before anything downstream saw it -- the note was
-   * neither rendered, nor validated, nor reported, and the author had no
-   * way to tell. Five real notes were being discarded that way in qou
-   * (`fine-structure-data`, `tm-interaction-completeness`,
-   * `millennium-bounds-via-surreals-intro`,
-   * `hecke-log-decomposition-table-data`,
-   * `q-beta-form-a-n1-symbolic-table-data`); qou #5115 found them and
-   * deliberately left them, because deleting the key destroys authored
-   * prose and granting the field is a schema decision.
-   *
-   * There is no reason a standalone kind cannot carry one: an author note
-   * is editorial metadata ABOUT a block, not content within it, and the
-   * render default is SKIP either way. Same shape of fix as the earlier
-   * `uses`/`tags` pass recorded on `EquationBlock.uses`.
-   */
-  authorNotes?: AuthorNote[];
 }
 
 // ── The discriminated union ──────────────────────────────────────

--- a/scripts/tests/block-base-fields.test.ts
+++ b/scripts/tests/block-base-fields.test.ts
@@ -40,10 +40,21 @@ import { BLOCK_KINDS } from "../../schemas/types";
  * `BlockSchema` is `z.discriminatedUnion(...).superRefine(...)`, i.e. a
  * `ZodEffects` wrapping the union. Unwrap rather than importing the fifteen
  * schemas by name, so a kind added later is covered without editing this file.
+ *
+ * Asserted STRUCTURALLY — `{ innerType(): { options: … } }` — rather than
+ * through `z.ZodEffects<z.ZodDiscriminatedUnion<…>>`. Naming zod's own
+ * generics looks tighter and is not: `ZodDiscriminatedUnionOption<"kind">`
+ * requires the shape to be `{ kind: ZodTypeAny } & ZodRawShape`, which a bare
+ * `ZodObject<ZodRawShape>` does not satisfy, so the "precise" spelling is a
+ * `tsc` error (TS2344) while proving nothing extra at runtime. The runtime
+ * checks below are what establish the shape — including the first test, which
+ * fails unless every `BLOCK_KINDS` member turns up here.
  */
-const union = (BlockSchema as unknown as z.ZodEffects<z.ZodDiscriminatedUnion<"kind", z.ZodObject<z.ZodRawShape>[]>>)
-  .innerType();
-const options = union.options as z.ZodObject<z.ZodRawShape>[];
+const options: z.ZodObject<z.ZodRawShape>[] = (
+  BlockSchema as unknown as {
+    innerType(): { options: z.ZodObject<z.ZodRawShape>[] };
+  }
+).innerType().options;
 
 const shapeOf = (schema: z.ZodObject<z.ZodRawShape>) => Object.keys(schema.shape);
 

--- a/scripts/tests/block-base-fields.test.ts
+++ b/scripts/tests/block-base-fields.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Every block schema must carry every field of `BlockBaseSchema`.
+ *
+ * Four kinds — `prose`, `equation`, `diagram`, `table` — used to RESTATE the
+ * base fields instead of extending the base, and restating is how they kept
+ * losing fields. A Zod object is non-strict, so a block declaring a field its
+ * schema had forgotten was accepted at authoring time and the key was
+ * SILENTLY STRIPPED: no error, no warning, nothing downstream ever saw it.
+ *
+ * The history is a sequence of one-field repairs, each of which fixed its
+ * field and left the mechanism:
+ *
+ *   - `EquationBlock` was the only member of the union with neither `uses`
+ *     nor a base supplying it; `tags` was in the Zod schema and not the type.
+ *   - 2026-08-24 (bean `folio-assistant-5nle`): `authorNotes` granted to all
+ *     four by hand, after qou #5115 found five real author notes discarded.
+ *   - Measured after that grant: `defines` was still absent from all four,
+ *     and `cites`, `simulator` and `computation` from three. One live qou
+ *     block was affected — `prose:knot-periodic-table` declared a
+ *     `computation` and had it dropped.
+ *
+ * `defines` was the sharp one: qou's AGENTS.md §4c REQUIRES every glossary
+ * term to be declared in `defines[]`, and the `defterm-declared` rule reads
+ * that array — so on those four kinds a term could not be declared at all,
+ * and the omission was indistinguishable from an authoring choice.
+ *
+ * This is the same defect `block-kinds.test.ts` exists for, one level down:
+ * there, five hand-maintained copies of the kind list each missed the same
+ * two kinds and 461 qou blocks went unswept. Restating a set that already
+ * exists is the shared cause. That one is guarded by `BLOCK_KINDS` plus a
+ * compile-time exhaustiveness assertion; this is the runtime guard for the
+ * field set, and it is a runtime one because Zod shapes are values.
+ */
+import { describe, test, expect } from "bun:test";
+import { z } from "zod";
+import { BlockBaseSchema, BlockSchema } from "../../schemas/constraints";
+import { BLOCK_KINDS } from "../../schemas/types";
+
+/**
+ * `BlockSchema` is `z.discriminatedUnion(...).superRefine(...)`, i.e. a
+ * `ZodEffects` wrapping the union. Unwrap rather than importing the fifteen
+ * schemas by name, so a kind added later is covered without editing this file.
+ */
+const union = (BlockSchema as unknown as z.ZodEffects<z.ZodDiscriminatedUnion<"kind", z.ZodObject<z.ZodRawShape>[]>>)
+  .innerType();
+const options = union.options as z.ZodObject<z.ZodRawShape>[];
+
+const shapeOf = (schema: z.ZodObject<z.ZodRawShape>) => Object.keys(schema.shape);
+
+const kindOf = (schema: z.ZodObject<z.ZodRawShape>): string => {
+  const lit = schema.shape.kind as z.ZodLiteral<string>;
+  return lit.value;
+};
+
+describe("block schemas vs BlockBaseSchema", () => {
+  test("the union reaches every kind, so nothing escapes the check below", () => {
+    // Without this, a kind added to BLOCK_KINDS but not to the union would
+    // simply not be tested — the exact way the previous defects survived.
+    expect(options.map(kindOf).sort()).toEqual([...BLOCK_KINDS].sort());
+  });
+
+  const baseKeys = shapeOf(BlockBaseSchema);
+
+  test("BlockBaseSchema still carries the fields this guard is about", () => {
+    // Pins the guard to something falsifiable: if `defines` or `authorNotes`
+    // is ever renamed, this fails here rather than passing vacuously.
+    for (const key of ["authorNotes", "defines", "cites", "simulator", "computation", "uses"]) {
+      expect(baseKeys).toContain(key);
+    }
+  });
+
+  for (const schema of options) {
+    const kind = kindOf(schema);
+    test(`${kind} declares every base field`, () => {
+      const keys = new Set(shapeOf(schema));
+      const missing = baseKeys.filter((k) => !keys.has(k));
+      expect(missing).toEqual([]);
+    });
+  }
+});
+
+describe("the four optional-label kinds accept what they used to drop", () => {
+  // Parses rather than inspecting shapes: a field present in the shape but
+  // typed wrongly would still drop the value, and the shape check above
+  // cannot see that.
+  const cases: Array<[string, Record<string, unknown>]> = [
+    ["prose", { kind: "prose", label: "prose:x" }],
+    ["equation", { kind: "equation", label: "eq:x" }],
+    ["diagram", { kind: "diagram", label: "fig:x" }],
+    ["table", { kind: "table", label: "tbl:x" }],
+  ];
+
+  for (const [kind, stub] of cases) {
+    test(kind, () => {
+      const authored = {
+        ...stub,
+        cites: ["someref2020"],
+        defines: ["some-term"],
+        authorNotes: [{ kind: "note" as const, body: "kept" }],
+        computation: {
+          engine: "python" as const,
+          script: "computations/x.py",
+          status: "not_run" as const,
+        },
+      };
+      const parsed = BlockSchema.parse(authored) as Record<string, unknown>;
+      for (const key of ["cites", "defines", "authorNotes", "computation"]) {
+        expect(parsed[key]).toBeDefined();
+      }
+    });
+  }
+});

--- a/scripts/tests/schema-ts-zod-parity.test.ts
+++ b/scripts/tests/schema-ts-zod-parity.test.ts
@@ -57,8 +57,35 @@ function interfaces(src: string): Map<string, { ext?: string; fields: Set<string
 
 const ifaces = interfaces(tsSrc);
 
+/**
+ * `type X = Omit<Y, "a" | "b">;` aliases, keyed by name.
+ *
+ * `prose`, `equation`, `diagram` and `table` extend `BlockBase` through one of
+ * these, because their `label` is optional where the base's is required and
+ * TS rejects a direct `extends` that loosens a property. Without following the
+ * alias, `tsFields` returns only each interface's OWN four or five fields and
+ * every inherited field reads as "in Zod, not in TS" — i.e. this test would
+ * fail on a tree where the drift it exists to catch had just been fixed.
+ * That is what it did.
+ */
+function omitAliases(src: string): Map<string, { from: string; omit: Set<string> }> {
+  const out = new Map<string, { from: string; omit: Set<string> }>();
+  for (const m of src.matchAll(/type (\w+) = Omit<(\w+),\s*([^>]*)>;/g)) {
+    const omit = new Set([...m[3].matchAll(/"(\w+)"/g)].map((k) => k[1]));
+    out.set(m[1], { from: m[2], omit });
+  }
+  return out;
+}
+
+const aliases = omitAliases(tsSrc);
+
 /** A block interface's fields, including everything it inherits. */
 function tsFields(name: string): Set<string> {
+  const alias = aliases.get(name);
+  if (alias) {
+    const inner = tsFields(alias.from);
+    return new Set([...inner].filter((f) => !alias.omit.has(f)));
+  }
   const entry = ifaces.get(name);
   if (!entry) return new Set();
   const inherited = entry.ext ? tsFields(entry.ext) : new Set<string>();


### PR DESCRIPTION
## The defect

`prose`, `equation`, `diagram` and `table` each listed their own field set rather than extending `BlockBase` / `BlockBaseSchema`. A Zod object is non-strict, so a block declaring a field its schema had forgotten was **accepted at authoring time and the key silently stripped** — no error, no warning, nothing downstream ever saw it.

Restating is how they kept losing fields, and the history is in this file's own comments: `EquationBlock` was once the only member of the union with neither `uses` nor a base supplying it; `tags` was in the Zod schema and not the TS; then on 2026-08-24 (bean `folio-assistant-5nle`) `authorNotes` had to be granted to all four **by hand**, after qou #5115 found five real author notes being discarded.

Each of those fixed its field and left the mechanism in place.

## Measured after that grant

| field | missing from |
|---|---|
| `defines` | all four |
| `cites` | equation, diagram, table |
| `simulator` | prose, equation, diagram |
| `computation` | prose, equation, diagram |

One live block is affected today: **`prose:knot-periodic-table`** in qou declares a `computation` and has it dropped. qou's validate reports 6 `Unknown field` warnings; that is the only one caused by a schema gap. The other five are invented names (`is_mathematics` ×3, `probe`, `consumers`) and are fixed on the qou side in litlfred/qou#6501.

**`defines` is the one that would have bitten hardest.** qou's AGENTS.md §4c *requires* every glossary term to be declared in `defines[]`, and the `defterm-declared` rule reads that array — so on these four kinds a term could not be declared at all, and the omission was indistinguishable from an authoring choice. Nothing in the corpus exercises it yet, which is why it was still there a week after a pass that was specifically looking at these four schemas.

The identical defect has a scar two hundred lines down in `types.ts`: `BLOCK_KINDS`, where `algorithm` and `table` reached the union and never reached five hand-maintained copies of it, excluding **461 qou blocks — 13% of the corpus** — from every sweep. Restating a set that already exists is the shared cause.

## The change

The four now extend the base. TS cannot loosen a property through `extends` (`BlockBase.label` is required, these four are optional), so they extend `Omit<BlockBase, "label">` via a named alias.

### The existing parity test failed on the fix, and that is a real gap

`schema-ts-zod-parity.test.ts` reads the source text and follows `interface X extends Y`. It does **not** follow a `type X = Omit<Y, …>` alias, so after the fix `tsFields` returned only each interface's own four or five fields and every inherited field read as *"in Zod, not in TS"* — 6 tests failed on a tree where the drift they exist to catch had just been repaired.

Taught it to resolve `Omit<>` aliases. This is not a workaround for the fix: a source-text walker that cannot see the construct the schemas use is reporting on something other than the schemas.

### New guard: `scripts/tests/block-base-fields.test.ts`

The companion to `block-kinds.test.ts`, one level down — that one guards the kind list, this guards the field set.

- Shape parity for **all 15 kinds** against `BlockBaseSchema`, derived by unwrapping `BlockSchema`'s union rather than importing schemas by name, so a kind added later is covered without editing the test.
- Asserts the union reaches every `BLOCK_KINDS` member, so a kind that never made it into the union cannot silently escape the check — the exact way the previous defects survived.
- **Round-trips a parse** as well as inspecting shapes: a field present in the shape but typed wrongly would still drop the value, and a shape check cannot see that.
- Pins itself to the field names it is about, so a rename fails loudly instead of passing vacuously.

## 🛑 Correcting the verification I first posted here

The first push **failed CI** — `TypeScript — tests, lint, types (hard)`, TS2344, on the new test file and nothing else. The original body claimed *"`bunx tsc --noEmit`: no new errors (the pre-existing ones are unresolved `csl-json` / `remark-html` / `fast-xml-parser` imports…)"*. **That was wrong, and the reason is worth recording:** `bun install` had never been run in this workspace, so 45 packages were absent and `tsc` reported five module-resolution errors that I read as the pre-existing baseline. With the dependencies installed, my file's error was the only one in the repo.

The defect itself is a small lesson in false precision. The unwrap was cast as `z.ZodEffects<z.ZodDiscriminatedUnion<"kind", z.ZodObject<z.ZodRawShape>[]>>`, which *looks* tighter than a structural assertion and is not: `ZodDiscriminatedUnionOption<"kind">` requires the shape to be `{ kind: ZodTypeAny } & ZodRawShape`, which a bare `ZodObject<ZodRawShape>` does not satisfy. So the "precise" spelling was a compile error proving nothing extra at runtime. Asserted structurally instead; what establishes the shape is the runtime check below it.

**Also corrected: the test-count line.** The original *"1219 pass / 23 fail → 1227 pass / 15 fail"* is a **local** measurement. Those failures are the Lean tactic-ladder suites, which need a toolchain this workspace lacks; **CI skips them and reports 0 fail.** The before/after comparison stands as a comparison — zero newly failing — but the absolute figures describe my container, not the repo.

Rebased onto `e7f5f55` while fixing this. Worth noting for anyone reading the first CI log: it showed only my error even though `content/pipeline/q-usage-audit.ts` had a genuine `paperFilterIdx` TS2552 at my base — because CI tests the **merge ref**, and main's `b2654c4` had already fixed it. A sibling hit the same crash.

## Verification

Run exactly as CI runs them, on the rebased tree, with dependencies installed:

- `bunx tsc --noEmit -p tsconfig.json` — **clean, zero errors.**
- `bun run lint` (`eslint .`) — **clean.**
- `bun test` — 1349 pass, 45 skip, **7 fail**, and all 7 are the Lean tactic-ladder suites that CI **skips** (they appear in CI's own skip list). None touches block schemas. CI's run on the previous head: **1352 pass, 59 skip, 0 fail.**
- **The new guard is falsifiable**, verified by stashing only the two schema files and re-running: exactly the 8 tests about these four kinds fail, and all 21 pass with the fix.
- qou `scripts/run-validate.ts content/quantum-observable-universe`: exit 0, `Unknown field` **6 → 5**.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqUzmZ9M7v8z1Wdw9FhzuD