### PR TITLE
readme_audit: verify the links an author wrote, don't generate over them

### DIFF
--- a/.beans/folio-assistant-rlnk--the-readme-tables-that-are-not-generated-are-unver.md
+++ b/.beans/folio-assistant-rlnk--the-readme-tables-that-are-not-generated-are-unver.md
@@ -1,0 +1,38 @@
+---
+# folio-assistant-rlnk
+title: The README tables that are not generated are unverified — nothing checks a link the author typed
+status: in-progress
+type: task
+priority: normal
+created_at: 2026-09-05T08:55:00Z
+updated_at: 2026-09-05T08:55:00Z
+---
+
+Third in the line after `rtoc` and `rmsy`. Those two made the *generated*
+sections verify their own links. Everything else in a folio README is authored
+Markdown, and nothing checks it at all.
+
+## The evidence that this is a real class, not a hypothetical
+
+qou's Published Artefacts table listed `blueprint/` and `docs/`. Neither has
+ever existed on `gh-pages` — the Lean documentation is published at
+`lean/docs/`. Both rows were dead in *both* columns and had been for as long
+as anyone had looked, in a table nobody could regenerate. I removed them by
+hand in #5974; nothing stops the next two from appearing.
+
+Its Project Structure table has the same shape: hand-maintained repo paths,
+never checked against the repo.
+
+## Why an audit rather than a sixth section
+
+A generator would have to invent the labels ("Folio landing page", "Blueprint
+(interactive graph)") and the path descriptions, which are authored prose and
+worth keeping. The defect in both tables was never staleness of layout — it was
+targets that do not resolve. So verify what the author wrote instead of
+replacing it.
+
+`readme_audit`: parse every Markdown link, resolve relative paths against the
+working tree and repo-internal links against the ref they name (`gh-pages` via
+the same listing `folio:toc` uses), report the dead ones with line numbers.
+Never rewrites. Keeps the third state: a ref that cannot be read makes its
+links **unchecked**, never dead.

--- a/.beans/folio-assistant-rlnk--the-readme-tables-that-are-not-generated-are-unver.md
+++ b/.beans/folio-assistant-rlnk--the-readme-tables-that-are-not-generated-are-unver.md
@@ -1,11 +1,11 @@
 ---
 # folio-assistant-rlnk
 title: The README tables that are not generated are unverified — nothing checks a link the author typed
-status: in-progress
+status: completed
 type: task
 priority: normal
 created_at: 2026-09-05T08:55:00Z
-updated_at: 2026-09-05T08:55:00Z
+updated_at: 2026-09-05T09:05:00Z
 ---
 
 Third in the line after `rtoc` and `rmsy`. Those two made the *generated*
@@ -36,3 +36,26 @@ working tree and repo-internal links against the ref they name (`gh-pages` via
 the same listing `folio:toc` uses), report the dead ones with line numbers.
 Never rewrites. Keeps the third state: a ref that cannot be read makes its
 links **unchecked**, never dead.
+
+## Landed
+
+- fa #165 — `content/pipeline/readme-links.ts`, `readme_audit` MCP tool,
+  `bun run readme:audit`. 15 tests; full suite 1360/0; tsc and eslint clean.
+- qou #6796 — the one dead link it found, plus two code-span siblings.
+
+## It paid for itself on the first run
+
+qou: 83 links checked, one dead — `tools/witness-schema/`, a package that lives
+at `schemas/witness-schema/`. Added to the README *after* the two PRs that
+cleaned up the artefacts table, which is the point: the class regenerates, so
+the check has to be standing rather than a one-off sweep.
+
+This repo's own README: 16 checked, 16 resolve.
+
+## Known gap, deliberately not closed
+
+The audit sees links. Two of the three wrong `tools/witness-schema/` paths were
+code spans, invisible to it. Widening to code spans means guessing which
+`foo/bar` strings are paths — globs, module names and shell fragments all look
+alike — so it is a heuristic, and a false positive in a link checker is what
+gets the checker turned off.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,7 @@ bun run init-folio --help           # scaffold a new folio repository
 bun run readme:sync                 # refresh a folio README's generated sections
 bun run readme:sync:check           # ...and fail if any is stale (for CI)
 bun run readme:sections             # list the sections a README can opt into
+bun run readme:audit                # verify the README's links still resolve
 ```
 
 ## Work-plan & todos — use `beans`
@@ -254,6 +255,25 @@ the table saying who can follow its links.
 for `--list`, and a renderer returning Markdown plus operator notes. The CLI,
 the MCP tool and the staleness check all read the registry, so nothing else
 needs touching.
+
+**The authored half is audited, not generated.** `readme_audit` /
+`bun run readme:audit` (`content/pipeline/readme-links.ts`) verifies every
+Markdown link in the file and writes nothing: relative paths against the
+working tree, links naming one of the repo's own refs against a real
+`git ls-tree` of that ref, and Pages URLs under the folio's `pagesBaseUrl`
+against the publish ref the site is served from. Between the two tools no link
+in a folio README is unaccounted for — sync owns the marked regions, audit
+checks everything else.
+
+It exists because generating the rest was the wrong instinct. qou's Published
+Artefacts table listed `blueprint/` and `docs/`, neither of which has ever
+existed on `gh-pages`; both rows were dead in both columns. But its labels —
+"Folio landing page", "Blueprint (interactive graph)", the Project Structure
+descriptions — are prose worth keeping, and a generator would have had to
+invent them. The defect was never a stale layout; it was targets that do not
+resolve. **Third state again:** an external host, an in-page anchor, and a ref
+this checkout cannot read are all reported as NOT CHECKED, never as dead, so a
+shallow clone does not produce a wall of false findings.
 
 ## CI health — a red workflow looks exactly like a green one from in here
 

--- a/adapters/document/index.ts
+++ b/adapters/document/index.ts
@@ -47,6 +47,7 @@ import { registerPreviewTools } from "../../src/tools/preview.js";
 import { registerSkillFetchTools } from "../../src/tools/skill-fetch.js";
 import { registerFolioInitTools } from "../../src/tools/folio-init.js";
 import { registerReadmeSyncTools } from "../../src/tools/readme-sync.js";
+import { registerReadmeAuditTools } from "../../src/tools/readme-audit.js";
 
 import type {
   ContentAdapter,
@@ -1073,6 +1074,10 @@ End every response with suggested follow-ups:
     // type, so the generated sections are generic too. A document folio simply
     // never carries the Lean markers, so those sections never render.
     registerReadmeSyncTools(server);
+    // Its read-only half: sync owns the generated regions, audit checks the
+    // links the author wrote. Between them nothing in the file is unaccounted
+    // for.
+    registerReadmeAuditTools(server);
   }
 
   /**

--- a/content/pipeline/readme-links.ts
+++ b/content/pipeline/readme-links.ts
@@ -1,0 +1,302 @@
+#!/usr/bin/env bun
+/**
+ * readme-links.ts — verify the links a README already carries.
+ *
+ * ## Why an audit and not a sixth generated section
+ *
+ * `readme-sections.ts` made the *generated* parts of a folio README verify
+ * their own targets. Everything else in the file is authored Markdown, and
+ * nothing checked it at all — which is how qou's Published Artefacts table
+ * came to list `blueprint/` and `docs/`, neither of which has ever existed on
+ * `gh-pages` (the Lean documentation is published at `lean/docs/`). Both rows
+ * were dead in both columns, in a table nobody could regenerate.
+ *
+ * Generating that table instead would mean inventing its labels — "Folio
+ * landing page", "Blueprint (interactive graph)", the Project Structure
+ * descriptions — which are prose worth keeping. The defect was never the
+ * layout going stale; it was targets that do not resolve. So this verifies
+ * what the author wrote and never rewrites a byte of it.
+ *
+ * ## What "checked" means, and the third state
+ *
+ * A link is only reported dead when this could actually look. A relative path
+ * is resolved against the working tree; a link naming one of the repo's own
+ * refs is resolved against a real `git ls-tree` of that ref; a GitHub Pages
+ * URL under the folio's configured `pagesBaseUrl` is resolved against the
+ * publish ref, because that is the branch the site is served from.
+ *
+ * Everything else — an external host, a bare `#anchor`, a `mailto:` — is
+ * **unchecked**, and so is any repo ref this checkout cannot read. Unchecked
+ * is reported separately and never counted as dead, the same rule the contents
+ * table follows for an unreadable publish ref: not-looked-at must not read as
+ * nothing-found.
+ *
+ * @module content/pipeline/readme-links
+ */
+
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+
+import { loadReadmeConfig, detectRepoUrl, publishedPaths } from "./readme-toc";
+import { findContentRepoRoot } from "./repo-root";
+
+// ── Findings ────────────────────────────────────────────────────────────────
+
+export interface LinkRef {
+  /** 1-based line in the source file. */
+  line: number;
+  /** The link text, for identifying the row a reader must fix. */
+  text: string;
+  /** The raw target as written. */
+  target: string;
+}
+
+export interface DeadLink extends LinkRef {
+  /** What was looked for and where. */
+  reason: string;
+}
+
+export interface AuditResult {
+  checked: number;
+  ok: number;
+  dead: DeadLink[];
+  /** Why links were not checked, and how many of each. */
+  unchecked: Record<string, number>;
+}
+
+// ── Parsing ─────────────────────────────────────────────────────────────────
+
+/**
+ * Blank out fenced code blocks, preserving line count.
+ *
+ * A README's shell examples are full of brackets and parentheses, and a
+ * command is not a link. Blanking rather than deleting keeps every reported
+ * line number pointing at the line a reader will actually open.
+ */
+function stripFences(src: string): string[] {
+  const lines = src.split("\n");
+  let inFence = false;
+  return lines.map((line) => {
+    if (/^\s*(```|~~~)/.test(line)) {
+      inFence = !inFence;
+      return "";
+    }
+    return inFence ? "" : line;
+  });
+}
+
+/**
+ * Every Markdown link in the file: inline `[text](target)` and reference
+ * definitions `[id]: target`.
+ *
+ * Images (`![alt](src)`) count too — a broken image is a broken link, and the
+ * one thing a reader cannot miss.
+ */
+export function parseLinks(src: string): LinkRef[] {
+  const out: LinkRef[] = [];
+  const lines = stripFences(src);
+
+  lines.forEach((line, i) => {
+    // Inline: [text](target) or [text](target "title"). The target stops at
+    // whitespace so a title does not become part of the path.
+    for (const m of line.matchAll(/!?\[([^\]]*)\]\(\s*([^)\s]+)(?:\s+"[^"]*")?\s*\)/g)) {
+      out.push({ line: i + 1, text: m[1], target: m[2] });
+    }
+    // Reference definition: [id]: target
+    const def = line.match(/^\s{0,3}\[([^\]]+)\]:\s*(\S+)/);
+    if (def) out.push({ line: i + 1, text: def[1], target: def[2] });
+  });
+  return out;
+}
+
+// ── Resolution ──────────────────────────────────────────────────────────────
+
+/** Strip the fragment and query, and percent-decode, leaving a repo path. */
+function toPath(target: string): string {
+  const bare = target.split("#")[0].split("?")[0];
+  try {
+    return decodeURIComponent(bare);
+  } catch {
+    return bare;
+  }
+}
+
+/** `owner/repo` from a repo web URL. */
+function ownerRepo(repoUrl: string): string | undefined {
+  return repoUrl.replace(/\/$/, "").match(/[^/]+\/[^/]+$/)?.[0];
+}
+
+/**
+ * Whether `path` names a file or a directory in a flat listing.
+ *
+ * `git ls-tree -r` lists files only, so a directory exists exactly when
+ * something sits under it — which is what a `tree/` link points at.
+ */
+function inListing(listing: Set<string>, path: string): boolean {
+  const clean = path.replace(/^\/+|\/+$/g, "");
+  if (clean === "") return true; // the root of the ref
+  if (listing.has(clean)) return true;
+  if (listing.has(`${clean}/index.html`)) return true;
+  const prefix = `${clean}/`;
+  for (const entry of listing) if (entry.startsWith(prefix)) return true;
+  return false;
+}
+
+interface Classified {
+  kind: "worktree" | "ref" | "unchecked";
+  path?: string;
+  ref?: string;
+  reason?: string;
+}
+
+/**
+ * Decide what, if anything, a target can be checked against.
+ *
+ * Exported because the classification *is* the interesting logic — a test
+ * that a Pages URL resolves against the publish ref is worth more than one
+ * asserting the reporter's wording.
+ */
+export function classify(
+  target: string,
+  opts: { repoUrl?: string; pagesBaseUrl?: string; publishRef: string },
+): Classified {
+  if (target.startsWith("#")) return { kind: "unchecked", reason: "in-page anchor" };
+  if (/^[a-z][a-z0-9+.-]*:/i.test(target) && !/^https?:/i.test(target)) {
+    return { kind: "unchecked", reason: "non-http scheme" };
+  }
+
+  if (/^https?:/i.test(target)) {
+    const repo = opts.repoUrl?.replace(/\/$/, "");
+    if (repo) {
+      // github.com/<owner>/<repo>/blob|tree|raw/<ref>/<path>
+      const esc = repo.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const m = target.match(new RegExp(`^${esc}/(?:blob|tree|raw)/([^/]+)/(.*)$`));
+      if (m) return { kind: "ref", ref: decodeURIComponent(m[1]), path: toPath(m[2]) };
+
+      const slug = ownerRepo(repo);
+      if (slug) {
+        const rawM = target.match(
+          new RegExp(`^https?://raw\\.githubusercontent\\.com/${slug}/([^/]+)/(.*)$`),
+        );
+        if (rawM) return { kind: "ref", ref: decodeURIComponent(rawM[1]), path: toPath(rawM[2]) };
+      }
+    }
+
+    const pages = opts.pagesBaseUrl?.replace(/\/$/, "");
+    if (pages && target.startsWith(pages)) {
+      // The Pages site is served from the publish ref, so that listing is the
+      // authority on whether the URL resolves.
+      return { kind: "ref", ref: opts.publishRef, path: toPath(target.slice(pages.length)) };
+    }
+
+    return { kind: "unchecked", reason: "external URL (not fetched)" };
+  }
+
+  return { kind: "worktree", path: toPath(target) };
+}
+
+// ── The audit ───────────────────────────────────────────────────────────────
+
+export function auditLinks(
+  root: string,
+  src: string,
+  opts: { repoUrl?: string; pagesBaseUrl?: string; publishRef: string; fetch?: boolean },
+): AuditResult {
+  const dead: DeadLink[] = [];
+  const unchecked: Record<string, number> = {};
+  let ok = 0;
+  let checked = 0;
+
+  // One listing per ref, computed on first use: `git ls-tree` over a published
+  // site is expensive enough that doing it per link would dominate the run.
+  const listings = new Map<string, Set<string> | undefined>();
+  const listingFor = (ref: string): Set<string> | undefined => {
+    if (!listings.has(ref)) listings.set(ref, publishedPaths(root, ref, opts.fetch ?? false));
+    return listings.get(ref);
+  };
+
+  const note = (reason: string) => {
+    unchecked[reason] = (unchecked[reason] ?? 0) + 1;
+  };
+
+  for (const link of parseLinks(src)) {
+    const c = classify(link.target, opts);
+
+    if (c.kind === "unchecked") {
+      note(c.reason ?? "unchecked");
+      continue;
+    }
+
+    if (c.kind === "worktree") {
+      checked++;
+      if (existsSync(join(root, c.path!))) ok++;
+      else dead.push({ ...link, reason: `no such path in the working tree: ${c.path}` });
+      continue;
+    }
+
+    const listing = listingFor(c.ref!);
+    if (!listing) {
+      // The ref is not readable here — a shallow clone that never fetched
+      // `gh-pages`, most often. Reporting these as dead would turn a clone
+      // detail into a wall of false findings.
+      note(`ref '${c.ref}' not readable in this checkout`);
+      continue;
+    }
+    checked++;
+    if (inListing(listing, c.path!)) ok++;
+    else dead.push({ ...link, reason: `not published at ${c.ref}: ${c.path}` });
+  }
+
+  return { checked, ok, dead, unchecked };
+}
+
+/** Shared by the CLI and the `readme_audit` MCP tool. */
+export function runReadmeAudit(opts: {
+  root?: string;
+  file?: string;
+  fetch?: boolean;
+}): { text: string; exitCode: number } {
+  const root = opts.root ?? findContentRepoRoot();
+  const cfg = loadReadmeConfig(root);
+  const file = opts.file ?? join(root, "README.md");
+  if (!existsSync(file)) return { text: `No file at ${file}.`, exitCode: 2 };
+
+  const result = auditLinks(root, readFileSync(file, "utf-8"), {
+    repoUrl: cfg.repoUrl ?? detectRepoUrl(root),
+    pagesBaseUrl: cfg.pagesBaseUrl,
+    publishRef: cfg.publishRef,
+    fetch: opts.fetch,
+  });
+
+  const lines: string[] = [];
+  for (const d of result.dead) {
+    lines.push(`${file}:${d.line}  [${d.text}](${d.target})`);
+    lines.push(`    ${d.reason}`);
+  }
+  const uncheckedTotal = Object.values(result.unchecked).reduce((a, b) => a + b, 0);
+  const summary =
+    `${result.checked} link(s) checked, ${result.ok} resolved, ${result.dead.length} dead; ` +
+    `${uncheckedTotal} not checked`;
+  lines.push(result.dead.length ? `\n${summary}` : summary);
+  for (const [reason, count] of Object.entries(result.unchecked).sort()) {
+    lines.push(`    ${count} × ${reason}`);
+  }
+
+  return { text: lines.join("\n"), exitCode: result.dead.length > 0 ? 1 : 0 };
+}
+
+if (import.meta.main) {
+  const argv = process.argv.slice(2);
+  const flag = (name: string): string | undefined => {
+    const i = argv.indexOf(`--${name}`);
+    return i >= 0 ? argv[i + 1] : undefined;
+  };
+  try {
+    const result = runReadmeAudit({ file: flag("file"), fetch: argv.includes("--fetch") });
+    (result.exitCode === 0 ? console.log : console.error)(result.text);
+    process.exit(result.exitCode);
+  } catch (e) {
+    console.error(e instanceof Error ? e.message : String(e));
+    process.exit(2);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "readme:sync": "bun run content/pipeline/readme-sections.ts",
     "readme:sync:check": "bun run content/pipeline/readme-sections.ts --check",
     "readme:sections": "bun run content/pipeline/readme-sections.ts --list",
+    "readme:audit": "bun run content/pipeline/readme-links.ts",
     "render:bpmn": "bun run scripts/render-bpmn.ts",
     "render:bpmn:check": "bun run scripts/render-bpmn.ts --check",
     "typecheck": "tsc --noEmit -p tsconfig.json"

--- a/scripts/tests/readme-links.test.ts
+++ b/scripts/tests/readme-links.test.ts
@@ -1,0 +1,213 @@
+/**
+ * `readme_audit` — link verification over authored README prose.
+ *
+ * The finding that motivated this: qou's Published Artefacts table listed
+ * `blueprint/` and `docs/`, neither of which has ever existed on `gh-pages`.
+ * Both rows were dead in both columns, in a hand-maintained table nobody could
+ * regenerate. So the tests worth having are the ones that pin *what counts as
+ * checked* — a Pages URL resolves against the publish ref, an unreadable ref
+ * makes its links unchecked rather than dead, and a shell example is not a
+ * link.
+ */
+import { describe, test, expect, afterEach } from "bun:test";
+import { execFileSync } from "child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { dirname, join } from "path";
+import { tmpdir } from "os";
+
+import {
+  auditLinks,
+  classify,
+  parseLinks,
+  runReadmeAudit,
+} from "../../content/pipeline/readme-links";
+
+const dirs: string[] = [];
+afterEach(() => {
+  while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true });
+});
+
+const OPTS = {
+  repoUrl: "https://github.com/owner/repo",
+  pagesBaseUrl: "https://owner.github.io/repo",
+  publishRef: "gh-pages",
+};
+
+/** A repo at a temp root, with `paths` present in the working tree. */
+function repo(paths: string[] = []): string {
+  const root = mkdtempSync(join(tmpdir(), "folio-links-"));
+  dirs.push(root);
+  for (const p of paths) {
+    mkdirSync(dirname(join(root, p)), { recursive: true });
+    writeFileSync(join(root, p), "x");
+  }
+  return root;
+}
+
+/** Give `root` a git repo whose branch `ref` holds `paths`. */
+function publish(root: string, ref: string, paths: string[]): void {
+  const env = {
+    ...process.env,
+    GIT_AUTHOR_NAME: "t", GIT_AUTHOR_EMAIL: "t@example.invalid",
+    GIT_COMMITTER_NAME: "t", GIT_COMMITTER_EMAIL: "t@example.invalid",
+  };
+  const g = (args: string[], extra: Record<string, string> = {}): string =>
+    execFileSync("git", ["-C", root, ...args], {
+      stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8", env: { ...env, ...extra },
+    }).trim();
+
+  g(["init", "-q", "-b", "main"]);
+  g(["remote", "add", "origin", "https://github.com/owner/repo.git"]);
+
+  const pub = mkdtempSync(join(tmpdir(), "folio-linkpub-"));
+  dirs.push(pub);
+  for (const p of paths) {
+    mkdirSync(dirname(join(pub, p)), { recursive: true });
+    writeFileSync(join(pub, p), "x");
+  }
+  const withIndex = { GIT_INDEX_FILE: join(pub, ".git-index"), GIT_WORK_TREE: pub };
+  execFileSync("git", ["--git-dir", join(root, ".git"), "--work-tree", pub, "add", "-A"], {
+    cwd: pub, stdio: ["ignore", "pipe", "pipe"], env: { ...env, ...withIndex },
+  });
+  const tree = g(["write-tree"], withIndex);
+  const commit = g(["commit-tree", tree, "-m", "publish"], withIndex);
+  g(["update-ref", `refs/heads/${ref}`, commit]);
+}
+
+describe("parsing", () => {
+  test("finds inline links, images and reference definitions, with line numbers", () => {
+    const links = parseLinks(
+      "# T\n\nSee [one](a.md) and ![img](b.png).\n\n[ref]: c.md\n",
+    );
+    expect(links).toEqual([
+      { line: 3, text: "one", target: "a.md" },
+      { line: 3, text: "img", target: "b.png" },
+      { line: 5, text: "ref", target: "c.md" },
+    ]);
+  });
+
+  test("a fenced shell example is not a link, and line numbers survive it", () => {
+    const links = parseLinks(
+      "# T\n\n```bash\nrun [thing](not-a-link)\n```\n\n[real](after.md)\n",
+    );
+    expect(links).toEqual([{ line: 7, text: "real", target: "after.md" }]);
+  });
+
+  test("a link title is not part of the target", () => {
+    expect(parseLinks('[x](a.md "Title")')[0].target).toBe("a.md");
+  });
+});
+
+describe("classification", () => {
+  test("a Pages URL resolves against the publish ref the site is served from", () => {
+    expect(classify("https://owner.github.io/repo/lean/docs/", OPTS)).toEqual({
+      kind: "ref", ref: "gh-pages", path: "/lean/docs/",
+    });
+  });
+
+  test("blob, tree and raw links name their own ref", () => {
+    for (const url of [
+      "https://github.com/owner/repo/blob/gh-pages/a.pdf",
+      "https://github.com/owner/repo/tree/gh-pages/a.pdf",
+      "https://raw.githubusercontent.com/owner/repo/gh-pages/a.pdf",
+    ]) {
+      expect(classify(url, OPTS)).toMatchObject({ kind: "ref", ref: "gh-pages", path: "a.pdf" });
+    }
+    // A ref that is not the publish ref is honoured as written.
+    expect(classify("https://github.com/owner/repo/blob/main/src/x.ts", OPTS))
+      .toMatchObject({ ref: "main", path: "src/x.ts" });
+  });
+
+  test("another repo, an anchor and a mailto are unchecked, not dead", () => {
+    for (const t of [
+      "https://github.com/someone/else/blob/main/x.md",
+      "https://example.com/",
+      "#a-heading",
+      "mailto:someone@example.invalid",
+    ]) {
+      expect(classify(t, OPTS).kind).toBe("unchecked");
+    }
+  });
+
+  test("fragments and percent-encoding are stripped from the path", () => {
+    expect(classify("docs/a%20b.md#sec", OPTS)).toEqual({ kind: "worktree", path: "docs/a b.md" });
+  });
+});
+
+describe("auditing", () => {
+  test("a missing relative path is dead, with the line it is on", () => {
+    const root = repo(["real.md"]);
+    const result = auditLinks(root, "a\n[ok](real.md)\n[bad](gone.md)\n", OPTS);
+
+    expect(result.ok).toBe(1);
+    expect(result.dead).toHaveLength(1);
+    expect(result.dead[0]).toMatchObject({ line: 3, text: "bad", target: "gone.md" });
+  });
+
+  test("the qou case: a table row pointing at a path never published", () => {
+    const root = repo();
+    publish(root, "gh-pages", ["lean/docs/index.html"]);
+    const src =
+      "| Lean docs | [lean/docs/](https://github.com/owner/repo/tree/gh-pages/lean/docs) |\n" +
+      "| Blueprint | [blueprint/](https://github.com/owner/repo/tree/gh-pages/blueprint) |\n";
+    const result = auditLinks(root, src, OPTS);
+
+    expect(result.ok).toBe(1);
+    expect(result.dead.map((d) => d.text)).toEqual(["blueprint/"]);
+  });
+
+  test("a directory resolves when anything sits under it", () => {
+    const root = repo();
+    publish(root, "gh-pages", ["python-api/index.html"]);
+    const result = auditLinks(
+      root, "[api](https://owner.github.io/repo/python-api/)\n", OPTS,
+    );
+    expect(result.dead).toEqual([]);
+    expect(result.ok).toBe(1);
+  });
+
+  test("an unreadable ref makes its links unchecked — never dead", () => {
+    const root = repo();
+    publish(root, "gh-pages", ["a.pdf"]);
+    const result = auditLinks(
+      root, "[x](https://github.com/owner/repo/blob/no-such-ref/a.pdf)\n", OPTS,
+    );
+
+    expect(result.dead).toEqual([]);
+    expect(result.checked).toBe(0);
+    expect(Object.keys(result.unchecked).join()).toContain("not readable");
+  });
+
+  test("external links are counted, not fetched", () => {
+    const root = repo();
+    const result = auditLinks(root, "[a](https://example.com/x)\n", OPTS);
+
+    expect(result.checked).toBe(0);
+    expect(result.unchecked["external URL (not fetched)"]).toBe(1);
+  });
+});
+
+describe("runReadmeAudit", () => {
+  test("exits 1 and names the file and line when a link is dead", () => {
+    const root = repo(["README.md"]);
+    writeFileSync(join(root, "README.md"), "# T\n\n[gone](missing.md)\n");
+    const result = runReadmeAudit({ root });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.text).toContain("README.md:3");
+    expect(result.text).toContain("1 dead");
+  });
+
+  test("exits 0 on a clean file and still reports what it could not check", () => {
+    const root = repo(["README.md", "there.md"]);
+    writeFileSync(join(root, "README.md"), "[a](there.md) [b](https://example.com)\n");
+    const result = runReadmeAudit({ root });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.text).toContain("1 not checked");
+  });
+
+  test("a missing file is an error, not a clean pass", () => {
+    expect(runReadmeAudit({ root: repo() }).exitCode).toBe(2);
+  });
+});

--- a/src/tools/readme-audit.ts
+++ b/src/tools/readme-audit.ts
@@ -1,0 +1,63 @@
+/**
+ * `readme_audit` — check that a folio README's links still resolve.
+ *
+ * Companion to `readme_sync`, and deliberately the other half of it: sync owns
+ * the generated regions and writes them; audit owns everything the author
+ * wrote and never writes anything. Between them, no link in the file is
+ * unaccounted for.
+ *
+ * @module src/tools/readme-audit
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import { runReadmeAudit } from "../../content/pipeline/readme-links";
+
+export function registerReadmeAuditTools(server: McpServer): void {
+  server.tool(
+    "readme_audit",
+    "Verify every Markdown link in the folio's README (or another file) still " +
+      "resolves: relative paths against the working tree, links naming one of " +
+      "the repo's own refs against a real listing of that ref, and GitHub " +
+      "Pages URLs against the publish ref the site is served from. External " +
+      "URLs, in-page anchors, and refs this checkout cannot read are reported " +
+      "as NOT CHECKED rather than dead. Read-only — it never edits the file.",
+    {
+      file: z
+        .string()
+        .optional()
+        .describe("Markdown file to audit. Defaults to the folio's README.md."),
+      fetch: z
+        .boolean()
+        .default(false)
+        .describe(
+          "Fetch a repo ref that is missing locally, so its links can be checked " +
+            "instead of counted as unchecked. Needed in a shallow clone.",
+        ),
+      dir: z
+        .string()
+        .optional()
+        .describe("Folio root. Defaults to the repo the server was pointed at."),
+    },
+    async ({ file, fetch, dir }) => {
+      try {
+        const result = runReadmeAudit({ root: dir, file, fetch });
+        return {
+          content: [{ type: "text" as const, text: result.text }],
+          isError: result.exitCode !== 0,
+        };
+      } catch (e) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `readme_audit failed: ${e instanceof Error ? e.message : String(e)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+}


### PR DESCRIPTION
Third in the line after #146 and #147. Those made the *generated* regions of a folio README verify their own targets. Everything else in the file is authored Markdown, and nothing checked it at all.

## The evidence this is a real class

qou's Published Artefacts table listed `blueprint/` and `docs/`. Neither has ever existed on `gh-pages` — the Lean documentation is published at `lean/docs/`. Both rows were dead in *both* columns, in a table nobody could regenerate. I removed them by hand in litlfred/qou#5974; nothing stopped the next two from appearing.

## Why an audit and not a sixth generated section

Generating that table would mean inventing its labels — "Folio landing page", "Blueprint (interactive graph)", the Project Structure path descriptions — which are prose worth keeping. The defect was never the layout going stale; it was targets that do not resolve.

So `content/pipeline/readme-links.ts` verifies what the author wrote and **writes nothing**. It parses every Markdown link, image and reference definition — skipping fenced code, so a shell example is not mistaken for one — and resolves each against the right authority:

| link | checked against |
|---|---|
| `docs/guide.md` | the working tree |
| `github.com/<owner>/<repo>/blob\|tree\|raw/<ref>/<path>` | a real `git ls-tree` of that ref |
| `raw.githubusercontent.com/<owner>/<repo>/<ref>/<path>` | same |
| a URL under the folio's `pagesBaseUrl` | the publish ref the site is served from |

A `tree/` link resolves when anything sits under the directory, and a Pages directory URL also tries `index.html`, because that is what the site actually serves.

## The third state, again

An external host, an in-page anchor, a `mailto:`, and **any ref this checkout cannot read** are reported as NOT CHECKED — never as dead. A shallow clone that never fetched `gh-pages` must not produce a wall of false findings. Same rule as the contents table's unreadable publish ref (#146) and a section's `skip` (#147).

## Surface

- `readme_audit` MCP tool, registered generic beside `readme_sync` — sync owns the marked regions, audit checks everything else, and between them no link in the file is unaccounted for
- `bun run readme:audit`, exit 1 on a dead link, reporting `file:line` and the link text so the row is findable

## Verification

- 15 tests in `scripts/tests/readme-links.test.ts`; full suite **1360 pass / 0 fail**
- `tsc --noEmit` clean; `eslint .` clean across the repo
- **This repo's own README**: 16 links checked, 16 resolve, 0 dead
- **qou's README**: 83 checked, 82 resolve, **1 dead** — `tools/witness-schema/`, a package that actually lives at `schemas/witness-schema`. A real defect, found on the first run, in a table added since the earlier PRs. Fix to follow in that repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQfsrwdYTJgGnUEj7ggAA9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WQfsrwdYTJgGnUEj7ggAA9)_