### PR TITLE
pdf-structure: emit the text before the first heading — split_sections was silently dropping it

### DIFF
--- a/scripts/pdf-structure.py
+++ b/scripts/pdf-structure.py
@@ -815,6 +815,36 @@ def split_sections(pages: list[str], toc: list[TocEntry]) -> list[Section]:
 
     page_lines = [p.splitlines() for p in pages]
     sections: list[Section] = []
+
+    # Everything before the first located mark. Without this the text above
+    # `marks[0]` is never emitted by the loop below and is silently lost --
+    # and the shape is perverse, because the `if not marks` branch above
+    # keeps the WHOLE document, so a file with zero headings is safe while
+    # one with a single late heading loses everything before it.
+    #
+    # Measured over the 623-document qou library (fraction of raw page text
+    # surviving sectioning): median 0.977, so this is not a systemic loss --
+    # but 18 documents keep under 50% and 44 under 90%. Worst cases:
+    # `arxiv-1304.4737v1` locates only 1 of its 6 correct TOC headings, and
+    # that one is "Acknowledgements" on page 14 of 18, so the entire paper
+    # is dropped (28.9% kept); DeTurck-Gluck `0406276v1` infers one heading,
+    # "References" on page 38 of 40, and keeps 8.4%.
+    #
+    # The id is deliberately NON-NUMERIC. Numbering this `sec-000` would
+    # shift every following section id, and section ids are cited outside
+    # this repo (docs/audits/* in litlfred/qou reference `sec-NNN-...`).
+    fpi, fli, _ = marks[0]
+    if fpi > 0 or fli > 0:
+        head_buf: list[str] = []
+        for p_i in range(0, fpi + 1):
+            src = page_lines[p_i]
+            head_buf.extend(src[:fli] if p_i == fpi else src)
+        head = re.sub(r"\n{3,}", "\n\n", "\n".join(head_buf)).strip()
+        if head:
+            sections.append(Section(
+                "sec-front-matter", None, "Front matter", 1, 1, fpi + 1,
+                len(head), len(head.split()), head))
+
     for i, (pi, li, e) in enumerate(marks):
         if i + 1 < len(marks):
             epi, eli, _ = marks[i + 1]


### PR DESCRIPTION
Closes #166.

`split_sections` builds heading marks, then emits sections starting at `marks[0]`. **Text above that first located mark is never emitted**, with no diagnostic.

```python
if not marks:
    return [Section("sec-000-document", ..., whole)]   # keeps EVERYTHING
for i, (pi, li, e) in enumerate(marks):                # starts at marks[0]
```

A document with **zero** headings keeps all its text; one with a single **late** heading loses everything before it. Correct when it finds nothing, broken when it finds one thing — which is why it went unnoticed.

## Measured, not estimated

623 documents in the `litlfred/qou` library, fraction of raw pypdf page text surviving sectioning: **median 0.977**, mean 0.945 — `<50%`: **18 docs**, `50–90%`: 26, `90–99%`: 499, `≥99%`: 80.

Not systemic, but the tail lands on primary sources: Kauffman's *State models and the Jones polynomial* (7.5 % kept), DeTurck–Gluck (8.4 %), Neumann–Zagier ×2 (9.9 %), `90-1-219` (10.4 %), `arxiv-1304.4737v1` (28.9 %).

`arxiv-1304.4737v1` shows the failure compounding: its TOC is inferred **correctly** — six headings, "I Introduction" p2 through "References" p15 — but only one is located, and it is "Acknowledgements" on p14 of 18. `sections` is exactly `[Acknowledgements 14–18]`; the whole paper is gone. (Marks failing to locate is a separate weakness — the ±2-page window and 44-char prefix match. This change is what stops it becoming *data loss*.)

## The change

Emit a leading section covering everything before `marks[0]`, when there is any.

The id is **`sec-front-matter`, deliberately non-numeric**. Numbering it `sec-000` would shift every following section id, and section ids are cited outside this repo — `docs/audits/*` in `litlfred/qou` reference `sec-NNN-…`.

## Verification

Before → after `chars_total` on the worst cases:

| doc | before | after | | sections |
|---|---:|---:|---:|---|
| `1-s20-0040938387900097-main` | 2079 | 27711 | 13.3× | 1 → 2 |
| `0406276v1` | 4510 | 53954 | 12.0× | 1 → 2 |
| `neumann-zagier-1985` | 5437 | 54993 | 10.1× | 2 → 3 |
| `90-1-219` | 4506 | 43175 | 9.6× | 3 → 4 |
| `arxiv-1304.4737v1` | 8170 | 28231 | 3.5× | 1 → 2 |

Three healthy controls, confirming no renumbering and no regression — **every pre-existing section id preserved**, only `sec-front-matter` added:

| doc | before | after | ids preserved |
|---|---:|---:|---|
| `arxiv-1712.08953v1` | 157714 | 158572 | ✅ |
| `0803219` | 53765 | 57582 | ✅ |
| `arxiv-1110.6212v2` | 76761 | 83039 | ✅ |

Those recover 858–6278 chars each — the title/author/abstract block, dropped for **nearly every document**. That is the 2 % the 0.977 median represents, and it is the part a reader searches for.

**End-to-end**: `grep coth` on the DeTurck–Gluck sections previously returned nothing for the paper that *defines* `φ₀(α) = −coth(α)/4π`. It now returns the defining line verbatim:

```
ϕ0(α)  =  (—1/(4π)) coth α
```

## Scope

Only `scripts/pdf-structure.py`; nothing else in the working tree is committed. Re-sectioning the affected library documents is a separate mechanical follow-up in `litlfred/qou`.

The first diagnosis of this — that `pypdf.extract_text()` was at fault and an extractor swap was needed — was **wrong** and is retracted in `litlfred/qou` bean `qou-b6ti`. pypdf gets 53,937 of pdfminer's 54,418 chars on that file; the extractor is fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDxdXe6rDoi3ghQQ5oxw3t

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDxdXe6rDoi3ghQQ5oxw3t)_